### PR TITLE
feat(moderation): contestation d'image bloquee par la moderation locale

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "expo-crypto": "^15.0.8",
         "expo-dev-client": "~6.0.20",
         "expo-device": "~8.0.10",
+        "expo-file-system": "^55.0.16",
         "expo-gl": "~14.0.2",
         "expo-haptics": "~15.0.7",
         "expo-image-manipulator": "~13.0.6",
@@ -7323,9 +7324,9 @@
       }
     },
     "node_modules/expo-file-system": {
-      "version": "19.0.21",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.21.tgz",
-      "integrity": "sha512-s3DlrDdiscBHtab/6W1osrjGL+C2bvoInPJD7sOwmxfJ5Woynv2oc+Fz1/xVXaE/V7HE/+xrHC/H45tu6lZzzg==",
+      "version": "55.0.16",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-55.0.16.tgz",
+      "integrity": "sha512-EetQ/zVFK07Vmz4Yke0fvoES4xVwScTdd0PMoLekuMX7puE4op75pNnEdh1M0AeWzkqLrBoZIaU2ynSrKN5VZg==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
@@ -7535,6 +7536,16 @@
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo/node_modules/expo-file-system": {
+      "version": "19.0.21",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.21.tgz",
+      "integrity": "sha512-s3DlrDdiscBHtab/6W1osrjGL+C2bvoInPJD7sOwmxfJ5Woynv2oc+Fz1/xVXaE/V7HE/+xrHC/H45tu6lZzzg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     },
     "node_modules/exponential-backoff": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "expo-crypto": "^15.0.8",
     "expo-dev-client": "~6.0.20",
     "expo-device": "~8.0.10",
+    "expo-file-system": "^55.0.16",
     "expo-gl": "~14.0.2",
     "expo-haptics": "~15.0.7",
     "expo-image-manipulator": "~13.0.6",

--- a/src/components/Chat/BlockedImageAppealModal.tsx
+++ b/src/components/Chat/BlockedImageAppealModal.tsx
@@ -1,0 +1,270 @@
+/**
+ * BlockedImageAppealModal - UI to contest a locally blocked image
+ */
+
+import React, { useCallback, useState } from "react";
+import {
+  Modal,
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  Image,
+  StyleSheet,
+  ActivityIndicator,
+  Alert,
+  ScrollView,
+} from "react-native";
+import { colors } from "../../theme/colors";
+import { useModerationStore } from "../../store/moderationStore";
+
+const MIN_CHARS = 20;
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+  imageUri: string;
+  blockReason?: string;
+  scores?: Record<string, number>;
+  messageTempId: string;
+  conversationId: string;
+  recipientId?: string;
+}
+
+export const BlockedImageAppealModal: React.FC<Props> = ({
+  visible,
+  onClose,
+  imageUri,
+  blockReason,
+  scores,
+  messageTempId,
+  conversationId,
+  recipientId,
+}) => {
+  const [reason, setReason] = useState("");
+  const [loading, setLoading] = useState(false);
+  const { createBlockedImageAppeal } = useModerationStore();
+
+  const canSubmit = reason.trim().length >= MIN_CHARS && !loading;
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit) return;
+    setLoading(true);
+    try {
+      await createBlockedImageAppeal({
+        imageUri,
+        reason: reason.trim(),
+        conversationId,
+        recipientId,
+        messageTempId,
+        blockReason,
+        scores,
+      });
+      setReason("");
+      onClose();
+      Alert.alert(
+        "Contestation envoyée",
+        "Un administrateur va examiner ton image.",
+      );
+    } catch (e: any) {
+      Alert.alert(
+        "Erreur",
+        e?.message || "Impossible d'envoyer la contestation.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [
+    canSubmit,
+    createBlockedImageAppeal,
+    imageUri,
+    reason,
+    conversationId,
+    recipientId,
+    messageTempId,
+    blockReason,
+    scores,
+    onClose,
+  ]);
+
+  const handleClose = useCallback(() => {
+    if (loading) return;
+    setReason("");
+    onClose();
+  }, [loading, onClose]);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={handleClose}
+    >
+      <View style={styles.backdrop}>
+        <View style={styles.sheet}>
+          <ScrollView contentContainerStyle={styles.scroll}>
+            <Text style={styles.title}>Contester le blocage</Text>
+            <Text style={styles.subtitle}>
+              Explique pourquoi ton image est conforme. Un administrateur
+              l'examinera.
+            </Text>
+
+            {imageUri ? (
+              <Image
+                source={{ uri: imageUri }}
+                style={styles.preview}
+                resizeMode="cover"
+              />
+            ) : null}
+
+            {blockReason ? (
+              <View style={styles.reasonBox}>
+                <Text style={styles.reasonLabel}>Raison du blocage</Text>
+                <Text style={styles.reasonText}>{blockReason}</Text>
+              </View>
+            ) : null}
+
+            <TextInput
+              style={styles.input}
+              placeholder="Explique pourquoi ton image est OK"
+              placeholderTextColor="rgba(255,255,255,0.4)"
+              multiline
+              maxLength={500}
+              value={reason}
+              onChangeText={setReason}
+              textAlignVertical="top"
+            />
+            <Text style={styles.counter}>
+              {reason.trim().length}/500 (min {MIN_CHARS})
+            </Text>
+
+            <View style={styles.actions}>
+              <TouchableOpacity
+                style={[styles.btn, styles.cancelBtn]}
+                onPress={handleClose}
+                disabled={loading}
+              >
+                <Text style={styles.cancelText}>Annuler</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[
+                  styles.btn,
+                  styles.submitBtn,
+                  !canSubmit && styles.submitBtnDisabled,
+                ]}
+                onPress={handleSubmit}
+                disabled={!canSubmit}
+              >
+                {loading ? (
+                  <ActivityIndicator color="#FFFFFF" />
+                ) : (
+                  <Text style={styles.submitText}>Envoyer la contestation</Text>
+                )}
+              </TouchableOpacity>
+            </View>
+          </ScrollView>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.6)",
+    justifyContent: "flex-end",
+  },
+  sheet: {
+    backgroundColor: "#1A1F3A",
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    maxHeight: "90%",
+  },
+  scroll: {
+    padding: 20,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: "700",
+    color: "#FFFFFF",
+    marginBottom: 6,
+  },
+  subtitle: {
+    fontSize: 13,
+    color: "rgba(255,255,255,0.6)",
+    marginBottom: 16,
+  },
+  preview: {
+    width: "100%",
+    height: 180,
+    borderRadius: 10,
+    backgroundColor: "rgba(255,255,255,0.05)",
+    marginBottom: 12,
+  },
+  reasonBox: {
+    backgroundColor: "rgba(240, 72, 72, 0.12)",
+    borderRadius: 8,
+    padding: 10,
+    marginBottom: 12,
+  },
+  reasonLabel: {
+    fontSize: 11,
+    fontWeight: "700",
+    color: "#F04848",
+    marginBottom: 3,
+  },
+  reasonText: {
+    fontSize: 13,
+    color: "rgba(255,255,255,0.8)",
+  },
+  input: {
+    backgroundColor: "rgba(255,255,255,0.05)",
+    borderRadius: 10,
+    padding: 12,
+    color: "#FFFFFF",
+    fontSize: 14,
+    minHeight: 100,
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.1)",
+  },
+  counter: {
+    fontSize: 11,
+    color: "rgba(255,255,255,0.4)",
+    alignSelf: "flex-end",
+    marginTop: 4,
+  },
+  actions: {
+    flexDirection: "row",
+    gap: 10,
+    marginTop: 16,
+  },
+  btn: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 10,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  cancelBtn: {
+    backgroundColor: "rgba(255,255,255,0.08)",
+  },
+  submitBtn: {
+    backgroundColor: colors.primary.main,
+  },
+  submitBtnDisabled: {
+    opacity: 0.4,
+  },
+  cancelText: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: "rgba(255,255,255,0.8)",
+  },
+  submitText: {
+    fontSize: 15,
+    fontWeight: "700",
+    color: "#FFFFFF",
+  },
+});
+
+export default BlockedImageAppealModal;

--- a/src/components/Chat/MessageBubble.tsx
+++ b/src/components/Chat/MessageBubble.tsx
@@ -68,6 +68,14 @@ interface MessageBubbleProps {
   onLongPress?: () => void;
   isHighlighted?: boolean;
   searchQuery?: string;
+  /** Blocked-image appeal state for this message (keyed by temp id) */
+  pendingAppeal?: {
+    appealId: string;
+    status: "pending" | "approved" | "rejected";
+    localUri: string;
+  };
+  /** Called when the user taps "Contester" on a locally blocked image */
+  onContest?: (message: MessageWithRelations) => void;
 }
 
 export const MessageBubble: React.FC<MessageBubbleProps> = ({
@@ -82,6 +90,8 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
   onLongPress,
   isHighlighted = false,
   searchQuery,
+  pendingAppeal,
+  onContest,
 }) => {
   const { getThemeColors } = useTheme();
   const themeColors = getThemeColors();
@@ -276,6 +286,34 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
             </Text>
             <DeliveryStatus status="failed" />
           </View>
+          {(message.metadata as any)?.blockedByModeration === true ? (
+            <View style={styles.appealRow}>
+              {!pendingAppeal && !(message.metadata as any)?.appealRejected ? (
+                <TouchableOpacity
+                  style={styles.contestBtn}
+                  onPress={() => onContest?.(message)}
+                  activeOpacity={0.7}
+                >
+                  <Text style={styles.contestBtnText}>Contester</Text>
+                </TouchableOpacity>
+              ) : null}
+              {pendingAppeal?.status === "pending" ? (
+                <View style={[styles.appealBadge, styles.appealBadgePending]}>
+                  <Text style={styles.appealBadgeText}>
+                    Contestation envoyée
+                  </Text>
+                </View>
+              ) : null}
+              {pendingAppeal?.status === "rejected" ||
+              (message.metadata as any)?.appealRejected ? (
+                <View style={[styles.appealBadge, styles.appealBadgeRejected]}>
+                  <Text style={styles.appealBadgeText}>
+                    Refusée par l'admin
+                  </Text>
+                </View>
+              ) : null}
+            </View>
+          ) : null}
         </View>
       );
     }
@@ -578,6 +616,41 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     padding: 2,
   },
+  appealRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginTop: 8,
+    gap: 8,
+  },
+  contestBtn: {
+    backgroundColor: "rgba(240, 72, 72, 0.25)",
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "rgba(240, 72, 72, 0.5)",
+  },
+  contestBtnText: {
+    color: "#F04848",
+    fontSize: 12,
+    fontWeight: "700",
+  },
+  appealBadge: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 6,
+  },
+  appealBadgePending: {
+    backgroundColor: "rgba(255, 176, 123, 0.2)",
+  },
+  appealBadgeRejected: {
+    backgroundColor: "rgba(120, 120, 120, 0.3)",
+  },
+  appealBadgeText: {
+    fontSize: 11,
+    fontWeight: "700",
+    color: "#FFFFFF",
+  },
 });
 
 export default memo(MessageBubble, (prevProps, nextProps) => {
@@ -589,6 +662,9 @@ export default memo(MessageBubble, (prevProps, nextProps) => {
     prevProps.message.is_deleted === nextProps.message.is_deleted &&
     prevProps.senderName === nextProps.senderName &&
     prevProps.onReactionDetailsPress === nextProps.onReactionDetailsPress &&
+    prevProps.pendingAppeal?.status === nextProps.pendingAppeal?.status &&
+    JSON.stringify(prevProps.message.metadata) ===
+      JSON.stringify(nextProps.message.metadata) &&
     JSON.stringify(prevProps.message.reactions) ===
       JSON.stringify(nextProps.message.reactions)
   );

--- a/src/components/Chat/index.ts
+++ b/src/components/Chat/index.ts
@@ -23,3 +23,4 @@ export { ForwardMessageModal } from "./ForwardMessageModal";
 export { NewConversationModal } from "./NewConversationModal";
 export { CameraCapture } from "./CameraCapture";
 export type { CameraCaptureResult } from "./CameraCapture";
+export { BlockedImageAppealModal } from "./BlockedImageAppealModal";

--- a/src/components/Moderation/AppealCard.tsx
+++ b/src/components/Moderation/AppealCard.tsx
@@ -79,7 +79,21 @@ export const AppealCard: React.FC<Props> = ({
           Appel du {formatDate(appeal.createdAt)}
         </Text>
         <View style={styles.badgeRow}>
-          <SanctionBadge type={sanctionType} />
+          <View
+            style={[
+              styles.typeBadge,
+              appeal.type === "blocked_image"
+                ? styles.typeBadgeImage
+                : styles.typeBadgeSanction,
+            ]}
+          >
+            <Text style={styles.typeBadgeText}>
+              {appeal.type === "blocked_image" ? "Image" : "Sanction"}
+            </Text>
+          </View>
+          {appeal.type !== "blocked_image" ? (
+            <SanctionBadge type={sanctionType} />
+          ) : null}
         </View>
       </View>
 
@@ -130,5 +144,23 @@ const styles = StyleSheet.create({
   badgeRow: {
     flexDirection: "row",
     marginTop: 6,
+    gap: 6,
+    alignItems: "center",
+  },
+  typeBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 6,
+  },
+  typeBadgeSanction: {
+    backgroundColor: "rgba(103, 116, 189, 0.25)",
+  },
+  typeBadgeImage: {
+    backgroundColor: "rgba(240, 72, 130, 0.25)",
+  },
+  typeBadgeText: {
+    fontSize: 11,
+    fontWeight: "700",
+    color: "#FFFFFF",
   },
 });

--- a/src/screens/Admin/AppealQueueScreen.tsx
+++ b/src/screens/Admin/AppealQueueScreen.tsx
@@ -3,7 +3,7 @@
  * Sorted by oldest first (FIFO), pull to refresh
  */
 
-import React, { useEffect, useCallback } from "react";
+import React, { useEffect, useCallback, useState } from "react";
 import {
   View,
   Text,
@@ -28,6 +28,9 @@ export const AppealQueueScreen: React.FC = () => {
   const { getThemeColors } = useTheme();
   const themeColors = getThemeColors();
   const { appealQueue, loading, fetchAppealQueue } = useModerationStore();
+  const [activeTab, setActiveTab] = useState<
+    "all" | "sanction" | "blocked_image"
+  >("all");
 
   useEffect(() => {
     fetchAppealQueue();
@@ -37,9 +40,14 @@ export const AppealQueueScreen: React.FC = () => {
     fetchAppealQueue();
   }, [fetchAppealQueue]);
 
-  // Sort by oldest first (FIFO)
+  // Sort by oldest first (FIFO), then filter by active tab
   const sortedAppeals = [...appealQueue]
     .filter((a) => a.status === "pending" || a.status === "under_review")
+    .filter((a) => {
+      if (activeTab === "all") return true;
+      const t = a.type ?? "sanction";
+      return t === activeTab;
+    })
     .sort(
       (a, b) =>
         new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
@@ -82,6 +90,36 @@ export const AppealQueueScreen: React.FC = () => {
               File d'appels
             </Text>
             <View style={styles.placeholder} />
+          </View>
+
+          {/* Tabs */}
+          <View style={styles.tabsRow}>
+            {(
+              [
+                { key: "sanction", label: "Sanctions" },
+                { key: "blocked_image", label: "Images" },
+                { key: "all", label: "Tous" },
+              ] as const
+            ).map((t) => (
+              <TouchableOpacity
+                key={t.key}
+                style={[
+                  styles.tabBtn,
+                  activeTab === t.key && styles.tabBtnActive,
+                ]}
+                onPress={() => setActiveTab(t.key)}
+                activeOpacity={0.7}
+              >
+                <Text
+                  style={[
+                    styles.tabText,
+                    activeTab === t.key && styles.tabTextActive,
+                  ]}
+                >
+                  {t.label}
+                </Text>
+              </TouchableOpacity>
+            ))}
           </View>
 
           {/* Info bar */}
@@ -204,5 +242,29 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 8,
     paddingBottom: 16,
+  },
+  tabsRow: {
+    flexDirection: "row",
+    paddingHorizontal: 16,
+    paddingTop: 8,
+    gap: 8,
+  },
+  tabBtn: {
+    flex: 1,
+    paddingVertical: 8,
+    borderRadius: 8,
+    backgroundColor: "rgba(255,255,255,0.06)",
+    alignItems: "center",
+  },
+  tabBtnActive: {
+    backgroundColor: colors.primary.main,
+  },
+  tabText: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "rgba(255,255,255,0.7)",
+  },
+  tabTextActive: {
+    color: "#FFFFFF",
   },
 });

--- a/src/screens/Admin/AppealReviewScreen.tsx
+++ b/src/screens/Admin/AppealReviewScreen.tsx
@@ -13,6 +13,7 @@ import {
   TextInput,
   Alert,
   ActivityIndicator,
+  Image,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { LinearGradient } from "expo-linear-gradient";
@@ -45,18 +46,23 @@ export const AppealReviewScreen: React.FC = () => {
   const { reviewAppeal } = useModerationStore();
 
   const appeal = route.params.appeal;
+  const isBlockedImage = appeal.type === "blocked_image";
   const [adminNotes, setAdminNotes] = useState("");
   const [processing, setProcessing] = useState(false);
   const [sanction, setSanction] = useState<UserSanction | null>(null);
-  const [loadingSanction, setLoadingSanction] = useState(true);
+  const [loadingSanction, setLoadingSanction] = useState(!isBlockedImage);
 
   useEffect(() => {
+    if (isBlockedImage || !appeal.sanctionId) {
+      setLoadingSanction(false);
+      return;
+    }
     sanctionsAPI
       .getSanction(appeal.sanctionId)
       .then(setSanction)
       .catch(() => {})
       .finally(() => setLoadingSanction(false));
-  }, [appeal.sanctionId]);
+  }, [appeal.sanctionId, isBlockedImage]);
 
   const handleAction = useCallback(
     (status: "accepted" | "rejected", actionLabel: string) => {
@@ -65,9 +71,15 @@ export const AppealReviewScreen: React.FC = () => {
           ? "La sanction sera levée et l'utilisateur sera rétabli."
           : "La sanction sera maintenue.";
 
+      const confirmMessage = isBlockedImage
+        ? status === "accepted"
+          ? "L'image sera renvoyée à l'utilisateur."
+          : "L'image restera bloquée."
+        : message;
+
       Alert.alert(
         `Confirmer : ${actionLabel}`,
-        `${message}\n\nNotes : ${adminNotes || "(aucune)"}`,
+        `${confirmMessage}\n\nNotes : ${adminNotes || "(aucune)"}`,
         [
           { text: "Annuler", style: "cancel" },
           {
@@ -78,7 +90,7 @@ export const AppealReviewScreen: React.FC = () => {
               try {
                 await reviewAppeal(appeal.id, status, adminNotes || undefined);
 
-                if (status === "accepted" && sanction) {
+                if (status === "accepted" && sanction && !isBlockedImage) {
                   try {
                     await sanctionsAPI.liftSanction(sanction.id);
                   } catch {
@@ -99,7 +111,7 @@ export const AppealReviewScreen: React.FC = () => {
         ],
       );
     },
-    [adminNotes, appeal, sanction, reviewAppeal, navigation],
+    [adminNotes, appeal, sanction, reviewAppeal, navigation, isBlockedImage],
   );
 
   return (
@@ -132,6 +144,46 @@ export const AppealReviewScreen: React.FC = () => {
           </View>
 
           <ScrollView contentContainerStyle={styles.scrollContent}>
+            {/* Blocked image preview */}
+            {isBlockedImage ? (
+              <View style={styles.section}>
+                <Text style={styles.sectionLabel}>Image contestée</Text>
+                {appeal.evidence?.thumbnailBase64 ? (
+                  <Image
+                    source={{
+                      uri: `data:image/jpeg;base64,${appeal.evidence.thumbnailBase64}`,
+                    }}
+                    style={styles.blockedPreview}
+                    resizeMode="contain"
+                  />
+                ) : (
+                  <Text style={styles.noData}>Aucune miniature transmise</Text>
+                )}
+                {appeal.evidence?.blockReason ? (
+                  <View style={styles.reasonBox}>
+                    <Text style={styles.reasonLabel}>Raison du blocage</Text>
+                    <Text style={styles.reasonText}>
+                      {appeal.evidence.blockReason}
+                    </Text>
+                  </View>
+                ) : null}
+                {appeal.evidence?.scores &&
+                Object.keys(appeal.evidence.scores).length > 0 ? (
+                  <View style={styles.scoresBox}>
+                    <Text style={styles.reasonLabel}>Scores du classifier</Text>
+                    {Object.entries(appeal.evidence.scores).map(([k, v]) => (
+                      <View key={k} style={styles.scoreRow}>
+                        <Text style={styles.scoreKey}>{k}</Text>
+                        <Text style={styles.scoreVal}>
+                          {typeof v === "number" ? v.toFixed(3) : String(v)}
+                        </Text>
+                      </View>
+                    ))}
+                  </View>
+                ) : null}
+              </View>
+            ) : null}
+
             {/* Appeal Details */}
             <View style={styles.section}>
               <Text style={styles.sectionLabel}>Détails de l'appel</Text>
@@ -192,57 +244,62 @@ export const AppealReviewScreen: React.FC = () => {
             </View>
 
             {/* Original Sanction */}
-            <View style={styles.section}>
-              <Text style={styles.sectionLabel}>Sanction originale</Text>
-              {loadingSanction ? (
-                <ActivityIndicator size="small" color={colors.primary.main} />
-              ) : sanction ? (
-                <>
-                  <View style={styles.sanctionRow}>
-                    <SanctionBadge
-                      type={sanction.type}
-                      active={sanction.active}
-                      size="medium"
-                    />
-                    {sanction.active && (
-                      <View style={styles.activeDot}>
-                        <Text style={styles.activeLabel}>Active</Text>
-                      </View>
-                    )}
-                  </View>
-                  <View style={styles.sanctionDetails}>
-                    <View style={styles.detailRow}>
-                      <Text style={styles.detailLabel}>Raison</Text>
-                      <Text style={styles.detailValue}>{sanction.reason}</Text>
+            {!isBlockedImage ? (
+              <View style={styles.section}>
+                <Text style={styles.sectionLabel}>Sanction originale</Text>
+                {loadingSanction ? (
+                  <ActivityIndicator size="small" color={colors.primary.main} />
+                ) : sanction ? (
+                  <>
+                    <View style={styles.sanctionRow}>
+                      <SanctionBadge
+                        type={sanction.type}
+                        active={sanction.active}
+                        size="medium"
+                      />
+                      {sanction.active && (
+                        <View style={styles.activeDot}>
+                          <Text style={styles.activeLabel}>Active</Text>
+                        </View>
+                      )}
                     </View>
-                    <View style={styles.detailRow}>
-                      <Text style={styles.detailLabel}>Date</Text>
-                      <Text style={styles.detailValue}>
-                        {formatDate(sanction.createdAt)}
-                      </Text>
-                    </View>
-                    <View style={styles.detailRow}>
-                      <Text style={styles.detailLabel}>Par</Text>
-                      <Text style={styles.detailValue}>
-                        {sanction.issuedBy.slice(0, 8)}...
-                      </Text>
-                    </View>
-                    {sanction.expiresAt && (
+                    <View style={styles.sanctionDetails}>
                       <View style={styles.detailRow}>
-                        <Text style={styles.detailLabel}>Expire</Text>
+                        <Text style={styles.detailLabel}>Raison</Text>
                         <Text style={styles.detailValue}>
-                          {formatDate(sanction.expiresAt)}
+                          {sanction.reason}
                         </Text>
                       </View>
-                    )}
-                  </View>
-                </>
-              ) : (
-                <Text style={styles.noData}>
-                  Sanction introuvable (ID: {appeal.sanctionId.slice(0, 8)}...)
-                </Text>
-              )}
-            </View>
+                      <View style={styles.detailRow}>
+                        <Text style={styles.detailLabel}>Date</Text>
+                        <Text style={styles.detailValue}>
+                          {formatDate(sanction.createdAt)}
+                        </Text>
+                      </View>
+                      <View style={styles.detailRow}>
+                        <Text style={styles.detailLabel}>Par</Text>
+                        <Text style={styles.detailValue}>
+                          {sanction.issuedBy.slice(0, 8)}...
+                        </Text>
+                      </View>
+                      {sanction.expiresAt && (
+                        <View style={styles.detailRow}>
+                          <Text style={styles.detailLabel}>Expire</Text>
+                          <Text style={styles.detailValue}>
+                            {formatDate(sanction.expiresAt)}
+                          </Text>
+                        </View>
+                      )}
+                    </View>
+                  </>
+                ) : (
+                  <Text style={styles.noData}>
+                    Sanction introuvable (ID:{" "}
+                    {appeal.sanctionId?.slice(0, 8) ?? "—"}...)
+                  </Text>
+                )}
+              </View>
+            ) : null}
 
             {/* Previous review */}
             {appeal.reviewerId && (
@@ -286,16 +343,34 @@ export const AppealReviewScreen: React.FC = () => {
                 <>
                   <TouchableOpacity
                     style={[styles.actionBtn, styles.rejectBtn]}
-                    onPress={() => handleAction("rejected", "Rejeter l'appel")}
+                    onPress={() =>
+                      handleAction(
+                        "rejected",
+                        isBlockedImage
+                          ? "Refuser (garder bloquée)"
+                          : "Rejeter l'appel",
+                      )
+                    }
                     activeOpacity={0.7}
                   >
                     <Ionicons name="close-circle" size={20} color="#FFFFFF" />
-                    <Text style={styles.actionBtnText}>Rejeter l'appel</Text>
+                    <Text style={styles.actionBtnText}>
+                      {isBlockedImage
+                        ? "Refuser (garder bloquée)"
+                        : "Rejeter l'appel"}
+                    </Text>
                   </TouchableOpacity>
 
                   <TouchableOpacity
                     style={[styles.actionBtn, styles.acceptBtn]}
-                    onPress={() => handleAction("accepted", "Accepter l'appel")}
+                    onPress={() =>
+                      handleAction(
+                        "accepted",
+                        isBlockedImage
+                          ? "Approuver (envoyer l'image)"
+                          : "Accepter l'appel",
+                      )
+                    }
                     activeOpacity={0.7}
                   >
                     <Ionicons
@@ -303,7 +378,11 @@ export const AppealReviewScreen: React.FC = () => {
                       size={20}
                       color="#FFFFFF"
                     />
-                    <Text style={styles.actionBtnText}>Accepter l'appel</Text>
+                    <Text style={styles.actionBtnText}>
+                      {isBlockedImage
+                        ? "Approuver (envoyer l'image)"
+                        : "Accepter l'appel"}
+                    </Text>
                   </TouchableOpacity>
                 </>
               )}
@@ -511,5 +590,34 @@ const styles = StyleSheet.create({
     fontSize: 15,
     fontWeight: "700",
     color: "#FFFFFF",
+  },
+  blockedPreview: {
+    width: 200,
+    height: 200,
+    alignSelf: "center",
+    borderRadius: 8,
+    backgroundColor: "rgba(255,255,255,0.05)",
+    marginBottom: 12,
+  },
+  scoresBox: {
+    backgroundColor: "rgba(255, 255, 255, 0.05)",
+    borderRadius: 8,
+    padding: 12,
+    marginTop: 8,
+  },
+  scoreRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginBottom: 3,
+  },
+  scoreKey: {
+    fontSize: 12,
+    color: "rgba(255,255,255,0.7)",
+    fontFamily: "monospace",
+  },
+  scoreVal: {
+    fontSize: 12,
+    color: "#FFFFFF",
+    fontFamily: "monospace",
   },
 });

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -68,6 +68,9 @@ import { SchedulingService } from "../../services/SchedulingService";
 import { gateChatImageBeforeSend } from "../../services/moderation";
 import { ScheduleDateTimePicker } from "../../components/Chat/ScheduleDateTimePicker";
 import { OfflineBanner } from "../../components/Chat/OfflineBanner";
+import { BlockedImageAppealModal } from "../../components/Chat/BlockedImageAppealModal";
+import { useModerationStore } from "../../store/moderationStore";
+import { getSharedSocket } from "../../services/messaging/websocket";
 import { offlineQueue, QueuedMessage } from "../../services/offlineQueue";
 import {
   validateReactionEmoji,
@@ -143,6 +146,18 @@ export const ChatScreen: React.FC = () => {
     null,
   );
   const [addingContact, setAddingContact] = useState(false);
+  const [appealModal, setAppealModal] = useState<{
+    visible: boolean;
+    imageUri: string;
+    blockReason?: string;
+    scores?: Record<string, number>;
+    messageTempId: string;
+  } | null>(null);
+  const pendingAppeals = useModerationStore((s) => s.pendingAppeals);
+  const handleAppealDecision = useModerationStore(
+    (s) => s.handleAppealDecision,
+  );
+  const cleanupAppeal = useModerationStore((s) => s.cleanupAppeal);
   const allConversations = useConversationsStore((s) => s.conversations);
   const onlineUserIds = usePresenceStore((s) => s.onlineUserIds);
   const lastSeenAt = usePresenceStore((s) => s.lastSeenAt);
@@ -474,6 +489,64 @@ export const ChatScreen: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversationId, token]);
 
+  // Listen for admin decisions on blocked-image appeals.
+  // On approve: re-submit the original image bypassing the gate.
+  // On reject: annotate the bubble so the user sees "Refusée par l'admin".
+  useEffect(() => {
+    if (!userId) return;
+    let socket: ReturnType<typeof getSharedSocket>;
+    try {
+      socket = getSharedSocket();
+    } catch {
+      return;
+    }
+    const channel = socket.channel(`user:${userId}`);
+    const onDecision = (data: any) => {
+      const messageTempId: string | undefined =
+        data?.messageTempId || data?.message_temp_id;
+      const decision: "approved" | "rejected" | undefined = data?.decision;
+      if (!messageTempId || !decision) return;
+
+      const current =
+        useModerationStore.getState().pendingAppeals[messageTempId];
+      handleAppealDecision({ messageTempId, decision });
+
+      if (decision === "approved" && current?.localUri) {
+        // Re-submit bypassing the gate, then cleanup.
+        handleSendMedia(current.localUri, "image", undefined, undefined, {
+          skipGate: true,
+        })
+          .catch((err) =>
+            logger.warn("ChatScreen", "re-submit after appeal failed", err),
+          )
+          .finally(() => {
+            cleanupAppeal(messageTempId).catch(() => {});
+          });
+      } else if (decision === "rejected") {
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === messageTempId
+              ? {
+                  ...m,
+                  metadata: {
+                    ...(m.metadata || {}),
+                    appealRejected: true,
+                  } as any,
+                  content: "Refusée par l'admin",
+                }
+              : m,
+          ),
+        );
+        cleanupAppeal(messageTempId).catch(() => {});
+      }
+    };
+    channel.on("blocked_image_decision", onDecision);
+    return () => {
+      channel.off("blocked_image_decision", onDecision);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userId]);
+
   // Check if the other user in a direct conversation is in our contacts
   useEffect(() => {
     if (!conversation || conversation.type !== "direct" || !userId) {
@@ -786,6 +859,7 @@ export const ChatScreen: React.FC = () => {
       type: "image" | "video" | "file" | "audio",
       replyToId?: string,
       caption?: string,
+      opts?: { skipGate?: boolean },
     ) => {
       // Stop typing indicator
       sendTyping(conversationId, false);
@@ -880,14 +954,13 @@ export const ChatScreen: React.FC = () => {
 
       try {
         // Gate check: block inappropriate images before upload
-        if (type === "image") {
+        if (type === "image" && !opts?.skipGate) {
           const gateResult = await gateChatImageBeforeSend(uri);
           if (!gateResult.ok) {
             const blockedReason =
               gateResult.reason || "Contenu bloqué par la modération";
-            // Show a user-visible alert so the sender is aware the image was blocked
-            showAlert("Envoi bloqué", blockedReason);
-            // Keep message in chat but mark as blocked
+            // Keep message in chat but mark as blocked, and annotate
+            // metadata so the bubble can offer a "Contester" action.
             setMessages((prev) =>
               prev.map((m) =>
                 m.id === tempMessageId
@@ -895,10 +968,25 @@ export const ChatScreen: React.FC = () => {
                       ...m,
                       status: "failed" as const,
                       content: blockedReason,
+                      metadata: {
+                        ...(m.metadata || {}),
+                        blockedByModeration: true,
+                        blockReason: blockedReason,
+                        scores: gateResult.scores,
+                        localUri: uri,
+                      } as any,
                     }
                   : m,
               ),
             );
+            // Open the appeal modal so the user can contest immediately.
+            setAppealModal({
+              visible: true,
+              imageUri: uri,
+              blockReason: blockedReason,
+              scores: gateResult.scores,
+              messageTempId: tempMessageId,
+            });
             return;
           }
         }
@@ -1619,6 +1707,17 @@ export const ChatScreen: React.FC = () => {
           onLongPress={() => handleMessageLongPress(message)}
           isHighlighted={isHighlighted}
           searchQuery={searchQuery}
+          pendingAppeal={pendingAppeals[message.id]}
+          onContest={(m) => {
+            const meta = (m.metadata || {}) as any;
+            setAppealModal({
+              visible: true,
+              imageUri: meta.localUri || "",
+              blockReason: meta.blockReason,
+              scores: meta.scores,
+              messageTempId: m.id,
+            });
+          }}
         />
       );
     },
@@ -1633,6 +1732,7 @@ export const ChatScreen: React.FC = () => {
       handleMessageLongPress,
       searchQuery,
       searchResults,
+      pendingAppeals,
     ],
   );
 
@@ -1813,6 +1913,31 @@ export const ChatScreen: React.FC = () => {
           resolveName={resolveReactorDisplayName}
           onClose={() => setReactionReactorsModal(null)}
         />
+        {appealModal ? (
+          <BlockedImageAppealModal
+            visible={appealModal.visible}
+            onClose={() =>
+              setAppealModal((prev) =>
+                prev ? { ...prev, visible: false } : prev,
+              )
+            }
+            imageUri={appealModal.imageUri}
+            blockReason={appealModal.blockReason}
+            scores={appealModal.scores}
+            messageTempId={appealModal.messageTempId}
+            conversationId={conversationId}
+            recipientId={
+              conversation?.type === "direct"
+                ? (
+                    conversation.member_user_ids ||
+                    conversation.members?.map(
+                      (m: { user_id: string }) => m.user_id,
+                    )
+                  )?.find((id: string) => id !== userId)
+                : undefined
+            }
+          />
+        ) : null}
         <MessageSearch
           visible={showSearch}
           onClose={() => {

--- a/src/services/moderation/gate-chat-image.ts
+++ b/src/services/moderation/gate-chat-image.ts
@@ -1,7 +1,14 @@
 import { tfjsService } from "./tfjs.service";
 import { logger } from "../../utils/logger";
 
-export type GateChatImageResult = { ok: true } | { ok: false; reason: string };
+export type GateChatImageResult =
+  | { ok: true }
+  | {
+      ok: false;
+      reason: string;
+      bestClass?: string;
+      scores?: Record<string, number>;
+    };
 
 /**
  * On-device TFJS image check before sending a chat image; block send if it fails.
@@ -20,6 +27,8 @@ export async function gateChatImageBeforeSend(
       return {
         ok: false,
         reason: "Cette image a été détectée comme contenu non autorisé.",
+        bestClass: r.bestClass,
+        scores: r.probs,
       };
     return { ok: true };
   } catch (e) {

--- a/src/services/moderation/moderationApi.ts
+++ b/src/services/moderation/moderationApi.ts
@@ -5,6 +5,8 @@ import type {
   Report,
   UserSanction,
   Appeal,
+  AppealEvidence,
+  AppealType,
   ReportStats,
   ConversationSanction,
   AuditLogEntry,
@@ -220,13 +222,20 @@ export const appealsAPI = {
   },
 
   async createAppeal(params: {
-    sanctionId: string;
+    sanctionId?: string | null;
+    type?: AppealType;
     reason: string;
-    evidence?: Record<string, any>;
+    evidence?: AppealEvidence;
   }): Promise<Appeal> {
+    const body = {
+      sanctionId: params.sanctionId ?? null,
+      type: params.type ?? "sanction",
+      reason: params.reason,
+      evidence: params.evidence ?? {},
+    };
     const res = await authenticatedFetch(`${USER_BASE()}/appeals`, {
       method: "POST",
-      body: JSON.stringify(params),
+      body: JSON.stringify(body),
     });
     return parseJson<Appeal>(res);
   },

--- a/src/store/moderationStore.ts
+++ b/src/store/moderationStore.ts
@@ -1,8 +1,11 @@
 import { create } from "zustand";
+import * as FileSystem from "expo-file-system";
+import * as ImageManipulator from "expo-image-manipulator";
 import type {
   Report,
   UserSanction,
   Appeal,
+  AppealEvidence,
   ReportStats,
   UserRole,
 } from "../types/moderation";
@@ -12,6 +15,13 @@ import {
   appealsAPI,
   rolesAPI,
 } from "../services/moderation/moderationApi";
+import { logger } from "../utils/logger";
+
+export interface PendingBlockedImageAppeal {
+  appealId: string;
+  status: "pending" | "approved" | "rejected";
+  localUri: string;
+}
 
 interface ModerationState {
   // Role
@@ -52,6 +62,25 @@ interface ModerationState {
     reason: string,
     evidence?: Record<string, any>,
   ) => Promise<void>;
+
+  // Blocked image appeals
+  pendingAppeals: Record<string, PendingBlockedImageAppeal>;
+  createBlockedImageAppeal: (params: {
+    imageUri: string;
+    reason: string;
+    conversationId: string;
+    recipientId?: string;
+    messageTempId: string;
+    blockReason?: string;
+    scores?: Record<string, number>;
+  }) => Promise<void>;
+  cleanupAppeal: (messageTempId: string) => Promise<void>;
+  handleAppealDecision: (params: {
+    messageTempId: string;
+    decision: "approved" | "rejected";
+    conversationId?: string;
+  }) => void;
+
   reset: () => void;
 }
 
@@ -67,6 +96,7 @@ const initialState = {
   stats: null as ReportStats | null,
   loading: false,
   error: null as string | null,
+  pendingAppeals: {} as Record<string, PendingBlockedImageAppeal>,
 };
 
 export const useModerationStore = create<ModerationState>((set, get) => ({
@@ -171,6 +201,138 @@ export const useModerationStore = create<ModerationState>((set, get) => ({
     } catch (e: any) {
       set({ error: e.message });
     }
+  },
+
+  createBlockedImageAppeal: async ({
+    imageUri,
+    reason,
+    conversationId,
+    recipientId,
+    messageTempId,
+    blockReason,
+    scores,
+  }) => {
+    const cacheDir = (FileSystem as any).cacheDirectory as string | undefined;
+    let localPath = imageUri;
+
+    try {
+      if (cacheDir) {
+        const dir = `${cacheDir}blocked-appeals`;
+        try {
+          const info = await (FileSystem as any).getInfoAsync(dir);
+          if (!info.exists) {
+            await (FileSystem as any).makeDirectoryAsync(dir, {
+              intermediates: true,
+            });
+          }
+        } catch {
+          try {
+            await (FileSystem as any).makeDirectoryAsync(dir, {
+              intermediates: true,
+            });
+          } catch {
+            /* ignore */
+          }
+        }
+
+        const ext = imageUri.split(".").pop()?.split("?")[0] || "jpg";
+        localPath = `${dir}/${messageTempId}.${ext}`;
+        try {
+          await (FileSystem as any).copyAsync({
+            from: imageUri,
+            to: localPath,
+          });
+        } catch (err) {
+          logger.warn(
+            "moderation",
+            "copyAsync failed — keeping original URI",
+            err,
+          );
+          localPath = imageUri;
+        }
+      }
+
+      const manipulated = await ImageManipulator.manipulateAsync(
+        imageUri,
+        [{ resize: { width: 200 } }],
+        {
+          compress: 0.5,
+          format: ImageManipulator.SaveFormat.JPEG,
+          base64: true,
+        },
+      );
+
+      const evidence: AppealEvidence = {
+        thumbnailBase64: manipulated.base64,
+        blockReason,
+        scores,
+        conversationId,
+        recipientId,
+        messageTempId,
+      };
+
+      const appeal = await appealsAPI.createAppeal({
+        type: "blocked_image",
+        sanctionId: null,
+        reason,
+        evidence,
+      });
+
+      set((state) => ({
+        pendingAppeals: {
+          ...state.pendingAppeals,
+          [messageTempId]: {
+            appealId: appeal.id,
+            status: "pending",
+            localUri: localPath,
+          },
+        },
+      }));
+    } catch (e: any) {
+      logger.error("moderation", "createBlockedImageAppeal failed", e);
+      set({ error: e.message });
+      throw e;
+    }
+  },
+
+  cleanupAppeal: async (messageTempId) => {
+    const entry = get().pendingAppeals[messageTempId];
+    if (entry?.localUri && entry.localUri.startsWith("file://") === false) {
+      // relative cache path — try to delete
+      try {
+        await (FileSystem as any).deleteAsync(entry.localUri, {
+          idempotent: true,
+        });
+      } catch {
+        /* ignore */
+      }
+    } else if (entry?.localUri) {
+      try {
+        await (FileSystem as any).deleteAsync(entry.localUri, {
+          idempotent: true,
+        });
+      } catch {
+        /* ignore */
+      }
+    }
+    set((state) => {
+      const next = { ...state.pendingAppeals };
+      delete next[messageTempId];
+      return { pendingAppeals: next };
+    });
+  },
+
+  handleAppealDecision: ({ messageTempId, decision }) => {
+    set((state) => {
+      const current = state.pendingAppeals[messageTempId];
+      if (!current) return state;
+      return {
+        pendingAppeals: {
+          ...state.pendingAppeals,
+          [messageTempId]: { ...current, status: decision },
+        },
+      };
+    });
   },
 
   reset: () => set(initialState),

--- a/src/types/moderation.ts
+++ b/src/types/moderation.ts
@@ -61,12 +61,26 @@ export interface UserSanction {
   updatedAt: string;
 }
 
+export type AppealType = "sanction" | "blocked_image";
+
+export interface AppealEvidence {
+  images?: string[];
+  thumbnailBase64?: string;
+  blockReason?: string;
+  scores?: Record<string, number>;
+  conversationId?: string;
+  recipientId?: string;
+  messageTempId?: string;
+  [key: string]: any;
+}
+
 export interface Appeal {
   id: string;
   userId: string;
-  sanctionId: string;
+  sanctionId: string | null;
+  type: AppealType;
   reason: string;
-  evidence: Record<string, any>;
+  evidence: AppealEvidence;
   status: AppealStatus;
   reviewerId: string | null;
   reviewerNotes: string | null;


### PR DESCRIPTION
## Summary
- Nouveau BlockedImageAppealModal (preview + raison texte)
- Bouton "Contester" sous bulle failed (MessageBubble)
- Store pendingAppeals + image originale cachee localement, thumbnail base64 envoye backend
- Handler WS blocked_image_decision: resubmit avec skipGate si approved, badge "refusee par l'admin" si rejected
- Admin AppealReviewScreen: affiche thumbnail base64 + blockReason + scores
- Tabs Sanctions/Images/Tous dans AppealQueueScreen

Part of feat blocked image appeal (user-service PR #102, notification-service incoming).

## Test plan
- [ ] CI type-check + lint passent
- [ ] Test E2E manuel sur preprod: block image -> contester -> admin approve -> resubmit auto