### PR TITLE
[WHISPR-1142] fix(chat): join user channel, persist appeal image on web, add polling fallback

### DIFF
--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -68,6 +68,7 @@ import { logger } from "../../utils/logger";
 import { MediaService } from "../../services/MediaService";
 import { SchedulingService } from "../../services/SchedulingService";
 import { gateChatImageBeforeSend } from "../../services/moderation";
+import { appealsAPI } from "../../services/moderation/moderationApi";
 import { ScheduleDateTimePicker } from "../../components/Chat/ScheduleDateTimePicker";
 import { OfflineBanner } from "../../components/Chat/OfflineBanner";
 import { BlockedImageAppealModal } from "../../components/Chat/BlockedImageAppealModal";
@@ -567,32 +568,24 @@ export const ChatScreen: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversationId, token]);
 
-  // Listen for admin decisions on blocked-image appeals.
+  // Applies an admin decision on a blocked-image appeal.
   // On approve: re-submit the original image bypassing the gate.
   // On reject: annotate the bubble so the user sees "Refusée par l'admin".
-  useEffect(() => {
-    if (!userId) return;
-    let socket: ReturnType<typeof getSharedSocket>;
-    try {
-      socket = getSharedSocket();
-    } catch {
-      return;
-    }
-    const channel = socket.channel(`user:${userId}`);
-    const onDecision = (data: any) => {
-      const messageTempId: string | undefined =
-        data?.messageTempId || data?.message_temp_id;
-      const decision: "approved" | "rejected" | undefined = data?.decision;
-      if (!messageTempId || !decision) return;
-
+  const applyBlockedImageDecision = useCallback(
+    (messageTempId: string, decision: "approved" | "rejected") => {
       const current =
         useModerationStore.getState().pendingAppeals[messageTempId];
+      if (!current || current.status !== "pending") return;
+
       handleAppealDecision({ messageTempId, decision });
 
-      if (decision === "approved" && current?.localUri) {
-        // Re-submit bypassing the gate, then cleanup.
+      // Prefer the base64 data URI when available (survives web logout) and
+      // fall back to the native file URI.
+      const replayUri = current?.localDataUri || current?.localUri;
+
+      if (decision === "approved" && replayUri) {
         handleSendMediaRef
-          .current(current.localUri, "image", undefined, undefined, {
+          .current(replayUri, "image", undefined, undefined, {
             skipGate: true,
           })
           .catch((err) =>
@@ -618,13 +611,92 @@ export const ChatScreen: React.FC = () => {
         );
         cleanupAppeal(messageTempId).catch(() => {});
       }
+    },
+    [cleanupAppeal, handleAppealDecision],
+  );
+
+  // WebSocket listener for admin decisions on blocked-image appeals.
+  useEffect(() => {
+    if (!userId) return;
+    let socket: ReturnType<typeof getSharedSocket>;
+    try {
+      socket = getSharedSocket();
+    } catch {
+      return;
+    }
+    const channel = socket.channel(`user:${userId}`);
+    const onDecision = (data: any) => {
+      const messageTempId: string | undefined =
+        data?.messageTempId || data?.message_temp_id;
+      const decision: "approved" | "rejected" | undefined = data?.decision;
+      if (!messageTempId || !decision) return;
+
+      applyBlockedImageDecision(messageTempId, decision);
     };
     channel.on("blocked_image_decision", onDecision);
+    // Phoenix only routes broadcasts to channels that have actually joined
+    // their topic. Without this, the backend `Endpoint.broadcast("user:<id>",
+    // "blocked_image_decision", ...)` never reaches the callback — which is
+    // exactly the WHISPR-1142 symptom.
+    channel.join().catch((err) => {
+      logger.warn("ChatScreen", "user channel join failed", err);
+    });
     return () => {
       channel.off("blocked_image_decision", onDecision);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [userId]);
+  }, [userId, applyBlockedImageDecision]);
+
+  // Polling fallback: if the WebSocket event is ever missed (connection loss,
+  // backend hiccup, app relaunch before the broadcast lands), poll the user-
+  // service for the status of every pending appeal and apply the decision as
+  // if it had come over the socket. Runs once on mount and then every 10s
+  // while there is at least one pending appeal on this screen.
+  useEffect(() => {
+    if (!userId) return;
+
+    const statusToDecision = (
+      status: string,
+    ): "approved" | "rejected" | null =>
+      status === "accepted"
+        ? "approved"
+        : status === "rejected"
+          ? "rejected"
+          : null;
+
+    const pollOnce = async () => {
+      const pending = useModerationStore.getState().pendingAppeals;
+      const entries = Object.entries(pending).filter(
+        ([, v]) => v.status === "pending",
+      );
+      if (entries.length === 0) return;
+
+      await Promise.all(
+        entries.map(async ([messageTempId, entry]) => {
+          try {
+            const appeal = await appealsAPI.getAppeal(entry.appealId);
+            const decision = statusToDecision(appeal.status);
+            if (decision) {
+              applyBlockedImageDecision(messageTempId, decision);
+            }
+          } catch (err) {
+            logger.warn("ChatScreen", "appeal poll failed", {
+              appealId: entry.appealId,
+              err,
+            });
+          }
+        }),
+      );
+    };
+
+    // Kick off an immediate check so a decision that landed while the app was
+    // closed is picked up as soon as the chat opens.
+    pollOnce().catch(() => {});
+    const id = setInterval(() => {
+      pollOnce().catch(() => {});
+    }, 10_000);
+    return () => clearInterval(id);
+  }, [userId, applyBlockedImageDecision]);
 
   // Check if the other user in a direct conversation is in our contacts
   useEffect(() => {

--- a/src/store/moderationStore.ts
+++ b/src/store/moderationStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { Platform } from "react-native";
 import * as FileSystem from "expo-file-system";
 import * as ImageManipulator from "expo-image-manipulator";
 
@@ -26,7 +27,18 @@ import { logger } from "../utils/logger";
 export interface PendingBlockedImageAppeal {
   appealId: string;
   status: "pending" | "approved" | "rejected";
+  /**
+   * Native file URI (file://…/blocked-appeals/<tempId>.jpg) or a blob/http URL.
+   * Survives process restarts on native because the file lives in
+   * FileSystem.cacheDirectory. On web, blob: URIs are revoked at logout/reload.
+   */
   localUri: string;
+  /**
+   * Full-size base64 data URI (web only). Persists in AsyncStorage so the image
+   * can be re-submitted after the user logs out and back in. Capped at ~5MB
+   * (post-resize) to keep AsyncStorage responsive.
+   */
+  localDataUri?: string;
 }
 
 interface ModerationState {
@@ -289,6 +301,46 @@ export const useModerationStore = create<ModerationState>()(
             evidence,
           });
 
+          // On web, blob: URIs are revoked at logout/reload, so we need a
+          // self-contained copy of the original image. Build a full-size
+          // base64 data URI (resized to a max of 1280px so we stay under a
+          // sensible AsyncStorage budget) that survives the session.
+          let localDataUri: string | undefined;
+          if (Platform.OS === "web") {
+            try {
+              const fullsize = await ImageManipulator.manipulateAsync(
+                imageUri,
+                [{ resize: { width: 1280 } }],
+                {
+                  compress: 0.8,
+                  format: ImageManipulator.SaveFormat.JPEG,
+                  base64: true,
+                },
+              );
+              if (fullsize.base64) {
+                const dataUri = `data:image/jpeg;base64,${fullsize.base64}`;
+                // Cap at ~5MB of base64 text to avoid choking AsyncStorage /
+                // IndexedDB. Above that threshold we give up on auto-retry
+                // and rely on the rejected message label.
+                if (dataUri.length <= 5 * 1024 * 1024) {
+                  localDataUri = dataUri;
+                } else {
+                  logger.warn(
+                    "moderation",
+                    "image too large for web persistence, skipping auto-retry payload",
+                    { size: dataUri.length },
+                  );
+                }
+              }
+            } catch (err) {
+              logger.warn(
+                "moderation",
+                "failed to build web-safe data URI for appeal",
+                err,
+              );
+            }
+          }
+
           set((state) => ({
             pendingAppeals: {
               ...state.pendingAppeals,
@@ -296,6 +348,7 @@ export const useModerationStore = create<ModerationState>()(
                 appealId: appeal.id,
                 status: "pending",
                 localUri: localPath,
+                ...(localDataUri ? { localDataUri } : {}),
               },
             },
           }));


### PR DESCRIPTION
## Summary

Trois fixes sur le flow complet de contestation image (Phase 4 auto re-send + Phase 5 rejection):

1. **ChatScreen.tsx**: on ouvrait un channel `user:<id>` sans jamais `join()`. Phoenix ne route les broadcasts que vers des channels joins, donc l'event `blocked_image_decision` n'arrivait jamais meme apres fix backend.
2. **moderationStore.ts**: sur web, le `localUri` pointait vers un `blob:` URL revoque au logout. On stocke maintenant en plus un data URI base64 full-size (resized a 1280px, cap 5MB) dans `pendingAppeals[tempId].localDataUri` qui survit a logout/reload via AsyncStorage.
3. **ChatScreen.tsx**: polling toutes les 10s + 1x au mount qui GET `/appeals/:id` pour chaque appeal en `pending`. Si le status a bascule, on applique la decision comme si le WS etait arrive. Fallback robuste si le backend fail ou si l'app est fermee au moment du broadcast.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test -- --testPathPattern=\"moderationStore|ChatScreen\"` -> 27/27 pass
- [ ] E2E Playwright Phase 4 apres deploy preprod
- [ ] E2E Playwright Phase 5 apres deploy preprod

Closes WHISPR-1142