### PR TITLE
[WHISPR-1163] fix(chat): flèche retour web et spam 401 sur thumbnails

### DIFF
--- a/ChatHeader.test.tsx
+++ b/ChatHeader.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * Tests for ChatHeader — specifically the back-button behaviour on web,
+ * where deep-linking or a page refresh can leave the navigation stack
+ * without a previous entry, making `navigation.goBack()` a no-op.
+ */
+
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+
+const mockGoBack = jest.fn();
+const mockNavigate = jest.fn();
+const mockCanGoBack = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({
+    goBack: mockGoBack,
+    navigate: mockNavigate,
+    canGoBack: mockCanGoBack,
+  }),
+}));
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: ({ testID }: any) => null,
+}));
+
+jest.mock("./src/context/ThemeContext", () => ({
+  useTheme: () => ({
+    getThemeColors: () => ({
+      text: { primary: "#fff", secondary: "#aaa" },
+    }),
+  }),
+}));
+
+jest.mock("./src/components/Chat/Avatar", () => ({
+  Avatar: () => null,
+}));
+
+import { ChatHeader } from "./src/screens/Chat/ChatHeader";
+
+describe("ChatHeader back button", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("calls navigation.goBack() when history is available", () => {
+    mockCanGoBack.mockReturnValue(true);
+
+    const { UNSAFE_getAllByType } = render(
+      <ChatHeader conversationName="Alice" conversationType="direct" />,
+    );
+
+    // The back TouchableOpacity is the first touchable in the header
+    const TouchableOpacity = require("react-native").TouchableOpacity;
+    const touchables = UNSAFE_getAllByType(TouchableOpacity);
+    fireEvent.press(touchables[0]);
+
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("navigates to ConversationsList when there is no history (web refresh / deep-link)", () => {
+    mockCanGoBack.mockReturnValue(false);
+
+    const { UNSAFE_getAllByType } = render(
+      <ChatHeader conversationName="Alice" conversationType="direct" />,
+    );
+
+    const TouchableOpacity = require("react-native").TouchableOpacity;
+    const touchables = UNSAFE_getAllByType(TouchableOpacity);
+    fireEvent.press(touchables[0]);
+
+    expect(mockGoBack).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith("ConversationsList");
+  });
+});

--- a/src/components/Chat/MediaMessage.tsx
+++ b/src/components/Chat/MediaMessage.tsx
@@ -75,13 +75,27 @@ async function streamMediaToRenderableUri(
  * That guarantees the image renders even when MinIO is not publicly reachable
  * from the device.
  */
+function uriNeedsAuthResolution(uri: string | undefined): boolean {
+  return (
+    !!uri &&
+    uri.includes("/media/v1/") &&
+    (uri.includes("/blob") || uri.includes("/thumbnail"))
+  );
+}
+
 function useResolvedMediaUrl(uri: string | undefined): {
   resolvedUri: string;
   loading: boolean;
   error: boolean;
 } {
-  const [resolvedUri, setResolvedUri] = useState(uri || "");
-  const [loading, setLoading] = useState(false);
+  // Start empty when the URI requires a Bearer token — otherwise React Native's
+  // <Image> renders the raw `/media/v1/<id>/thumbnail` URL before the effect
+  // can swap in a presigned one, producing a flood of unauthenticated GETs
+  // that the gateway answers with 401.
+  const [resolvedUri, setResolvedUri] = useState(
+    uriNeedsAuthResolution(uri) ? "" : uri || "",
+  );
+  const [loading, setLoading] = useState(uriNeedsAuthResolution(uri));
   const [error, setError] = useState(false);
   const blobUrlRef = useRef<string | null>(null);
 
@@ -101,21 +115,19 @@ function useResolvedMediaUrl(uri: string | undefined): {
     if (!uri) {
       revokeBlobUrl();
       setResolvedUri("");
+      setLoading(false);
       return;
     }
 
-    // Only resolve blob/thumbnail endpoints that need auth
-    const needsAuth =
-      uri.includes("/media/v1/") &&
-      (uri.includes("/blob") || uri.includes("/thumbnail"));
-
-    if (!needsAuth) {
+    if (!uriNeedsAuthResolution(uri)) {
       revokeBlobUrl();
       setResolvedUri(uri);
+      setLoading(false);
       return;
     }
 
     let cancelled = false;
+    setResolvedUri("");
     setLoading(true);
     setError(false);
 

--- a/src/screens/Chat/ChatHeader.tsx
+++ b/src/screens/Chat/ChatHeader.tsx
@@ -49,7 +49,13 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
   return (
     <View style={[styles.container, { backgroundColor: "transparent" }]}>
       <TouchableOpacity
-        onPress={() => navigation.goBack()}
+        onPress={() => {
+          if (navigation.canGoBack()) {
+            navigation.goBack();
+          } else {
+            (navigation as any).navigate("ConversationsList");
+          }
+        }}
         style={styles.backButton}
       >
         <Ionicons


### PR DESCRIPTION
- ChatHeader: le bouton retour vérifie canGoBack() et bascule sur navigate("ConversationsList") quand la pile est vide (rafraîchissement web, deep-link).
- MediaMessage: useResolvedMediaUrl initialise resolvedUri vide et loading true tant que l'URL exige un Bearer, pour que <Image> n'émette plus la requête /media/v1/<id>/thumbnail sans Authorization avant que l'effet ne la remplace par une URL présignée.