### PR TITLE
feat(calls): InCallScreen layout utilisable sur web

### DIFF
--- a/src/components/Calls/CallParticipantTile.web.tsx
+++ b/src/components/Calls/CallParticipantTile.web.tsx
@@ -47,8 +47,17 @@ export const CallParticipantTile: React.FC<Props> = ({ participant }) => {
         />
       ) : (
         <View style={styles.placeholder}>
+          <View style={styles.avatar}>
+            <Text style={styles.avatarLetter}>
+              {(participant.name ||
+                participant.identity ||
+                "?")[0].toUpperCase()}
+            </Text>
+          </View>
           <Text style={styles.identity} numberOfLines={1}>
-            {participant.identity}
+            {participant.isLocal
+              ? "Vous"
+              : participant.name || `${participant.identity.slice(0, 8)}…`}
           </Text>
         </View>
       )}
@@ -70,6 +79,20 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 8,
+    gap: 12,
+  },
+  avatar: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    backgroundColor: "#4a5cff",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  avatarLetter: {
+    color: "#fff",
+    fontSize: 28,
+    fontFamily: "Inter_600SemiBold",
   },
   identity: {
     color: "#fff",

--- a/src/screens/Calls/InCallScreen.tsx
+++ b/src/screens/Calls/InCallScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { View, StyleSheet, FlatList } from "react-native";
+import { View, Text, StyleSheet, FlatList } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import { RoomEvent, type Participant } from "livekit-client";
 import { useCallsStore } from "../../store/callsStore";
@@ -8,7 +8,8 @@ import { CallParticipantTile } from "../../components/Calls/CallParticipantTile"
 import { CallControls } from "../../components/Calls/CallControls";
 
 /**
- * In-call UI: grid of participant tiles + controls bar.
+ * In-call UI: status header (ringing/connected + elapsed time), grid of
+ * participant tiles, fixed controls bar at the bottom.
  * Syncs participants from the LiveKit Room whenever connections or track
  * subscriptions change.
  */
@@ -19,16 +20,19 @@ export const InCallScreen: React.FC = () => {
   const [participants, setParticipants] = useState<Participant[]>([]);
   const [muted, setMuted] = useState(false);
   const [camOff, setCamOff] = useState(false);
+  const [connectedAt, setConnectedAt] = useState<number | null>(null);
+  const [now, setNow] = useState(Date.now());
 
   useEffect(() => {
     const room = active?.room;
     if (!room) return;
 
     const sync = () => {
-      setParticipants([
-        room.localParticipant,
-        ...Array.from(room.remoteParticipants.values()),
-      ]);
+      const remote = Array.from(room.remoteParticipants.values());
+      setParticipants([room.localParticipant, ...remote]);
+      if (remote.length > 0 && connectedAt === null) {
+        setConnectedAt(Date.now());
+      }
     };
     sync();
 
@@ -43,7 +47,14 @@ export const InCallScreen: React.FC = () => {
       room.off(RoomEvent.TrackSubscribed, sync);
       room.off(RoomEvent.TrackUnsubscribed, sync);
     };
-  }, [active]);
+  }, [active, connectedAt]);
+
+  // Tick the elapsed-time counter once per second while connected.
+  useEffect(() => {
+    if (connectedAt === null) return;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [connectedAt]);
 
   const onToggleMute = useCallback(async () => {
     const next = !muted;
@@ -67,23 +78,53 @@ export const InCallScreen: React.FC = () => {
     }
     if (navigation.canGoBack()) {
       navigation.goBack();
+    } else {
+      (navigation as any).navigate("ConversationsList");
     }
   }, [end, navigation]);
+
+  const remoteCount = participants.length - 1; // exclude self
+  const status: "ringing" | "connected" =
+    remoteCount > 0 ? "connected" : "ringing";
+
+  const elapsed =
+    connectedAt === null ? 0 : Math.floor((now - connectedAt) / 1000);
+  const mm = String(Math.floor(elapsed / 60)).padStart(2, "0");
+  const ss = String(elapsed % 60).padStart(2, "0");
 
   const numColumns = participants.length <= 4 ? 2 : 3;
 
   return (
     <View style={styles.container}>
-      <FlatList
-        data={participants}
-        // key forces FlatList to remount when numColumns changes — otherwise
-        // React Native crashes with "numColumns cannot change dynamically".
-        key={`cols-${numColumns}`}
-        keyExtractor={(p) => p.identity}
-        numColumns={numColumns}
-        renderItem={({ item }) => <CallParticipantTile participant={item} />}
-        contentContainerStyle={styles.grid}
-      />
+      <View style={styles.header}>
+        <Text style={styles.statusLabel}>
+          {status === "ringing" ? "Appel en cours…" : "En communication"}
+        </Text>
+        {status === "connected" && (
+          <Text style={styles.elapsed}>
+            {mm}:{ss}
+          </Text>
+        )}
+        {status === "ringing" && (
+          <Text style={styles.hint}>
+            En attente que le destinataire décroche
+          </Text>
+        )}
+      </View>
+
+      <View style={styles.grid}>
+        <FlatList
+          data={participants}
+          // key forces FlatList to remount when numColumns changes — otherwise
+          // React Native crashes with "numColumns cannot change dynamically".
+          key={`cols-${numColumns}`}
+          keyExtractor={(p) => p.identity}
+          numColumns={numColumns}
+          renderItem={({ item }) => <CallParticipantTile participant={item} />}
+          contentContainerStyle={styles.gridContent}
+        />
+      </View>
+
       <CallControls
         muted={muted}
         cameraOff={camOff}
@@ -97,8 +138,42 @@ export const InCallScreen: React.FC = () => {
 };
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: "#000" },
-  grid: { gap: 8, padding: 8 },
+  container: {
+    flex: 1,
+    backgroundColor: "#000",
+    justifyContent: "space-between",
+  },
+  header: {
+    paddingTop: 32,
+    paddingBottom: 16,
+    paddingHorizontal: 16,
+    alignItems: "center",
+    backgroundColor: "rgba(0,0,0,0.4)",
+  },
+  statusLabel: {
+    color: "#fff",
+    fontSize: 18,
+    fontFamily: "Inter_600SemiBold",
+  },
+  elapsed: {
+    color: "#9fe8a0",
+    fontSize: 16,
+    marginTop: 4,
+    fontVariant: ["tabular-nums"],
+  },
+  hint: {
+    color: "#bbb",
+    fontSize: 13,
+    marginTop: 4,
+  },
+  grid: {
+    flex: 1,
+    minHeight: 0,
+  },
+  gridContent: {
+    gap: 8,
+    padding: 8,
+  },
 });
 
 export default InCallScreen;


### PR DESCRIPTION
Avant : InCallScreen sur web montrait une FlatList qui poussait la barre CallControls (Mute/Cam/Flip/End) en dehors de la fenêtre — impossible de raccrocher, aucune indication de l'état du call, aucun nom lisible.

- Ajoute un header fixe avec statut ("Appel en cours…" → "En communication") et chrono mm:ss déclenché quand un remote participant rejoint.
- `container` en flex column + justify space-between pour que la grille prenne la place restante et les contrôles restent fixés en bas.
- Fallback de navigation quand canGoBack() est faux (refresh / deep-link).
- CallParticipantTile.web : placeholder enrichi avec avatar lettré + "Vous" pour le participant local, 8 premiers caractères de l'UUID sinon (en attendant la résolution de nom côté store conversations).

Note : la notification "incoming_call" côté callee n'est pas encore câblée (messaging-service ne souscrit pas aux événements Redis whispr:calls:initiated publiés par calls-service). Ticket séparé.