### PR TITLE
fix(profile): empêcher l'édition du profil d'un autre utilisateur dep…

### DIFF
--- a/ProfileScreenReadOnly.test.tsx
+++ b/ProfileScreenReadOnly.test.tsx
@@ -1,0 +1,149 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react-native";
+import { ProfileScreen } from "./src/screens/Profile/ProfileScreen";
+
+const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({
+    navigate: mockNavigate,
+    goBack: mockGoBack,
+    reset: jest.fn(),
+  }),
+  useRoute: () => ({
+    params: { userId: "other-user-456" },
+  }),
+  useFocusEffect: (cb: () => void | (() => void)) => {
+    const React = require("react");
+    React.useEffect(() => cb(), []);
+  },
+}));
+jest.mock("expo-linear-gradient", () => ({
+  LinearGradient: ({ children }: any) => children,
+}));
+jest.mock("expo-image-picker", () => ({
+  requestMediaLibraryPermissionsAsync: jest
+    .fn()
+    .mockResolvedValue({ status: "granted" }),
+  requestCameraPermissionsAsync: jest
+    .fn()
+    .mockResolvedValue({ status: "granted" }),
+  launchImageLibraryAsync: jest.fn().mockResolvedValue({ canceled: true }),
+  launchCameraAsync: jest.fn().mockResolvedValue({ canceled: true }),
+  MediaTypeOptions: { Images: "Images" },
+}));
+jest.mock("@expo/vector-icons", () => ({ Ionicons: () => null }));
+jest.mock("./src/context/AuthContext", () => ({
+  useAuth: () => ({ userId: "current-user-123" }),
+}));
+jest.mock("./src/components", () => ({
+  Logo: () => null,
+  Button: ({ title, onPress, disabled }: any) => {
+    const { TouchableOpacity, Text } = require("react-native");
+    return (
+      <TouchableOpacity onPress={onPress} disabled={disabled}>
+        <Text>{title}</Text>
+      </TouchableOpacity>
+    );
+  },
+}));
+jest.mock("./src/services", () => {
+  const singleton = {
+    getProfile: jest.fn().mockResolvedValue({ success: false }),
+    getUserProfile: jest.fn().mockResolvedValue({
+      success: true,
+      profile: {
+        id: "other-user-456",
+        firstName: "Alice",
+        lastName: "Martin",
+        username: "alice",
+        phoneNumber: "+33611112222",
+        biography: "Bio d'Alice",
+      },
+    }),
+    updateProfile: jest.fn().mockResolvedValue({ success: true }),
+  };
+  return { UserService: { getInstance: () => singleton } };
+});
+jest.mock("./src/services/MediaService", () => ({
+  MediaService: {
+    uploadMedia: jest
+      .fn()
+      .mockResolvedValue({ id: "media-1", url: "https://cdn.test/img.jpg" }),
+  },
+}));
+jest.mock("./src/theme/colors", () => ({
+  colors: {
+    background: {
+      gradient: { app: ["#000", "#111"] },
+      primary: "#000",
+      secondary: "#111",
+      dark: "#000",
+    },
+    text: {
+      light: "#fff",
+      secondary: "#aaa",
+      placeholder: "#666",
+      primary: "#000",
+    },
+    primary: { main: "#6200ee" },
+    ui: { error: "#f00", border: "#333" },
+    status: { online: "#0f0", offline: "#888" },
+  },
+  withOpacity: (c: string) => c,
+}));
+jest.mock("./src/theme", () => ({
+  colors: {
+    text: {
+      light: "#fff",
+      secondary: "#aaa",
+      placeholder: "#666",
+      primary: "#000",
+    },
+    primary: { main: "#6200ee" },
+    background: {
+      primary: "#000",
+      secondary: "#111",
+      gradient: { app: ["#000", "#111"] },
+    },
+    ui: { error: "#f00", border: "#333" },
+    status: { online: "#0f0", offline: "#888" },
+  },
+  spacing: { xl: 24, xs: 4, md: 16, lg: 20, sm: 8, xxxl: 40 },
+  typography: {
+    fontSize: { xl: 24, base: 14, sm: 12, lg: 18, xxxl: 32, xs: 10 },
+    fontWeight: { bold: "700", medium: "500", semiBold: "600" },
+  },
+  borderRadius: { lg: 12, xl: 20 },
+  shadows: {},
+}));
+
+describe("ProfileScreen — viewing another user", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("hides the 'Modifier le profil' button when viewing another user", async () => {
+    const { queryByText, getByText } = render(<ProfileScreen />);
+    await waitFor(() => expect(getByText("Alice Martin")).toBeTruthy());
+    expect(queryByText("Modifier le profil")).toBeNull();
+    expect(queryByText("Sauvegarder")).toBeNull();
+  });
+
+  it("never calls updateProfile when viewing another user", async () => {
+    const services = require("./src/services") as {
+      UserService: {
+        getInstance: () => {
+          updateProfile: jest.Mock;
+          getUserProfile: jest.Mock;
+        };
+      };
+    };
+    const instance = services.UserService.getInstance();
+
+    const { getByText } = render(<ProfileScreen />);
+    await waitFor(() => expect(getByText("Alice Martin")).toBeTruthy());
+
+    expect(instance.getUserProfile).toHaveBeenCalledWith("other-user-456");
+    expect(instance.updateProfile).not.toHaveBeenCalled();
+  });
+});

--- a/src/screens/Profile/ProfileScreen.tsx
+++ b/src/screens/Profile/ProfileScreen.tsx
@@ -344,6 +344,7 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
 
   // Handle profile update
   const handleSaveProfile = async () => {
+    if (!isOwnProfile) return;
     const firstNameError = validateField("firstName", profile.firstName);
     const lastNameError = validateField("lastName", profile.lastName);
     const normalizedUsername = normalizeUsername(profile.username);
@@ -736,7 +737,7 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
               <TouchableOpacity
                 onPress={() => setShowImagePicker(true)}
                 style={styles.profilePictureContainer}
-                disabled={!isEditing}
+                disabled={!isEditing || !isOwnProfile}
               >
                 <Avatar
                   uri={profile.profilePicture}
@@ -932,26 +933,28 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
             </View>
 
             {/* Action Buttons */}
-            <View style={styles.actionButtons}>
-              {!isEditing ? (
-                <Button
-                  title="Modifier le profil"
-                  variant="primary"
-                  size="large"
-                  onPress={() => setIsEditing(true)}
-                  fullWidth
-                />
-              ) : (
-                <Button
-                  title={loading ? "Sauvegarde..." : "Sauvegarder"}
-                  variant="primary"
-                  size="large"
-                  onPress={handleSaveProfile}
-                  loading={loading}
-                  fullWidth
-                />
-              )}
-            </View>
+            {isOwnProfile && (
+              <View style={styles.actionButtons}>
+                {!isEditing ? (
+                  <Button
+                    title="Modifier le profil"
+                    variant="primary"
+                    size="large"
+                    onPress={() => setIsEditing(true)}
+                    fullWidth
+                  />
+                ) : (
+                  <Button
+                    title={loading ? "Sauvegarde..." : "Sauvegarder"}
+                    variant="primary"
+                    size="large"
+                    onPress={handleSaveProfile}
+                    loading={loading}
+                    fullWidth
+                  />
+                )}
+              </View>
+            )}
           </ScrollView>
         </Animated.View>
       </KeyboardAvoidingView>


### PR DESCRIPTION
…uis un groupe

Depuis WHISPR-1040, ProfileScreen sait afficher le profil d'un autre membre (via getUserProfile + isOwnProfile dans loadProfile). Mais l'UI d'édition n'a jamais été conditionnée à isOwnProfile :

- le bouton "Modifier le profil" était rendu sans condition
- le picker d'avatar n'était gardé que par isEditing
- handleSaveProfile n'avait aucun garde

Conséquence : un utilisateur ouvrant le profil d'un autre membre depuis un groupe pouvait cliquer sur Modifier puis Sauvegarder. updateProfile passe toujours par /profile/{userId} où {userId} est remplacé par le sub du JWT (UserService.authFetch), donc le backend (assertOwnership) répond OK pour le PATCH — mais le body envoyé contient les champs préremplis du membre consulté. Résultat : le profil de l'utilisateur courant est écrasé avec les valeurs du membre observé.

Ce commit applique isOwnProfile aux trois entrées d'édition restantes :
- bouton "Modifier" / "Sauvegarder" non rendu quand !isOwnProfile
- TouchableOpacity de l'avatar désactivé quand !isOwnProfile
- handleSaveProfile retourne immédiatement quand !isOwnProfile

Closes WHISPR-1168