### PR TITLE
feat(groups): permettre à tout membre d'inviter de nouveaux membres

### DIFF
--- a/GroupDetailsScreen.test.tsx
+++ b/GroupDetailsScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, waitFor } from "@testing-library/react-native";
+import { render, waitFor, fireEvent } from "@testing-library/react-native";
 import { GroupDetailsScreen } from "./src/screens/Groups/GroupDetailsScreen";
 import { groupsAPI } from "./src/services/groups/api";
 
@@ -204,6 +204,41 @@ describe("GroupDetailsScreen", () => {
     const { toJSON } = render(<GroupDetailsScreen />);
     await waitFor(() => {
       expect(toJSON()).toBeTruthy();
+    });
+  });
+
+  it("renders 'Ajouter un membre' for a non-admin member (WHISPR-1169)", async () => {
+    mockedGroupsAPI.getGroupMembers.mockResolvedValue({
+      members: [
+        {
+          id: "user1",
+          user_id: "user1",
+          display_name: "Me",
+          role: "member",
+          joined_at: "2024-01-01T00:00:00Z",
+          is_active: true,
+        },
+        {
+          id: "user2",
+          user_id: "user2",
+          display_name: "Admin Other",
+          role: "admin",
+          joined_at: "2024-01-01T00:00:00Z",
+          is_active: true,
+        },
+      ],
+      total: 2,
+    } as any);
+
+    const { getByText, getAllByText } = render(<GroupDetailsScreen />);
+    await waitFor(() => {
+      expect(getAllByText("Test Group").length).toBeGreaterThan(0);
+    });
+
+    fireEvent.press(getByText("Membres"));
+
+    await waitFor(() => {
+      expect(getByText("Ajouter un membre")).toBeTruthy();
     });
   });
 });

--- a/src/screens/Groups/GroupDetailsScreen.tsx
+++ b/src/screens/Groups/GroupDetailsScreen.tsx
@@ -823,35 +823,33 @@ export const GroupDetailsScreen: React.FC = () => {
             {stats && stats.adminCount > 1 ? "s" : ""}
           </Text>
         </View>
-        {isAdmin && (
-          <TouchableOpacity
+        <TouchableOpacity
+          style={[
+            styles.addMemberButton,
+            { backgroundColor: withOpacity(colors.primary.main, 0.15) },
+          ]}
+          onPress={openAddMemberModal}
+          activeOpacity={0.7}
+          accessibilityRole="button"
+          accessibilityLabel="Ajouter un membre"
+        >
+          <View
             style={[
-              styles.addMemberButton,
-              { backgroundColor: withOpacity(colors.primary.main, 0.15) },
+              styles.addMemberIcon,
+              { backgroundColor: colors.primary.main },
             ]}
-            onPress={openAddMemberModal}
-            activeOpacity={0.7}
-            accessibilityRole="button"
-            accessibilityLabel="Ajouter un membre"
           >
-            <View
-              style={[
-                styles.addMemberIcon,
-                { backgroundColor: colors.primary.main },
-              ]}
-            >
-              <Ionicons name="person-add" size={18} color={colors.text.light} />
-            </View>
-            <Text style={[styles.addMemberText, { color: colors.text.light }]}>
-              Ajouter un membre
-            </Text>
-            <Ionicons
-              name="chevron-forward"
-              size={18}
-              color={withOpacity(colors.text.light, 0.5)}
-            />
-          </TouchableOpacity>
-        )}
+            <Ionicons name="person-add" size={18} color={colors.text.light} />
+          </View>
+          <Text style={[styles.addMemberText, { color: colors.text.light }]}>
+            Ajouter un membre
+          </Text>
+          <Ionicons
+            name="chevron-forward"
+            size={18}
+            color={withOpacity(colors.text.light, 0.5)}
+          />
+        </TouchableOpacity>
         {members.map((member, index) => (
           <AnimatedTouchableOpacity
             key={member.id}

--- a/src/screens/Groups/GroupManagementScreen.tsx
+++ b/src/screens/Groups/GroupManagementScreen.tsx
@@ -421,11 +421,10 @@ export const GroupManagementScreen: React.FC = () => {
   );
 
   const handleAddMembers = useCallback(() => {
-    if (!isAdmin) return;
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
     setShowAddMembersModal(true);
     loadAvailableContacts();
-  }, [isAdmin]);
+  }, []);
 
   const loadAvailableContacts = useCallback(async () => {
     try {


### PR DESCRIPTION
Aligne le frontend avec le backend messaging-service WHISPR-1169 : tout membre actif d'un groupe peut désormais inviter de nouveaux membres (comportement standard WhatsApp / Telegram / Signal).

Modifications :
- GroupDetailsScreen.tsx : retirer la garde {isAdmin && (...)} autour du bouton "Ajouter un membre"
- GroupManagementScreen.tsx : retirer la garde if (!isAdmin) return dans handleAddMembers
- Test de régression : non-admin member voit "Ajouter un membre"

Les autres actions admin (retirer un membre, changer un rôle, modifier les paramètres, supprimer le groupe) restent gardées par isAdmin.

Closes WHISPR-1169 (côté frontend)