### PR TITLE
refactor(profile): split ProfileScreen into MyProfileScreen and UserProfileScreen [WHISPR-1189]

### DIFF
--- a/MyProfileScreen.test.tsx
+++ b/MyProfileScreen.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, fireEvent, waitFor } from "@testing-library/react-native";
-import { ProfileScreen } from "./src/screens/Profile/ProfileScreen";
+import { MyProfileScreen } from "./src/screens/Profile/MyProfileScreen";
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
@@ -11,19 +11,14 @@ jest.mock("@react-navigation/native", () => ({
     goBack: mockGoBack,
     reset: jest.fn(),
   }),
-  useRoute: () => ({
-    params: {
-      firstName: "John",
-      lastName: "Doe",
-      username: "johndoe",
-      phoneNumber: "+33612345678",
-      biography: "",
-    },
-  }),
+  useRoute: () => ({ params: {} }),
   useFocusEffect: (cb: () => void | (() => void)) => {
     const React = require("react");
     React.useEffect(() => cb(), []);
   },
+}));
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
 jest.mock("expo-linear-gradient", () => ({
   LinearGradient: ({ children }: any) => children,
@@ -40,15 +35,11 @@ jest.mock("expo-image-picker", () => ({
   MediaTypeOptions: { Images: "Images" },
 }));
 jest.mock("@expo/vector-icons", () => ({ Ionicons: () => null }));
+jest.mock("./src/components/Chat/Avatar", () => ({
+  Avatar: () => null,
+}));
 jest.mock("./src/context/AuthContext", () => ({
-  useAuth: () => ({
-    isAuthenticated: true,
-    isLoading: false,
-    userId: "user1",
-    deviceId: "dev1",
-    signIn: jest.fn(),
-    signOut: jest.fn(),
-  }),
+  useAuth: () => ({ userId: "user-123" }),
 }));
 jest.mock("./src/components", () => ({
   Logo: () => null,
@@ -63,24 +54,30 @@ jest.mock("./src/components", () => ({
 }));
 jest.mock("./src/services", () => {
   const singleton = {
-    getProfile: jest.fn().mockResolvedValue({ success: false }),
+    getProfile: jest.fn().mockResolvedValue({
+      success: true,
+      profile: {
+        id: "user-123",
+        firstName: "John",
+        lastName: "Doe",
+        username: "johndoe",
+        phoneNumber: "+33612345678",
+        biography: "",
+      },
+    }),
+    getUserProfile: jest.fn(),
     updateProfile: jest.fn().mockResolvedValue({ success: true }),
   };
-  return {
-    UserService: { getInstance: () => singleton },
-  };
+  return { UserService: { getInstance: () => singleton } };
 });
 jest.mock("./src/services/MediaService", () => ({
   MediaService: {
     uploadMedia: jest
       .fn()
       .mockResolvedValue({ id: "media-1", url: "https://cdn.test/img.jpg" }),
+    getMediaMetadata: jest.fn().mockResolvedValue({ id: "media-1" }),
   },
 }));
-jest.mock("./src/context/AuthContext", () => ({
-  useAuth: () => ({ userId: "user-123" }),
-}));
-// ProfileScreen uses colors.background.gradient.app from theme/colors (not theme)
 jest.mock("./src/theme/colors", () => ({
   colors: {
     background: {
@@ -127,95 +124,57 @@ jest.mock("./src/theme", () => ({
   shadows: {},
 }));
 
-describe("ProfileScreen", () => {
+describe("MyProfileScreen", () => {
   beforeEach(() => jest.clearAllMocks());
 
   it("renders profile header", () => {
-    const { getByText } = render(<ProfileScreen />);
+    const { getByText } = render(<MyProfileScreen />);
     expect(getByText("Profil")).toBeTruthy();
   });
 
-  it("renders user name from route params", () => {
-    const { getByText } = render(<ProfileScreen />);
-    expect(getByText("John Doe")).toBeTruthy();
-  });
-
-  it("renders edit profile button", () => {
-    const { getByText } = render(<ProfileScreen />);
-    expect(getByText("Modifier le profil")).toBeTruthy();
-  });
-
-  it("enters edit mode on edit button press", () => {
-    const { getByText } = render(<ProfileScreen />);
-    fireEvent.press(getByText("Modifier le profil"));
-    expect(getByText("Sauvegarder")).toBeTruthy();
+  it("loads and renders profile data from UserService.getProfile", async () => {
+    const { getByText } = render(<MyProfileScreen />);
+    await waitFor(() => expect(getByText("John Doe")).toBeTruthy());
   });
 
   it("navigates back on back press when not editing", () => {
-    const { getByText } = render(<ProfileScreen />);
+    const { getByText } = render(<MyProfileScreen />);
     fireEvent.press(getByText("← Retour"));
     expect(mockGoBack).toHaveBeenCalled();
   });
 
-  it("navigates to Settings on settings press", () => {
-    const { getByText } = render(<ProfileScreen />);
-    fireEvent.press(getByText("⚙️"));
-    expect(mockNavigate).toHaveBeenCalledWith("Settings");
+  it("enters edit mode and exposes a Save button", async () => {
+    const { getByLabelText, getByText } = render(<MyProfileScreen />);
+    fireEvent.press(getByLabelText("Modifier le profil"));
+    await waitFor(() => expect(getByText("Sauvegarder")).toBeTruthy());
   });
 });
 
-// ---------------------------------------------------------------------------
-// Handler-level tests (Sprint 3)
-// ---------------------------------------------------------------------------
-
-describe("ProfileScreen — edit / save flow", () => {
+describe("MyProfileScreen — save flow", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  const pickerMock = require("expo-image-picker") as {
-    requestMediaLibraryPermissionsAsync: jest.Mock;
-    launchImageLibraryAsync: jest.Mock;
-    requestCameraPermissionsAsync: jest.Mock;
-    launchCameraAsync: jest.Mock;
-  };
-
-  it("keeps the profile picture untouched when the image picker is cancelled", async () => {
-    pickerMock.requestMediaLibraryPermissionsAsync.mockResolvedValueOnce({
-      status: "granted",
-    });
-    pickerMock.launchImageLibraryAsync.mockResolvedValueOnce({
-      canceled: true,
-    });
-
-    const { getByText } = render(<ProfileScreen />);
-    fireEvent.press(getByText("Modifier le profil"));
-    // Re-pressing the avatar area is not part of the rendered text — the flow
-    // is tested through the launchImageLibraryAsync mock above.
-
-    await waitFor(() => {
-      expect(pickerMock.requestMediaLibraryPermissionsAsync).not.toThrow();
-    });
-  });
-
-  it("aborts the save when a required field becomes invalid", async () => {
+  it("aborts the save when a required field becomes empty", async () => {
     const services = require("./src/services") as {
       UserService: { getInstance: () => { updateProfile: jest.Mock } };
     };
     const mockInstance = services.UserService.getInstance();
     (mockInstance.updateProfile as jest.Mock).mockClear();
 
-    const { getByText, getByDisplayValue } = render(<ProfileScreen />);
-    fireEvent.press(getByText("Modifier le profil"));
+    const { getByLabelText, getByText, getByDisplayValue } = render(
+      <MyProfileScreen />,
+    );
+    await waitFor(() => expect(getByText("John Doe")).toBeTruthy());
 
-    // Clear the firstName field → validation should reject
+    fireEvent.press(getByLabelText("Modifier le profil"));
     fireEvent.changeText(getByDisplayValue("John"), "");
     fireEvent.press(getByText("Sauvegarder"));
 
-    await waitFor(() => {
-      expect(mockInstance.updateProfile).not.toHaveBeenCalled();
-    });
+    await waitFor(() =>
+      expect(mockInstance.updateProfile).not.toHaveBeenCalled(),
+    );
   });
 
-  it("calls UserService.updateProfile when the save flow succeeds", async () => {
+  it("calls UserService.updateProfile on a successful save", async () => {
     const services = require("./src/services") as {
       UserService: {
         getInstance: () => {
@@ -235,8 +194,12 @@ describe("ProfileScreen — edit / save flow", () => {
       },
     });
 
-    const { getByText, getByDisplayValue } = render(<ProfileScreen />);
-    fireEvent.press(getByText("Modifier le profil"));
+    const { getByLabelText, getByText, getByDisplayValue } = render(
+      <MyProfileScreen />,
+    );
+    await waitFor(() => expect(getByText("John Doe")).toBeTruthy());
+
+    fireEvent.press(getByLabelText("Modifier le profil"));
     fireEvent.changeText(getByDisplayValue("John"), "Jane");
     fireEvent.press(getByText("Sauvegarder"));
 

--- a/UserProfileScreen.test.tsx
+++ b/UserProfileScreen.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, waitFor } from "@testing-library/react-native";
-import { ProfileScreen } from "./src/screens/Profile/ProfileScreen";
+import { UserProfileScreen } from "./src/screens/Profile/UserProfileScreen";
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
@@ -11,46 +11,25 @@ jest.mock("@react-navigation/native", () => ({
     goBack: mockGoBack,
     reset: jest.fn(),
   }),
-  useRoute: () => ({
-    params: { userId: "other-user-456" },
-  }),
+  useRoute: () => ({ params: { userId: "other-user-456" } }),
   useFocusEffect: (cb: () => void | (() => void)) => {
     const React = require("react");
     React.useEffect(() => cb(), []);
   },
 }));
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
 jest.mock("expo-linear-gradient", () => ({
   LinearGradient: ({ children }: any) => children,
 }));
-jest.mock("expo-image-picker", () => ({
-  requestMediaLibraryPermissionsAsync: jest
-    .fn()
-    .mockResolvedValue({ status: "granted" }),
-  requestCameraPermissionsAsync: jest
-    .fn()
-    .mockResolvedValue({ status: "granted" }),
-  launchImageLibraryAsync: jest.fn().mockResolvedValue({ canceled: true }),
-  launchCameraAsync: jest.fn().mockResolvedValue({ canceled: true }),
-  MediaTypeOptions: { Images: "Images" },
-}));
 jest.mock("@expo/vector-icons", () => ({ Ionicons: () => null }));
-jest.mock("./src/context/AuthContext", () => ({
-  useAuth: () => ({ userId: "current-user-123" }),
-}));
-jest.mock("./src/components", () => ({
-  Logo: () => null,
-  Button: ({ title, onPress, disabled }: any) => {
-    const { TouchableOpacity, Text } = require("react-native");
-    return (
-      <TouchableOpacity onPress={onPress} disabled={disabled}>
-        <Text>{title}</Text>
-      </TouchableOpacity>
-    );
-  },
+jest.mock("./src/components/Chat/Avatar", () => ({
+  Avatar: () => null,
 }));
 jest.mock("./src/services", () => {
   const singleton = {
-    getProfile: jest.fn().mockResolvedValue({ success: false }),
+    getProfile: jest.fn(),
     getUserProfile: jest.fn().mockResolvedValue({
       success: true,
       profile: {
@@ -58,21 +37,13 @@ jest.mock("./src/services", () => {
         firstName: "Alice",
         lastName: "Martin",
         username: "alice",
-        phoneNumber: "+33611112222",
         biography: "Bio d'Alice",
       },
     }),
-    updateProfile: jest.fn().mockResolvedValue({ success: true }),
+    updateProfile: jest.fn(),
   };
   return { UserService: { getInstance: () => singleton } };
 });
-jest.mock("./src/services/MediaService", () => ({
-  MediaService: {
-    uploadMedia: jest
-      .fn()
-      .mockResolvedValue({ id: "media-1", url: "https://cdn.test/img.jpg" }),
-  },
-}));
 jest.mock("./src/theme/colors", () => ({
   colors: {
     background: {
@@ -119,31 +90,50 @@ jest.mock("./src/theme", () => ({
   shadows: {},
 }));
 
-describe("ProfileScreen — viewing another user", () => {
+describe("UserProfileScreen", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("hides the 'Modifier le profil' button when viewing another user", async () => {
-    const { queryByText, getByText } = render(<ProfileScreen />);
-    await waitFor(() => expect(getByText("Alice Martin")).toBeTruthy());
-    expect(queryByText("Modifier le profil")).toBeNull();
-    expect(queryByText("Sauvegarder")).toBeNull();
-  });
-
-  it("never calls updateProfile when viewing another user", async () => {
+  it("calls getUserProfile with the route userId", async () => {
     const services = require("./src/services") as {
       UserService: {
-        getInstance: () => {
-          updateProfile: jest.Mock;
-          getUserProfile: jest.Mock;
-        };
+        getInstance: () => { getUserProfile: jest.Mock };
       };
     };
     const instance = services.UserService.getInstance();
 
-    const { getByText } = render(<ProfileScreen />);
+    const { getByText } = render(<UserProfileScreen />);
+    await waitFor(() => expect(getByText("Alice Martin")).toBeTruthy());
+    expect(instance.getUserProfile).toHaveBeenCalledWith("other-user-456");
+  });
+
+  it("does not render an edit pencil nor a Save button", async () => {
+    const { queryByLabelText, queryByText, getByText } = render(
+      <UserProfileScreen />,
+    );
     await waitFor(() => expect(getByText("Alice Martin")).toBeTruthy());
 
-    expect(instance.getUserProfile).toHaveBeenCalledWith("other-user-456");
+    expect(queryByLabelText("Modifier le profil")).toBeNull();
+    expect(queryByText("Sauvegarder")).toBeNull();
+  });
+
+  it("does not render the phone number field", async () => {
+    const { queryByText, getByText } = render(<UserProfileScreen />);
+    await waitFor(() => expect(getByText("Alice Martin")).toBeTruthy());
+
+    expect(queryByText("Numéro de téléphone")).toBeNull();
+  });
+
+  it("never calls updateProfile", async () => {
+    const services = require("./src/services") as {
+      UserService: {
+        getInstance: () => { updateProfile: jest.Mock };
+      };
+    };
+    const instance = services.UserService.getInstance();
+
+    const { getByText } = render(<UserProfileScreen />);
+    await waitFor(() => expect(getByText("Alice Martin")).toBeTruthy());
+
     expect(instance.updateProfile).not.toHaveBeenCalled();
   });
 });

--- a/linkingConfig.test.ts
+++ b/linkingConfig.test.ts
@@ -6,7 +6,10 @@
  * drop a screen or change a URL path.
  */
 
-import { DEEP_LINK_PREFIXES, linkingConfig } from "./src/navigation/linkingConfig";
+import {
+  DEEP_LINK_PREFIXES,
+  linkingConfig,
+} from "./src/navigation/linkingConfig";
 
 describe("linkingConfig", () => {
   it("exposes the whispr:// scheme", () => {
@@ -18,7 +21,7 @@ describe("linkingConfig", () => {
     expect(linkingConfig.config?.screens).toMatchObject({
       Chat: "conversation/:conversationId",
       GroupDetails: "group/:groupId",
-      Profile: "profile/:userId",
+      UserProfile: "profile/:userId",
     });
   });
 
@@ -26,7 +29,7 @@ describe("linkingConfig", () => {
     const screens = linkingConfig.config?.screens as Record<string, any>;
     expect(screens.Chat).toMatch(/^conversation\/:conversationId$/);
     expect(screens.GroupDetails).toMatch(/^group\/:groupId$/);
-    expect(screens.Profile).toMatch(/^profile\/:userId$/);
+    expect(screens.UserProfile).toMatch(/^profile\/:userId$/);
   });
 
   it("maps the Settings screen and its capitalised alias (WHISPR-1115)", () => {

--- a/src/components/Profile/ProfileFieldRow.tsx
+++ b/src/components/Profile/ProfileFieldRow.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { colors, spacing, typography } from "../../theme";
+
+interface ProfileFieldRowProps {
+  label: string;
+  value?: string;
+  placeholder?: string;
+}
+
+export const ProfileFieldRow: React.FC<ProfileFieldRowProps> = ({
+  label,
+  value,
+  placeholder = "—",
+}) => (
+  <View style={styles.section}>
+    <Text style={styles.label}>{label}</Text>
+    <Text style={styles.value}>{value || placeholder}</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  section: {
+    marginBottom: spacing.xl,
+  },
+  label: {
+    fontSize: typography.fontSize.sm,
+    fontWeight: typography.fontWeight.semiBold,
+    color: "rgba(255,255,255,0.8)",
+    marginBottom: spacing.sm,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+  value: {
+    fontSize: typography.fontSize.base,
+    fontWeight: typography.fontWeight.medium,
+    color: colors.text.light,
+    lineHeight: 20,
+    marginBottom: spacing.sm,
+  },
+});

--- a/src/components/Profile/ProfileHeader.tsx
+++ b/src/components/Profile/ProfileHeader.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { colors, spacing, typography } from "../../theme";
+
+interface ProfileHeaderProps {
+  title: string;
+  onBack: () => void;
+  rightActions?: React.ReactNode;
+}
+
+export const ProfileHeader: React.FC<ProfileHeaderProps> = ({
+  title,
+  onBack,
+  rightActions,
+}) => {
+  const insets = useSafeAreaInsets();
+  return (
+    <View style={[styles.header, { paddingTop: insets.top + spacing.md }]}>
+      <TouchableOpacity
+        onPress={onBack}
+        style={styles.backButton}
+        accessibilityRole="button"
+        accessibilityLabel="Retour"
+      >
+        <Text style={styles.backButtonText}>← Retour</Text>
+      </TouchableOpacity>
+
+      <Text style={styles.headerTitle}>{title}</Text>
+
+      <View style={styles.rightSlot}>{rightActions}</View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.lg,
+    backgroundColor: "transparent",
+    borderBottomWidth: 0,
+  },
+  backButton: {
+    padding: spacing.sm,
+  },
+  backButtonText: {
+    fontSize: typography.fontSize.base,
+    color: colors.text.light,
+    fontWeight: typography.fontWeight.medium,
+  },
+  headerTitle: {
+    fontSize: typography.fontSize.xl,
+    fontWeight: typography.fontWeight.bold,
+    color: colors.text.light,
+  },
+  rightSlot: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.md,
+    minWidth: 40,
+    justifyContent: "flex-end",
+  },
+});

--- a/src/components/Profile/ProfilePictureBlock.tsx
+++ b/src/components/Profile/ProfilePictureBlock.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  Animated,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { Avatar } from "../Chat/Avatar";
+import { colors, spacing, typography } from "../../theme";
+
+interface ProfilePictureBlockProps {
+  uri?: string;
+  name: string;
+  editable?: boolean;
+  onPress?: () => void;
+  label?: string;
+  scaleAnim?: Animated.Value;
+}
+
+export const ProfilePictureBlock: React.FC<ProfilePictureBlockProps> = ({
+  uri,
+  name,
+  editable = false,
+  onPress,
+  label,
+  scaleAnim,
+}) => {
+  const content = (
+    <>
+      <TouchableOpacity
+        onPress={onPress}
+        style={styles.container}
+        disabled={!editable}
+        activeOpacity={editable ? 0.7 : 1}
+      >
+        <Avatar uri={uri} name={name} size={120} />
+
+        {editable && (
+          <View style={styles.editOverlay}>
+            <Ionicons name="camera" size={18} color="#333" />
+          </View>
+        )}
+      </TouchableOpacity>
+
+      {label && <Text style={styles.label}>{label}</Text>}
+    </>
+  );
+
+  if (scaleAnim) {
+    return (
+      <Animated.View
+        style={[styles.section, { transform: [{ scale: scaleAnim }] }]}
+      >
+        {content}
+      </Animated.View>
+    );
+  }
+
+  return <View style={styles.section}>{content}</View>;
+};
+
+const styles = StyleSheet.create({
+  section: {
+    alignItems: "center",
+    paddingTop: spacing.md,
+    paddingBottom: spacing.xxxl,
+  },
+  container: {
+    position: "relative",
+    marginBottom: spacing.md,
+  },
+  editOverlay: {
+    position: "absolute",
+    bottom: 0,
+    right: 0,
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: colors.primary.main,
+    justifyContent: "center",
+    alignItems: "center",
+    borderWidth: 3,
+    borderColor: colors.background.primary,
+  },
+  label: {
+    fontSize: typography.fontSize.sm,
+    color: colors.text.light,
+    textAlign: "center",
+    opacity: 0.9,
+  },
+});

--- a/src/components/Profile/StatusChip.tsx
+++ b/src/components/Profile/StatusChip.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { colors, spacing, typography } from "../../theme";
+
+interface StatusChipProps {
+  isOnline: boolean;
+  lastSeen?: string;
+}
+
+export const StatusChip: React.FC<StatusChipProps> = ({
+  isOnline,
+  lastSeen,
+}) => (
+  <View style={styles.section}>
+    <Text style={styles.label}>Statut</Text>
+    <View
+      style={[styles.chip, isOnline ? styles.chipOnline : styles.chipOffline]}
+    >
+      <View
+        style={[
+          styles.dot,
+          {
+            backgroundColor: isOnline
+              ? colors.status.online
+              : colors.status.offline,
+          },
+        ]}
+      />
+      <Text
+        style={[styles.text, isOnline ? styles.textOnline : styles.textOffline]}
+      >
+        {isOnline ? "Actif maintenant" : `Hors ligne - ${lastSeen ?? ""}`}
+      </Text>
+    </View>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  section: {
+    marginBottom: spacing.xl,
+  },
+  label: {
+    fontSize: typography.fontSize.sm,
+    fontWeight: typography.fontWeight.semiBold,
+    color: "rgba(255,255,255,0.8)",
+    marginBottom: spacing.sm,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+  chip: {
+    flexDirection: "row",
+    alignItems: "center",
+    alignSelf: "flex-start",
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    borderRadius: 999,
+    borderWidth: 0,
+  },
+  chipOnline: {
+    backgroundColor: "rgba(33, 192, 4, 0.18)",
+  },
+  chipOffline: {
+    backgroundColor: "rgba(142, 142, 147, 0.18)",
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    marginRight: spacing.sm,
+  },
+  text: {
+    fontSize: typography.fontSize.sm,
+    fontWeight: typography.fontWeight.medium,
+  },
+  textOnline: {
+    color: colors.text.light,
+  },
+  textOffline: {
+    color: "rgba(255,255,255,0.85)",
+  },
+});

--- a/src/components/Profile/index.ts
+++ b/src/components/Profile/index.ts
@@ -1,0 +1,4 @@
+export { ProfileHeader } from "./ProfileHeader";
+export { ProfilePictureBlock } from "./ProfilePictureBlock";
+export { ProfileFieldRow } from "./ProfileFieldRow";
+export { StatusChip } from "./StatusChip";

--- a/src/navigation/AuthNavigator.tsx
+++ b/src/navigation/AuthNavigator.tsx
@@ -4,7 +4,8 @@ import { WelcomeScreen } from "../screens/Auth/WelcomeScreen";
 import { PhoneInputScreen } from "../screens/Auth/PhoneInputScreen";
 import { OtpScreen } from "../screens/Auth/OtpScreen";
 import { ProfileSetupScreen } from "../screens/Auth/ProfileSetupScreen";
-import { ProfileScreen } from "../screens/Profile/ProfileScreen";
+import { MyProfileScreen } from "../screens/Profile/MyProfileScreen";
+import { UserProfileScreen } from "../screens/Profile/UserProfileScreen";
 import { SettingsScreen } from "../screens/Settings/SettingsScreen";
 import { AboutContentScreen } from "../screens/Settings/AboutContentScreen";
 import { DevicesScreen } from "../screens/Settings/DevicesScreen";
@@ -75,16 +76,8 @@ export type AuthStackParamList = {
     demoCode?: string;
   };
   ProfileSetup: undefined;
-  Profile: {
-    userId?: string;
-    token?: string;
-    firstName?: string;
-    lastName?: string;
-    phoneNumber?: string;
-    profilePicture?: string;
-    username?: string;
-    biography?: string;
-  };
+  MyProfile: undefined;
+  UserProfile: { userId: string };
   Settings: undefined;
   AboutContent: undefined;
   SecurityKeys: undefined;
@@ -269,7 +262,8 @@ export const AuthNavigator: React.FC = () => {
       <Stack.Screen name="PhoneInput" component={PhoneInputScreen} />
       <Stack.Screen name="Otp" component={OtpScreen} />
       <Stack.Screen name="ProfileSetup" component={ProfileSetupScreen} />
-      <Stack.Screen name="Profile" component={ProfileScreen} />
+      <Stack.Screen name="MyProfile" component={MyProfileScreen} />
+      <Stack.Screen name="UserProfile" component={UserProfileScreen} />
       <Stack.Screen
         name="Settings"
         component={SettingsScreen}

--- a/src/navigation/linkingConfig.ts
+++ b/src/navigation/linkingConfig.ts
@@ -43,7 +43,7 @@ export const linkingConfig: LinkingOptions<LinkingParamList> = {
       // whispr://group/<groupId>
       GroupDetails: "group/:groupId",
       // whispr://profile/<userId>
-      Profile: "profile/:userId",
+      UserProfile: "profile/:userId",
       // whispr://settings — support both cases since some notifications and
       // email links shipped with the capitalised `Settings` path (WHISPR-1115).
       Settings: {

--- a/src/screens/Groups/GroupDetailsScreen.tsx
+++ b/src/screens/Groups/GroupDetailsScreen.tsx
@@ -862,12 +862,13 @@ export const GroupDetailsScreen: React.FC = () => {
               Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(
                 () => {},
               );
-              navigation.navigate("Profile", {
-                userId:
-                  member.user_id === CURRENT_USER_ID
-                    ? CURRENT_USER_ID
-                    : member.user_id,
-              });
+              if (member.user_id === CURRENT_USER_ID) {
+                navigation.navigate("MyProfile");
+              } else {
+                navigation.navigate("UserProfile", {
+                  userId: member.user_id,
+                });
+              }
             }}
             accessibilityRole="button"
             accessibilityLabel={`Ouvrir le profil de ${

--- a/src/screens/Profile/MyProfileScreen.tsx
+++ b/src/screens/Profile/MyProfileScreen.tsx
@@ -1,10 +1,9 @@
 /**
- * ProfileScreen - User Profile Management
- * WHISPR-132: Implement ProfileScreen with user profile management
+ * MyProfileScreen - Édition du profil de l'utilisateur connecté.
+ * Séparé de UserProfileScreen (consultation d'un profil tiers) — WHISPR-1189.
  */
 
 import React, { useState, useRef, useEffect, useCallback } from "react";
-import { formatUsername, normalizeUsername } from "../../utils";
 import {
   View,
   Text,
@@ -20,32 +19,25 @@ import {
   ActivityIndicator,
 } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
-import {
-  useNavigation,
-  useRoute,
-  useFocusEffect,
-  type RouteProp,
-} from "@react-navigation/native";
+import { useNavigation, useFocusEffect } from "@react-navigation/native";
 import type { StackNavigationProp } from "@react-navigation/stack";
 import * as ImagePicker from "expo-image-picker";
 import { Ionicons } from "@expo/vector-icons";
-import { Logo, Button } from "../../components";
-import { Avatar } from "../../components/Chat/Avatar";
+import { Button } from "../../components";
 import {
-  colors,
-  spacing,
-  typography,
-  borderRadius,
-  shadows,
-} from "../../theme";
+  ProfileHeader,
+  ProfilePictureBlock,
+  ProfileFieldRow,
+  StatusChip,
+} from "../../components/Profile";
+import { formatUsername, normalizeUsername } from "../../utils";
+import { colors, spacing, typography, borderRadius } from "../../theme";
 import { UserService } from "../../services";
 import type { UpdateProfileRequest } from "../../services/UserService";
 import { MediaService } from "../../services/MediaService";
 import { useAuth } from "../../context/AuthContext";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
-// Types
 interface UserProfile {
   id: string;
   firstName: string;
@@ -59,43 +51,22 @@ interface UserProfile {
   createdAt?: string;
 }
 
-interface ProfileScreenProps {
-  userId?: string;
-  token?: string;
-}
+type NavigationProp = StackNavigationProp<any, "MyProfile">;
 
-type NavigationProp = StackNavigationProp<any, "Profile">;
-type RouteParams = {
-  userId?: string;
-  token?: string;
-  firstName?: string;
-  lastName?: string;
-  username?: string;
-  phoneNumber?: string;
-  biography?: string;
-  profilePicture?: string;
-};
+const isMediaNotFound = (message?: string) =>
+  typeof message === "string" && /media not found/i.test(message);
 
-export const ProfileScreen: React.FC<ProfileScreenProps> = ({
-  userId,
-  token,
-}) => {
+export const MyProfileScreen: React.FC = () => {
   const { userId: currentUserId } = useAuth();
   const navigation = useNavigation<NavigationProp>();
-  const route = useRoute<RouteProp<{ Profile: RouteParams }, "Profile">>();
-  const params = route.params;
-  const insets = useSafeAreaInsets();
-  // ProfileScreen params loaded
 
-  // States
   const [profile, setProfile] = useState<UserProfile>({
-    id: params?.userId || userId || currentUserId || "",
-    firstName: params?.firstName || "",
-    lastName: params?.lastName || "",
-    username: params?.username || "",
-    phoneNumber: params?.phoneNumber || "",
-    biography: params?.biography || "",
-    profilePicture: params?.profilePicture,
+    id: currentUserId || "",
+    firstName: "",
+    lastName: "",
+    username: "",
+    phoneNumber: "",
+    biography: "",
     isOnline: true,
     lastSeen: "Maintenant",
     createdAt: "",
@@ -117,7 +88,7 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
     remoteUrl?: string;
   } | null>(null);
   const saveAbortRef = useRef<AbortController | null>(null);
-  const lastLoadRef = useRef<{ userKey: string; at: number } | null>(null);
+  const lastLoadAt = useRef<number | null>(null);
 
   const fadeAnim = useRef(new Animated.Value(0)).current;
   const slideAnim = useRef(new Animated.Value(40)).current;
@@ -138,25 +109,19 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
       }),
     ]).start();
 
-    // Cleanup: cancel any pending save on unmount
     return () => {
       if (saveAbortRef.current) {
         saveAbortRef.current.abort();
         saveAbortRef.current = null;
       }
     };
-  }, []);
-
-  const viewedUserId = params?.userId || userId || "";
-  const isOwnProfile = !viewedUserId || viewedUserId === currentUserId;
+  }, [fadeAnim, slideAnim]);
 
   const loadProfile = useCallback(async () => {
     try {
       setProfileLoadError(null);
       const service = UserService.getInstance();
-      const res = isOwnProfile
-        ? await service.getProfile()
-        : await service.getUserProfile(viewedUserId);
+      const res = await service.getProfile();
       if (res.success && res.profile) {
         const p = res.profile;
         setProfile((prev) => ({
@@ -171,10 +136,7 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
             pendingAvatar?.localUri || p.profilePicture || prev.profilePicture,
           createdAt: p.createdAt || prev.createdAt,
         }));
-        lastLoadRef.current = {
-          userKey: isOwnProfile ? "me" : viewedUserId,
-          at: Date.now(),
-        };
+        lastLoadAt.current = Date.now();
         setProfileLoaded(true);
         return;
       }
@@ -184,21 +146,16 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
       setProfileLoadError(e?.message || "Impossible de récupérer le profil");
       setProfileLoaded(true);
     }
-  }, [pendingAvatar?.localUri, isOwnProfile, viewedUserId]);
+  }, [pendingAvatar?.localUri]);
 
-  // Re-fetch profile from API every time the screen gains focus
   useFocusEffect(
     useCallback(() => {
-      const key = isOwnProfile ? "me" : viewedUserId;
-      const last = lastLoadRef.current;
-      if (last && last.userKey === key && Date.now() - last.at < 30_000) {
-        return;
-      }
+      const last = lastLoadAt.current;
+      if (last && Date.now() - last < 30_000) return;
       loadProfile();
-    }, [isOwnProfile, loadProfile, viewedUserId]),
+    }, [loadProfile]),
   );
 
-  // Handle profile picture change
   const handleImagePicker = async () => {
     try {
       const { status } =
@@ -220,10 +177,7 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
 
       if (!result.canceled && result.assets[0]) {
         const uri = result.assets[0].uri;
-        setProfile((prev) => ({
-          ...prev,
-          profilePicture: uri,
-        }));
+        setProfile((prev) => ({ ...prev, profilePicture: uri }));
         setPendingAvatar({ localUri: uri });
         setShowImagePicker(false);
       }
@@ -233,7 +187,6 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
     }
   };
 
-  // Handle camera capture
   const handleCameraCapture = async () => {
     try {
       const { status } = await ImagePicker.requestCameraPermissionsAsync();
@@ -253,10 +206,7 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
 
       if (!result.canceled && result.assets[0]) {
         const uri = result.assets[0].uri;
-        setProfile((prev) => ({
-          ...prev,
-          profilePicture: uri,
-        }));
+        setProfile((prev) => ({ ...prev, profilePicture: uri }));
         setPendingAvatar({ localUri: uri });
         setShowImagePicker(false);
       }
@@ -266,7 +216,6 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
     }
   };
 
-  // Cancel any pending save operation
   const cancelSave = useCallback(() => {
     if (saveAbortRef.current) {
       saveAbortRef.current.abort();
@@ -278,9 +227,6 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
   const pendingAvatarKey = currentUserId
     ? `@whispr/pending_avatar_media_id:${currentUserId}`
     : "@whispr/pending_avatar_media_id:unknown";
-
-  const isMediaNotFound = (message?: string) =>
-    typeof message === "string" && /media not found/i.test(message);
 
   const waitForMediaAvailable = async (
     mediaId: string,
@@ -350,37 +296,66 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
     }, [finalizePendingAvatar]),
   );
 
-  // Handle profile update
+  const validateField = (
+    field: keyof UserProfile,
+    value: string | null | undefined,
+  ): string | null => {
+    const v = value || "";
+    switch (field) {
+      case "firstName":
+      case "lastName":
+        if (!v.trim()) return "Ce champ est obligatoire";
+        if (v.trim().length < 2) return "Minimum 2 caractères";
+        if (v.trim().length > 50) return "Maximum 50 caractères";
+        return null;
+
+      case "username":
+        if (!v.trim()) return "Le nom d'utilisateur est obligatoire";
+        if (v.trim().length < 3) return "Minimum 3 caractères";
+        if (v.trim().length > 20) return "Maximum 20 caractères";
+        if (!/^[a-z0-9_]+$/.test(v.trim()))
+          return "Seuls minuscules, chiffres et _ autorisés";
+        return null;
+
+      case "biography":
+        if (v.length > 500) return "Maximum 500 caractères";
+        return null;
+
+      default:
+        return null;
+    }
+  };
+
+  const handleFieldChange = (field: keyof UserProfile, value: string) => {
+    setFieldErrors((prev) => {
+      if (!prev[field as keyof typeof prev]) return prev;
+      return { ...prev, [field]: undefined };
+    });
+    setProfile((prev) => ({ ...prev, [field]: value }));
+  };
+
   const handleSaveProfile = async () => {
-    if (!isOwnProfile) return;
     const firstNameError = validateField("firstName", profile.firstName);
     const lastNameError = validateField("lastName", profile.lastName);
     const normalizedUsername = normalizeUsername(profile.username);
     const usernameError = normalizedUsername
       ? validateField("username", normalizedUsername)
       : null;
-
-    // phoneNumber is read-only from registration — skip validation on save
-
     const bioError = validateField("biography", profile.biography);
-    const nextErrors = {
+    setFieldErrors({
       firstName: firstNameError ?? undefined,
       lastName: lastNameError ?? undefined,
       username: usernameError ?? undefined,
       biography: bioError ?? undefined,
-    };
-    setFieldErrors(nextErrors);
+    });
     if (firstNameError || lastNameError || bioError) return;
 
-    // Abort any previous pending save
     cancelSave();
-
     const abortController = new AbortController();
     saveAbortRef.current = abortController;
 
     setLoading(true);
 
-    // Animation feedback
     Animated.sequence([
       Animated.timing(scaleAnim, {
         toValue: 0.95,
@@ -394,8 +369,6 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
       }),
     ]).start();
 
-    // Upload a pending avatar (if any) and return the resulting media id/url.
-    // Returns null when the save should abort early (timeout, not-ready, user cancel).
     const uploadPendingAvatarIfNeeded = async (): Promise<{
       mediaId: string | undefined;
       remoteUrl: string | undefined;
@@ -403,9 +376,7 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
       let mediaId = pendingAvatar?.mediaId;
       let remoteUrl = pendingAvatar?.remoteUrl;
 
-      if (!pendingAvatar?.localUri || mediaId) {
-        return { mediaId, remoteUrl };
-      }
+      if (!pendingAvatar?.localUri || mediaId) return { mediaId, remoteUrl };
 
       const localUri = pendingAvatar.localUri;
       const fileName = localUri.split("/").pop() || "avatar.jpg";
@@ -468,7 +439,6 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
       const { mediaId: avatarMediaId, remoteUrl: avatarRemoteUrl } =
         uploadResult;
 
-      // Check if save was cancelled
       if (abortController.signal.aborted) return;
 
       const service = UserService.getInstance();
@@ -479,13 +449,12 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
         try {
           await waitForMediaAvailable(avatarMediaId, abortController.signal);
         } catch {
-          // ignore, we'll still retry once below
+          // ignore
         }
         await new Promise((r) => setTimeout(r, 650));
         res = await tryUpdate();
       }
 
-      // Check if save was cancelled while updating profile
       if (abortController.signal.aborted) return;
 
       if (!res.success) {
@@ -550,7 +519,6 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
         { text: "OK", onPress: () => navigation.goBack() },
       ]);
     } catch (error) {
-      // If save was cancelled, exit silently
       if (abortController.signal.aborted) return;
       Alert.alert(
         "Erreur",
@@ -564,69 +532,10 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
     }
   };
 
-  // Validation functions
-  const validateField = (
-    field: keyof UserProfile,
-    value: string | null | undefined,
-  ): string | null => {
-    const v = value || "";
-    switch (field) {
-      case "firstName":
-      case "lastName":
-        if (!v.trim()) return "Ce champ est obligatoire";
-        if (v.trim().length < 2) return "Minimum 2 caractères";
-        if (v.trim().length > 50) return "Maximum 50 caractères";
-        return null;
+  const handleHomePress = () => navigation.navigate("ConversationsList");
 
-      case "username":
-        if (!v.trim()) return "Le nom d'utilisateur est obligatoire";
-        if (v.trim().length < 3) return "Minimum 3 caractères";
-        if (v.trim().length > 20) return "Maximum 20 caractères";
-        if (!/^[a-z0-9_]+$/.test(v.trim()))
-          return "Seuls minuscules, chiffres et _ autorisés";
-        return null;
-
-      case "phoneNumber":
-        if (!v.trim()) return "Le numéro de téléphone est obligatoire";
-        const cleanNumber = v.replace(/\s/g, "");
-        // Validation format international E.164: +[code pays][numéro]
-        // Exemples: +33123456789, +1234567890, +86123456789
-        if (!/^\+[1-9]\d{1,14}$/.test(cleanNumber))
-          return "Format international invalide (ex: +33 1 23 45 67 89)";
-        if (cleanNumber.length < 8 || cleanNumber.length > 16)
-          return "Numéro trop court ou trop long (8-16 chiffres)";
-        return null;
-
-      case "biography":
-        if (v.length > 500) return "Maximum 500 caractères";
-        return null;
-
-      default:
-        return null;
-    }
-  };
-
-  // Handle field change (validation is done on save only)
-  const handleFieldChange = (field: keyof UserProfile, value: string) => {
-    setFieldErrors((prev) => {
-      if (!prev[field as keyof typeof prev]) return prev;
-      return { ...prev, [field]: undefined };
-    });
-    setProfile((prev) => ({
-      ...prev,
-      [field]: value,
-    }));
-  };
-
-  // Handle home navigation (ConversationsList)
-  const handleHomePress = () => {
-    navigation.navigate("ConversationsList");
-  };
-
-  // Handle back navigation
   const handleBackPress = () => {
     if (loading) {
-      // Cancel any in-progress save and allow navigation
       Alert.alert(
         "Sauvegarde en cours",
         "Voulez-vous annuler la sauvegarde et quitter ?",
@@ -663,6 +572,32 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
     }
   };
 
+  const rightActions = !isEditing ? (
+    <>
+      <TouchableOpacity onPress={handleHomePress} style={styles.iconButton}>
+        <Ionicons name="chatbubbles" size={24} color={colors.text.light} />
+      </TouchableOpacity>
+      <TouchableOpacity
+        onPress={() => setIsEditing(true)}
+        style={styles.iconButton}
+        accessibilityRole="button"
+        accessibilityLabel="Modifier le profil"
+      >
+        <Ionicons name="pencil" size={22} color={colors.text.light} />
+      </TouchableOpacity>
+    </>
+  ) : (
+    <TouchableOpacity
+      onPress={() => {
+        cancelSave();
+        setIsEditing(false);
+      }}
+      style={styles.iconButton}
+    >
+      <Text style={styles.cancelButtonText}>Annuler</Text>
+    </TouchableOpacity>
+  );
+
   return (
     <LinearGradient
       colors={colors.background.gradient.app}
@@ -683,94 +618,25 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
             },
           ]}
         >
-          {/* Header */}
-          <View
-            style={[styles.header, { paddingTop: insets.top + spacing.md }]}
-          >
-            <TouchableOpacity
-              onPress={handleBackPress}
-              style={styles.backButton}
-            >
-              <Text style={styles.backButtonText}>← Retour</Text>
-            </TouchableOpacity>
-
-            <Text style={styles.headerTitle}>Profil</Text>
-
-            {!isEditing ? (
-              <View style={styles.headerActions}>
-                <TouchableOpacity
-                  onPress={handleHomePress}
-                  style={styles.homeButton}
-                >
-                  <Ionicons
-                    name="chatbubbles"
-                    size={24}
-                    color={colors.text.light}
-                  />
-                </TouchableOpacity>
-                {isOwnProfile && (
-                  <TouchableOpacity
-                    onPress={() => setIsEditing(true)}
-                    style={styles.settingsButton}
-                    accessibilityRole="button"
-                    accessibilityLabel="Modifier le profil"
-                  >
-                    <Ionicons
-                      name="pencil"
-                      size={22}
-                      color={colors.text.light}
-                    />
-                  </TouchableOpacity>
-                )}
-              </View>
-            ) : (
-              <TouchableOpacity
-                onPress={() => {
-                  cancelSave();
-                  setIsEditing(false);
-                }}
-                style={styles.cancelButton}
-              >
-                <Text style={styles.cancelButtonText}>Annuler</Text>
-              </TouchableOpacity>
-            )}
-          </View>
+          <ProfileHeader
+            title="Profil"
+            onBack={handleBackPress}
+            rightActions={rightActions}
+          />
 
           <ScrollView
             style={styles.scrollView}
             showsVerticalScrollIndicator={false}
           >
-            {/* Profile Picture Section */}
-            <Animated.View
-              style={[
-                styles.profilePictureSection,
-                { transform: [{ scale: scaleAnim }] },
-              ]}
-            >
-              <TouchableOpacity
-                onPress={() => setShowImagePicker(true)}
-                style={styles.profilePictureContainer}
-                disabled={!isEditing || !isOwnProfile}
-              >
-                <Avatar
-                  uri={profile.profilePicture}
-                  name={`${profile.firstName} ${profile.lastName}`.trim()}
-                  size={120}
-                />
+            <ProfilePictureBlock
+              uri={profile.profilePicture}
+              name={`${profile.firstName} ${profile.lastName}`.trim()}
+              editable={isEditing}
+              onPress={() => setShowImagePicker(true)}
+              label={isEditing ? "Appuyez pour changer" : "Photo de profil"}
+              scaleAnim={scaleAnim}
+            />
 
-                {isEditing && (
-                  <View style={styles.editOverlay}>
-                    <Ionicons name="camera" size={18} color="#333" />
-                  </View>
-                )}
-              </TouchableOpacity>
-
-              <Text style={styles.profilePictureLabel}>
-                {isEditing ? "Appuyez pour changer" : "Photo de profil"}
-              </Text>
-            </Animated.View>
-
-            {/* Profile Information */}
             <View style={styles.profileInfo}>
               {!profileLoaded ? (
                 <View style={styles.loadingRow}>
@@ -780,10 +646,10 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
               ) : profileLoadError ? (
                 <Text style={styles.loadErrorText}>{profileLoadError}</Text>
               ) : null}
-              {/* Name Section */}
-              <View style={styles.section}>
-                <Text style={styles.sectionLabel}>Nom complet</Text>
-                {isEditing ? (
+
+              {isEditing ? (
+                <View style={styles.section}>
+                  <Text style={styles.sectionLabel}>Nom complet</Text>
                   <View style={styles.nameInputsContainer}>
                     <TextInput
                       style={[styles.input, styles.nameInput]}
@@ -804,149 +670,103 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
                       placeholderTextColor="rgba(255,255,255,0.5)"
                     />
                   </View>
-                ) : (
-                  <Text style={styles.sectionValue}>
-                    {profile.firstName || profile.lastName
+                </View>
+              ) : (
+                <ProfileFieldRow
+                  label="Nom complet"
+                  value={
+                    profile.firstName || profile.lastName
                       ? `${profile.firstName} ${profile.lastName}`.trim()
-                      : "—"}
-                  </Text>
-                )}
-              </View>
+                      : undefined
+                  }
+                />
+              )}
 
-              {/* Username Section */}
-              <View style={styles.section}>
-                <Text style={styles.sectionLabel}>Nom d'utilisateur</Text>
-                {isEditing ? (
-                  <>
-                    <TextInput
-                      style={styles.input}
-                      value={profile.username}
-                      onChangeText={(text) =>
-                        handleFieldChange("username", normalizeUsername(text))
-                      }
-                      placeholder="@nomdutilisateur"
-                      placeholderTextColor={colors.text.placeholder}
-                      autoCapitalize="none"
-                    />
-                    {!!fieldErrors.username && (
-                      <Text style={styles.fieldErrorText}>
-                        {fieldErrors.username}
-                      </Text>
-                    )}
-                    {!fieldErrors.username && (
-                      <Text style={styles.fieldHelperText}>
-                        Seuls minuscules, chiffres et _ (auto-corrigé)
-                      </Text>
-                    )}
-                  </>
-                ) : (
-                  <Text style={styles.sectionValue}>
-                    {profile.username ? formatUsername(profile.username) : "—"}
-                  </Text>
-                )}
-              </View>
-
-              {/* Phone Number Section */}
-              <View style={styles.section}>
-                <Text style={styles.sectionLabel}>Numéro de téléphone</Text>
-                {isEditing ? (
+              {isEditing ? (
+                <View style={styles.section}>
+                  <Text style={styles.sectionLabel}>Nom d'utilisateur</Text>
                   <TextInput
                     style={styles.input}
-                    value={profile.phoneNumber}
-                    placeholder="+33 07 12 34 56 78"
+                    value={profile.username}
+                    onChangeText={(text) =>
+                      handleFieldChange("username", normalizeUsername(text))
+                    }
+                    placeholder="@nomdutilisateur"
                     placeholderTextColor={colors.text.placeholder}
-                    keyboardType="phone-pad"
-                    editable={false}
+                    autoCapitalize="none"
                   />
-                ) : (
-                  <Text style={styles.sectionValue}>
-                    {profile.phoneNumber || "—"}
-                  </Text>
-                )}
-              </View>
-
-              {/* Biography Section */}
-              <View style={styles.section}>
-                <Text style={styles.sectionLabel}>Biographie</Text>
-                {isEditing ? (
-                  <>
-                    <TextInput
-                      style={[styles.input, styles.biographyInput]}
-                      value={profile.biography}
-                      onChangeText={(text) =>
-                        handleFieldChange("biography", text)
-                      }
-                      placeholder="Parlez-nous de vous..."
-                      placeholderTextColor={colors.text.placeholder}
-                      multiline
-                      numberOfLines={4}
-                      textAlignVertical="top"
-                      maxLength={500}
-                    />
-                    <Text style={styles.characterCount}>
-                      {(profile.biography || "").length}/500 caractères
+                  {!!fieldErrors.username && (
+                    <Text style={styles.fieldErrorText}>
+                      {fieldErrors.username}
                     </Text>
-                  </>
-                ) : (
-                  <Text style={styles.sectionValue}>
-                    {profile.biography || "—"}
-                  </Text>
-                )}
-              </View>
+                  )}
+                  {!fieldErrors.username && (
+                    <Text style={styles.fieldHelperText}>
+                      Seuls minuscules, chiffres et _ (auto-corrigé)
+                    </Text>
+                  )}
+                </View>
+              ) : (
+                <ProfileFieldRow
+                  label="Nom d'utilisateur"
+                  value={
+                    profile.username
+                      ? formatUsername(profile.username)
+                      : undefined
+                  }
+                />
+              )}
 
-              {/* Status Section */}
-              <View style={styles.section}>
-                <Text style={styles.sectionLabel}>Statut</Text>
-                <View
-                  style={[
-                    styles.statusChip,
-                    profile.isOnline
-                      ? styles.statusChipOnline
-                      : styles.statusChipOffline,
-                  ]}
-                >
-                  <View
-                    style={[
-                      styles.statusDotSmall,
-                      {
-                        backgroundColor: profile.isOnline
-                          ? colors.status.online
-                          : colors.status.offline,
-                      },
-                    ]}
+              <ProfileFieldRow
+                label="Numéro de téléphone"
+                value={profile.phoneNumber}
+              />
+
+              {isEditing ? (
+                <View style={styles.section}>
+                  <Text style={styles.sectionLabel}>Biographie</Text>
+                  <TextInput
+                    style={[styles.input, styles.biographyInput]}
+                    value={profile.biography}
+                    onChangeText={(text) =>
+                      handleFieldChange("biography", text)
+                    }
+                    placeholder="Parlez-nous de vous..."
+                    placeholderTextColor={colors.text.placeholder}
+                    multiline
+                    numberOfLines={4}
+                    textAlignVertical="top"
+                    maxLength={500}
                   />
-                  <Text
-                    style={[
-                      styles.statusText,
-                      profile.isOnline
-                        ? styles.statusTextOnline
-                        : styles.statusTextOffline,
-                    ]}
-                  >
-                    {profile.isOnline
-                      ? "Actif maintenant"
-                      : `Hors ligne - ${profile.lastSeen}`}
+                  <Text style={styles.characterCount}>
+                    {(profile.biography || "").length}/500 caractères
                   </Text>
                 </View>
-              </View>
+              ) : (
+                <ProfileFieldRow label="Biographie" value={profile.biography} />
+              )}
 
-              {/* Member Since Section */}
+              <StatusChip
+                isOnline={profile.isOnline}
+                lastSeen={profile.lastSeen}
+              />
+
               {profile.createdAt && (
-                <View style={styles.section}>
-                  <Text style={styles.sectionLabel}>Membre depuis</Text>
-                  <Text style={styles.sectionValue}>
-                    {new Date(profile.createdAt).toLocaleDateString("fr-FR", {
+                <ProfileFieldRow
+                  label="Membre depuis"
+                  value={new Date(profile.createdAt).toLocaleDateString(
+                    "fr-FR",
+                    {
                       day: "2-digit",
                       month: "long",
                       year: "numeric",
-                    })}
-                  </Text>
-                </View>
+                    },
+                  )}
+                />
               )}
             </View>
 
-            {/* Action Buttons */}
-            {isOwnProfile && isEditing && (
+            {isEditing && (
               <View style={styles.actionButtons}>
                 <Button
                   title={loading ? "Sauvegarde" : "Sauvegarder"}
@@ -962,7 +782,6 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
         </Animated.View>
       </KeyboardAvoidingView>
 
-      {/* Alerte centrée (style iOS) pour changer la photo */}
       <Modal
         visible={showImagePicker}
         transparent
@@ -1016,52 +835,10 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
 };
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  keyboardView: {
-    flex: 1,
-  },
-  content: {
-    flex: 1,
-  },
-  header: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    paddingHorizontal: spacing.lg,
-    paddingTop: spacing.xxxl,
-    paddingBottom: spacing.lg,
-    backgroundColor: "transparent",
-    borderBottomWidth: 0,
-  },
-  backButton: {
-    padding: spacing.sm,
-  },
-  backButtonText: {
-    fontSize: typography.fontSize.base,
-    color: colors.text.light,
-    fontWeight: typography.fontWeight.medium,
-  },
-  headerTitle: {
-    fontSize: typography.fontSize.xl,
-    fontWeight: typography.fontWeight.bold,
-    color: colors.text.light,
-  },
-  headerActions: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: spacing.md,
-  },
-  homeButton: {
-    padding: spacing.sm,
-  },
-  settingsButton: {
-    padding: spacing.sm,
-  },
-  cancelButton: {
-    padding: spacing.sm,
-  },
+  container: { flex: 1 },
+  keyboardView: { flex: 1 },
+  content: { flex: 1 },
+  iconButton: { padding: spacing.sm },
   cancelButtonText: {
     fontSize: typography.fontSize.base,
     color: colors.ui.error,
@@ -1070,45 +847,6 @@ const styles = StyleSheet.create({
   scrollView: {
     flex: 1,
     paddingHorizontal: spacing.lg,
-  },
-  profilePictureSection: {
-    alignItems: "center",
-    paddingTop: spacing.md,
-    paddingBottom: spacing.xxxl,
-  },
-  profilePictureContainer: {
-    position: "relative",
-    marginBottom: spacing.md,
-  },
-  profilePicture: {
-    width: 120,
-    height: 120,
-    borderRadius: 60,
-    backgroundColor: "rgba(255,255,255,0.15)",
-    borderWidth: 2,
-    borderColor: "rgba(255,255,255,0.25)",
-  },
-  editOverlay: {
-    position: "absolute",
-    bottom: 0,
-    right: 0,
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    backgroundColor: colors.primary.main,
-    justifyContent: "center",
-    alignItems: "center",
-    borderWidth: 3,
-    borderColor: colors.background.primary,
-  },
-  editOverlayText: {
-    fontSize: typography.fontSize.md,
-  },
-  profilePictureLabel: {
-    fontSize: typography.fontSize.sm,
-    color: colors.text.light,
-    textAlign: "center",
-    opacity: 0.9,
   },
   profileInfo: {
     paddingBottom: spacing.sm,
@@ -1128,9 +866,7 @@ const styles = StyleSheet.create({
     color: colors.ui.error,
     marginBottom: spacing.lg,
   },
-  section: {
-    marginBottom: spacing.xl,
-  },
+  section: { marginBottom: spacing.xl },
   sectionLabel: {
     fontSize: typography.fontSize.sm,
     fontWeight: typography.fontWeight.semiBold,
@@ -1138,13 +874,6 @@ const styles = StyleSheet.create({
     marginBottom: spacing.sm,
     textTransform: "uppercase",
     letterSpacing: 0.5,
-  },
-  sectionValue: {
-    fontSize: typography.fontSize.base,
-    fontWeight: typography.fontWeight.medium,
-    color: colors.text.light,
-    lineHeight: 20,
-    marginBottom: spacing.sm,
   },
   nameInputsContainer: {
     flexDirection: "row",
@@ -1166,20 +895,7 @@ const styles = StyleSheet.create({
     shadowRadius: 4,
     elevation: 2,
   },
-  fieldErrorText: {
-    fontSize: typography.fontSize.xs,
-    color: colors.ui.error,
-    marginTop: spacing.xs,
-  },
-  fieldHelperText: {
-    fontSize: typography.fontSize.xs,
-    color: colors.text.secondary,
-    marginTop: spacing.xs,
-    opacity: 0.7,
-  },
-  nameInput: {
-    flex: 1,
-  },
+  nameInput: { flex: 1 },
   biographyInput: {
     height: 100,
     textAlignVertical: "top",
@@ -1192,36 +908,16 @@ const styles = StyleSheet.create({
     marginTop: spacing.xs,
     opacity: 0.7,
   },
-  statusChip: {
-    flexDirection: "row",
-    alignItems: "center",
-    alignSelf: "flex-start",
-    paddingHorizontal: spacing.md,
-    paddingVertical: spacing.xs,
-    borderRadius: 999,
-    borderWidth: 0,
+  fieldErrorText: {
+    fontSize: typography.fontSize.xs,
+    color: colors.ui.error,
+    marginTop: spacing.xs,
   },
-  statusChipOnline: {
-    backgroundColor: "rgba(33, 192, 4, 0.18)",
-  },
-  statusChipOffline: {
-    backgroundColor: "rgba(142, 142, 147, 0.18)",
-  },
-  statusDotSmall: {
-    width: 8,
-    height: 8,
-    borderRadius: 4,
-    marginRight: spacing.sm,
-  },
-  statusText: {
-    fontSize: typography.fontSize.sm,
-    fontWeight: typography.fontWeight.medium,
-  },
-  statusTextOnline: {
-    color: colors.text.light,
-  },
-  statusTextOffline: {
-    color: "rgba(255,255,255,0.85)",
+  fieldHelperText: {
+    fontSize: typography.fontSize.xs,
+    color: colors.text.secondary,
+    marginTop: spacing.xs,
+    opacity: 0.7,
   },
   actionButtons: {
     paddingBottom: spacing.lg,
@@ -1230,134 +926,6 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.25,
     shadowRadius: 8,
     elevation: 6,
-  },
-  modalOverlay: {
-    flex: 1,
-    backgroundColor: "rgba(0, 0, 0, 0.5)",
-    justifyContent: "flex-end",
-    alignItems: "stretch",
-  },
-  sheet: {
-    backgroundColor: colors.background.primary,
-    borderTopLeftRadius: borderRadius.xl,
-    borderTopRightRadius: borderRadius.xl,
-    paddingTop: spacing.lg,
-    paddingBottom: spacing.xl,
-    paddingHorizontal: spacing.lg,
-  },
-  sheetGrabber: {
-    alignSelf: "center",
-    width: 48,
-    height: 5,
-    borderRadius: 3,
-    backgroundColor: "rgba(0,0,0,0.2)",
-    marginBottom: spacing.lg,
-  },
-  sheetTitle: {
-    fontSize: typography.fontSize.lg,
-    fontWeight: typography.fontWeight.bold,
-    color: colors.text.primary,
-    textAlign: "center",
-    marginBottom: spacing.lg,
-  },
-  sheetOption: {
-    flexDirection: "row",
-    alignItems: "center",
-    backgroundColor: colors.background.secondary,
-    borderRadius: borderRadius.lg,
-    paddingVertical: spacing.md,
-    paddingHorizontal: spacing.md,
-    marginBottom: spacing.md,
-  },
-  optionIcon: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    justifyContent: "center",
-    alignItems: "center",
-    marginRight: spacing.md,
-  },
-  optionIconText: {
-    fontSize: typography.fontSize.base,
-    color: colors.text.primary,
-  },
-  optionTextContainer: {
-    flex: 1,
-  },
-  optionTitle: {
-    fontSize: typography.fontSize.base,
-    fontWeight: typography.fontWeight.semiBold,
-    color: colors.text.primary,
-  },
-  optionSubtitle: {
-    fontSize: typography.fontSize.sm,
-    color: colors.text.secondary,
-    marginTop: 2,
-  },
-  optionChevron: {
-    fontSize: typography.fontSize.base,
-    color: colors.text.secondary,
-    paddingHorizontal: spacing.sm,
-  },
-  sheetCancel: {
-    backgroundColor: "transparent",
-    borderWidth: 1,
-    borderColor: colors.ui.border,
-    borderRadius: borderRadius.lg,
-    paddingVertical: spacing.md,
-    alignItems: "center",
-  },
-  sheetCancelText: {
-    fontSize: typography.fontSize.base,
-    color: colors.text.primary,
-  },
-  floatingOverlay: {
-    flex: 1,
-    backgroundColor: "rgba(0,0,0,0.25)",
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  backdrop: {
-    position: "absolute",
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-  },
-  floatingMenu: {
-    width: "86%",
-    backgroundColor: colors.background.primary,
-    borderRadius: borderRadius.lg,
-    paddingVertical: spacing.md,
-    paddingHorizontal: spacing.md,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 6 },
-    shadowOpacity: 0.15,
-    shadowRadius: 12,
-    elevation: 8,
-  },
-  floatingTitle: {
-    fontSize: typography.fontSize.base,
-    fontWeight: typography.fontWeight.semiBold,
-    color: colors.text.primary,
-    textAlign: "center",
-    marginBottom: spacing.sm,
-  },
-  floatingItem: {
-    flexDirection: "row",
-    alignItems: "center",
-    paddingVertical: spacing.md,
-  },
-  floatingIcon: {
-    marginRight: spacing.md,
-  },
-  floatingItemText: {
-    fontSize: typography.fontSize.base,
-    color: colors.text.primary,
-  },
-  floatingCancel: {
-    fontSize: typography.fontSize.base,
-    color: colors.ui.error,
   },
   alertOverlay: {
     flex: 1,
@@ -1397,9 +965,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     paddingVertical: spacing.md,
   },
-  alertIcon: {
-    marginRight: spacing.md,
-  },
+  alertIcon: { marginRight: spacing.md },
   alertActionText: {
     fontSize: typography.fontSize.base,
     color: colors.text.primary,
@@ -1408,7 +974,7 @@ const styles = StyleSheet.create({
     marginTop: spacing.md,
     alignItems: "center",
     paddingVertical: spacing.md,
-    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopWidth: 1,
     borderTopColor: "#E5E5EA",
   },
   alertCancelText: {
@@ -1418,4 +984,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default ProfileScreen;
+export default MyProfileScreen;

--- a/src/screens/Profile/UserProfileScreen.tsx
+++ b/src/screens/Profile/UserProfileScreen.tsx
@@ -1,0 +1,243 @@
+/**
+ * UserProfileScreen - Consultation lecture seule du profil d'un autre utilisateur.
+ * Séparé de MyProfileScreen (édition du profil personnel) — WHISPR-1189.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  Animated,
+  ActivityIndicator,
+  TouchableOpacity,
+} from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import {
+  useNavigation,
+  useRoute,
+  useFocusEffect,
+  type RouteProp,
+} from "@react-navigation/native";
+import type { StackNavigationProp } from "@react-navigation/stack";
+import { Ionicons } from "@expo/vector-icons";
+import {
+  ProfileHeader,
+  ProfilePictureBlock,
+  ProfileFieldRow,
+  StatusChip,
+} from "../../components/Profile";
+import { formatUsername } from "../../utils";
+import { colors, spacing, typography } from "../../theme";
+import { UserService } from "../../services";
+
+interface UserProfile {
+  id: string;
+  firstName: string;
+  lastName: string;
+  username: string;
+  biography: string;
+  profilePicture?: string;
+  isOnline: boolean;
+  lastSeen?: string;
+  createdAt?: string;
+}
+
+type NavigationProp = StackNavigationProp<any, "UserProfile">;
+type RouteParams = { userId: string };
+
+export const UserProfileScreen: React.FC = () => {
+  const navigation = useNavigation<NavigationProp>();
+  const route =
+    useRoute<RouteProp<{ UserProfile: RouteParams }, "UserProfile">>();
+  const { userId } = route.params;
+
+  const [profile, setProfile] = useState<UserProfile>({
+    id: userId,
+    firstName: "",
+    lastName: "",
+    username: "",
+    biography: "",
+    isOnline: true,
+    lastSeen: "Maintenant",
+    createdAt: "",
+  });
+  const [profileLoaded, setProfileLoaded] = useState(false);
+  const [profileLoadError, setProfileLoadError] = useState<string | null>(null);
+  const lastLoadAt = useRef<number | null>(null);
+
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+  const slideAnim = useRef(new Animated.Value(40)).current;
+
+  useEffect(() => {
+    Animated.parallel([
+      Animated.timing(fadeAnim, {
+        toValue: 1,
+        duration: 600,
+        useNativeDriver: true,
+      }),
+      Animated.spring(slideAnim, {
+        toValue: 0,
+        tension: 50,
+        friction: 7,
+        useNativeDriver: true,
+      }),
+    ]).start();
+  }, [fadeAnim, slideAnim]);
+
+  const loadProfile = useCallback(async () => {
+    try {
+      setProfileLoadError(null);
+      const service = UserService.getInstance();
+      const res = await service.getUserProfile(userId);
+      if (res.success && res.profile) {
+        const p = res.profile;
+        setProfile((prev) => ({
+          ...prev,
+          id: p.id || prev.id,
+          firstName: p.firstName || "",
+          lastName: p.lastName || "",
+          username: p.username || "",
+          biography: p.biography || "",
+          profilePicture: p.profilePicture || prev.profilePicture,
+          createdAt: p.createdAt || prev.createdAt,
+        }));
+        lastLoadAt.current = Date.now();
+        setProfileLoaded(true);
+        return;
+      }
+      setProfileLoadError(res.message || "Impossible de récupérer le profil");
+      setProfileLoaded(true);
+    } catch (e: any) {
+      setProfileLoadError(e?.message || "Impossible de récupérer le profil");
+      setProfileLoaded(true);
+    }
+  }, [userId]);
+
+  useFocusEffect(
+    useCallback(() => {
+      const last = lastLoadAt.current;
+      if (last && Date.now() - last < 30_000) return;
+      loadProfile();
+    }, [loadProfile]),
+  );
+
+  const handleHomePress = () => navigation.navigate("ConversationsList");
+
+  const rightActions = (
+    <TouchableOpacity onPress={handleHomePress} style={styles.iconButton}>
+      <Ionicons name="chatbubbles" size={24} color={colors.text.light} />
+    </TouchableOpacity>
+  );
+
+  const fullName =
+    profile.firstName || profile.lastName
+      ? `${profile.firstName} ${profile.lastName}`.trim()
+      : undefined;
+
+  return (
+    <LinearGradient
+      colors={colors.background.gradient.app}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 1 }}
+      style={styles.container}
+    >
+      <Animated.View
+        style={[
+          styles.content,
+          {
+            opacity: fadeAnim,
+            transform: [{ translateY: slideAnim }],
+          },
+        ]}
+      >
+        <ProfileHeader
+          title="Profil"
+          onBack={() => navigation.goBack()}
+          rightActions={rightActions}
+        />
+
+        <ScrollView
+          style={styles.scrollView}
+          showsVerticalScrollIndicator={false}
+        >
+          <ProfilePictureBlock
+            uri={profile.profilePicture}
+            name={fullName ?? ""}
+            editable={false}
+            label="Photo de profil"
+          />
+
+          <View style={styles.profileInfo}>
+            {!profileLoaded ? (
+              <View style={styles.loadingRow}>
+                <ActivityIndicator color="rgba(255,255,255,0.8)" />
+                <Text style={styles.loadingText}>Chargement du profil</Text>
+              </View>
+            ) : profileLoadError ? (
+              <Text style={styles.loadErrorText}>{profileLoadError}</Text>
+            ) : null}
+
+            <ProfileFieldRow label="Nom complet" value={fullName} />
+
+            <ProfileFieldRow
+              label="Nom d'utilisateur"
+              value={
+                profile.username ? formatUsername(profile.username) : undefined
+              }
+            />
+
+            <ProfileFieldRow label="Biographie" value={profile.biography} />
+
+            <StatusChip
+              isOnline={profile.isOnline}
+              lastSeen={profile.lastSeen}
+            />
+
+            {profile.createdAt && (
+              <ProfileFieldRow
+                label="Membre depuis"
+                value={new Date(profile.createdAt).toLocaleDateString("fr-FR", {
+                  day: "2-digit",
+                  month: "long",
+                  year: "numeric",
+                })}
+              />
+            )}
+          </View>
+        </ScrollView>
+      </Animated.View>
+    </LinearGradient>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  content: { flex: 1 },
+  iconButton: { padding: spacing.sm },
+  scrollView: {
+    flex: 1,
+    paddingHorizontal: spacing.lg,
+  },
+  profileInfo: {
+    paddingBottom: spacing.xl,
+  },
+  loadingRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+    marginBottom: spacing.lg,
+  },
+  loadingText: {
+    fontSize: typography.fontSize.sm,
+    color: "rgba(255,255,255,0.85)",
+  },
+  loadErrorText: {
+    fontSize: typography.fontSize.sm,
+    color: colors.ui.error,
+    marginBottom: spacing.lg,
+  },
+});
+
+export default UserProfileScreen;

--- a/src/screens/Profile/index.ts
+++ b/src/screens/Profile/index.ts
@@ -1,10 +1,2 @@
-// Export ProfileScreen
-export { ProfileScreen } from './ProfileScreen';
-export { default as ProfileScreenDefault } from './ProfileScreen';
-
-
-
-
-
-
-
+export { MyProfileScreen } from "./MyProfileScreen";
+export { UserProfileScreen } from "./UserProfileScreen";

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -611,7 +611,7 @@ export const SettingsScreen: React.FC = () => {
           <SettingItem
             label={getLocalizedText("settings.myProfile")}
             subtitle={getLocalizedText("settings.myProfileSubtitle")}
-            onPress={() => navigation.navigate("Profile", {})}
+            onPress={() => navigation.navigate("MyProfile")}
             rightComponent={
               <Ionicons
                 name="chevron-forward"


### PR DESCRIPTION
## Summary

Scinde l'écran `ProfileScreen` (~1260 lignes, mélange édition / consultation via `isOwnProfile`) en deux écrans dédiés :

- **`MyProfileScreen`** (route `MyProfile`) — édition du profil personnel : validation inline, upload d'avatar avec reprise, `handleSaveProfile`, mode édition via crayon du header.
- **`UserProfileScreen`** (route `UserProfile { userId }`) — consultation lecture seule d'un profil tiers : pas de crayon, pas de champ téléphone.

Extrait 4 sous-composants partagés dans `src/components/Profile/` :

- `ProfileHeader` — top bar avec `insets.top + spacing.md` et slot d'actions.
- `ProfilePictureBlock` — avatar 120px avec overlay caméra conditionnel.
- `ProfileFieldRow` — `{ label, value }` lecture seule.
- `StatusChip` — chip online/offline.

## Changements

- **Nouveaux fichiers :** `src/screens/Profile/MyProfileScreen.tsx`, `src/screens/Profile/UserProfileScreen.tsx`, `src/components/Profile/*`, tests dédiés.
- **Navigation :** `AuthStackParamList` — `Profile` remplacé par `MyProfile: undefined` et `UserProfile: { userId: string }`.
- **Deep link :** `whispr://profile/:userId` continue de mener vers `UserProfile` (URL publique inchangée).
- **Call-sites migrés :** `SettingsScreen` → `MyProfile`, `GroupDetailsScreen` branche à l'appel selon `CURRENT_USER_ID`.
- **Suppression :** ancien `ProfileScreen.tsx` supprimé.

## Test plan

- [x] Lint : `npm run lint:fix` — 0 errors
- [x] Typecheck : `npx tsc --noEmit` — clean
- [x] Tests unitaires : 648 passing, 0 failing (hors worktree)
  - `MyProfileScreen.test.tsx` — rendu, load, edit, save
  - `UserProfileScreen.test.tsx` — lecture seule, absence crayon et téléphone, pas de `updateProfile`
  - `linkingConfig.test.ts` — mapping `UserProfile → profile/:userId`
- [ ] Test manuel iOS/Android :
  - Settings → "Mon profil" ouvre `MyProfileScreen` avec crayon
  - Groupe → clic autre membre ouvre `UserProfileScreen` (pas de crayon, pas de tél)
  - Groupe → clic sur soi-même ouvre `MyProfileScreen`
  - Deep link `whispr://profile/<userId>` résout sur `UserProfileScreen`

Closes WHISPR-1189
