### PR TITLE
feat(chat): permettre l'envoi d'images sans recadrage forcé

### DIFF
--- a/imageCompression.test.ts
+++ b/imageCompression.test.ts
@@ -1,0 +1,52 @@
+/**
+ * WHISPR-1039: garantit que la compression ne déforme jamais une image.
+ * Test unitaire pur sur la fonction de décision `buildResizeAction`.
+ */
+
+import { buildResizeAction } from "./src/utils/imageCompression";
+
+describe("buildResizeAction (WHISPR-1039)", () => {
+  const MAX_W = 1920;
+  const MAX_H = 1920;
+
+  it("borne uniquement la largeur pour une image paysage trop large", () => {
+    expect(buildResizeAction(4000, 3000, MAX_W, MAX_H)).toEqual([
+      { resize: { width: MAX_W } },
+    ]);
+  });
+
+  it("borne uniquement la hauteur pour une image portrait trop haute", () => {
+    expect(buildResizeAction(1080, 4000, MAX_W, MAX_H)).toEqual([
+      { resize: { height: MAX_H } },
+    ]);
+  });
+
+  it("ne renvoie aucun resize si l'image rentre déjà dans les bornes", () => {
+    expect(buildResizeAction(800, 600, MAX_W, MAX_H)).toEqual([]);
+    expect(buildResizeAction(MAX_W, MAX_H, MAX_W, MAX_H)).toEqual([]);
+  });
+
+  it("traite une image carrée trop grande comme paysage (cap largeur)", () => {
+    expect(buildResizeAction(3000, 3000, MAX_W, MAX_H)).toEqual([
+      { resize: { width: MAX_W } },
+    ]);
+  });
+
+  it("ne contraint jamais les deux dimensions simultanément", () => {
+    // Régression directe : avant le fix, le resize forçait { width, height }
+    // ce qui écrasait l'image en carré 1920x1920.
+    for (const [w, h] of [
+      [4000, 3000],
+      [1080, 4000],
+      [3000, 3000],
+      [200, 200],
+    ]) {
+      const result = buildResizeAction(w, h, MAX_W, MAX_H);
+      if (result.length === 0) continue;
+      const resize = result[0].resize as Record<string, unknown>;
+      const hasWidth = "width" in resize;
+      const hasHeight = "height" in resize;
+      expect(hasWidth && hasHeight).toBe(false);
+    }
+  });
+});

--- a/src/components/Chat/MediaMessage.tsx
+++ b/src/components/Chat/MediaMessage.tsx
@@ -271,6 +271,12 @@ function ensureExpoAvVideoLoaded(): void {
   }
 }
 
+// Bornes du ratio d'affichage des images dans le chat (WHISPR-1039) :
+// au-delà, on tombe sur du `cover` graceful plutôt que de laisser un
+// panorama 5:1 ou un screenshot 1:4 casser la grille de la conversation.
+const MIN_IMAGE_ASPECT = 0.5;
+const MAX_IMAGE_ASPECT = 2.0;
+
 interface MediaMessageProps {
   uri: string;
   type: "image" | "video" | "file";
@@ -295,6 +301,9 @@ export const MediaMessage: React.FC<MediaMessageProps> = ({
   const playerVideoRef = useRef<any>(null); // Ref for full-screen player
   const [videoStatus, setVideoStatus] = useState<any>({});
   const [thumbnailError, setThumbnailError] = useState(false);
+  // WHISPR-1039: ratio mesuré sur l'image résolue, borné pour éviter qu'une
+  // image très étirée ne casse la mise en page de la conversation.
+  const [imageAspectRatio, setImageAspectRatio] = useState<number | null>(null);
 
   // Resolve blob/thumbnail URLs to fresh presigned URLs
   const {
@@ -305,6 +314,21 @@ export const MediaMessage: React.FC<MediaMessageProps> = ({
   const { resolvedUri: resolvedThumbUri } = useResolvedMediaUrl(
     thumbnailUri || uri,
   );
+
+  // WHISPR-1039: on lit le ratio via l'évènement onLoad natif plutôt que
+  // Image.getSize pour fonctionner uniformément iOS/Android/web et éviter
+  // les soucis de mock côté tests.
+  const handleImageLoad = (event: {
+    nativeEvent: { source?: { width?: number; height?: number } };
+  }) => {
+    const source = event?.nativeEvent?.source;
+    const width = source?.width;
+    const height = source?.height;
+    if (!width || !height) return;
+    const raw = width / height;
+    const clamped = Math.min(MAX_IMAGE_ASPECT, Math.max(MIN_IMAGE_ASPECT, raw));
+    setImageAspectRatio(clamped);
+  };
 
   // Cleanup video refs on unmount to prevent memory leaks
   useEffect(() => {
@@ -400,8 +424,14 @@ export const MediaMessage: React.FC<MediaMessageProps> = ({
           ) : (
             <Image
               source={{ uri: resolvedThumbUri || resolvedMainUri }}
-              style={styles.image}
+              style={[
+                styles.image,
+                imageAspectRatio !== null
+                  ? { aspectRatio: imageAspectRatio }
+                  : null,
+              ]}
               resizeMode="cover"
+              onLoad={handleImageLoad}
             />
           )}
         </TouchableOpacity>

--- a/src/components/Chat/MessageInput.tsx
+++ b/src/components/Chat/MessageInput.tsx
@@ -288,11 +288,11 @@ export const MessageInput: React.FC<MessageInputProps> = ({
         return;
       }
 
-      // Launch image picker
+      // Launch image picker without forcing a crop: WHISPR-1039 wants the
+      // user to send images in their native ratio (portrait/landscape/square).
       const result = await ImagePicker.launchImageLibraryAsync({
         mediaTypes: ImagePicker.MediaTypeOptions.Images,
-        allowsEditing: true,
-        aspect: [4, 3],
+        allowsEditing: false,
         quality: 0.8,
       });
 

--- a/src/utils/imageCompression.ts
+++ b/src/utils/imageCompression.ts
@@ -1,9 +1,12 @@
 /**
  * Image compression utilities
  * WHISPR-265: Compression automatique des images avant envoi
+ * WHISPR-1039: ne plus déformer les images, le côté le plus long est borné
+ *              et le ratio d'origine est préservé.
  */
 
 import * as ImageManipulator from "expo-image-manipulator";
+import { Image } from "react-native";
 
 export interface CompressionOptions {
   maxWidth?: number;
@@ -16,6 +19,42 @@ const DEFAULT_MAX_WIDTH = 1920;
 const DEFAULT_MAX_HEIGHT = 1920;
 const DEFAULT_QUALITY = 0.8;
 const DEFAULT_COMPRESS = 0.7;
+
+function getImageSize(uri: string): Promise<{ width: number; height: number }> {
+  return new Promise((resolve, reject) => {
+    Image.getSize(
+      uri,
+      (width, height) => resolve({ width, height }),
+      (err) =>
+        reject(
+          err instanceof Error ? err : new Error(String(err ?? "unknown")),
+        ),
+    );
+  });
+}
+
+/**
+ * Choisit l'action `resize` la plus appropriée tout en préservant le ratio.
+ * Si le côté le plus long dépasse sa borne, on ne contraint que ce côté ;
+ * `expo-image-manipulator` calcule alors automatiquement l'autre. Si
+ * l'image rentre déjà dans les bornes, on saute l'étape `resize`.
+ *
+ * Exporté pour permettre un test unitaire pur (cf. WHISPR-1039).
+ */
+export function buildResizeAction(
+  width: number,
+  height: number,
+  maxWidth: number,
+  maxHeight: number,
+): ImageManipulator.Action[] {
+  if (width >= height && width > maxWidth) {
+    return [{ resize: { width: maxWidth } }];
+  }
+  if (height > width && height > maxHeight) {
+    return [{ resize: { height: maxHeight } }];
+  }
+  return [];
+}
 
 /**
  * Compress an image file
@@ -35,19 +74,22 @@ export async function compressImage(
       compress = DEFAULT_COMPRESS,
     } = options;
 
-    // Get image dimensions
+    let resizeAction: ImageManipulator.Action[];
+    try {
+      const { width, height } = await getImageSize(uri);
+      resizeAction = buildResizeAction(width, height, maxWidth, maxHeight);
+    } catch {
+      // Si la sonde de dimensions échoue, on borne uniquement la largeur :
+      // mieux vaut une image potentiellement plus grande que prévu qu'une
+      // image écrasée à un carré (régression de la compression "1920x1920").
+      resizeAction = [{ resize: { width: maxWidth } }];
+    }
+
     const manipResult = await ImageManipulator.manipulateAsync(
       uri,
-      [
-        {
-          resize: {
-            width: maxWidth,
-            height: maxHeight,
-          },
-        },
-      ],
+      resizeAction,
       {
-        compress: compress,
+        compress,
         format: ImageManipulator.SaveFormat.JPEG,
       },
     );


### PR DESCRIPTION
Aligne le parcours d'envoi d'image sur WHISPR-1039 : l'utilisateur peut envoyer une image dans son ratio natif (portrait, paysage, carré) et le rendu en conversation s'adapte dynamiquement.

- MessageInput.handlePickImage : retire allowsEditing/aspect du launchImageLibraryAsync. Les avatars (Profile/ProfileSetup/GroupMgmt) conservent volontairement aspect=[1,1].
- imageCompression.compressImage : ne contraint plus simultanément width et height (le resize 1920x1920 écrasait l'image en carré). On sonde le ratio via Image.getSize puis on ne borne que le côté le plus long ; la compression qualité reste inchangée.
- MediaMessage : remplace l'aspectRatio fixe 4/3 par un ratio mesuré via onLoad et borné [0.5 ; 2.0] pour ne pas casser la grille du chat sur des images extrêmes (panorama / screenshot très haut). Aucune déformation : seules les valeurs hors bornes retombent en cover.

Tests : 5 nouveaux specs purs sur buildResizeAction (régression directe sur la déformation 1920x1920). Suite complète 682/682 verts.