### PR TITLE
feat(navigation): refonte de la bottom tab bar en pilule flottante gl…

### DIFF
--- a/ContactsScreen.test.tsx
+++ b/ContactsScreen.test.tsx
@@ -1,57 +1,67 @@
-import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react-native';
-import { ContactsScreen } from './src/screens/Contacts/ContactsScreen';
-import { contactsAPI } from './src/services/contacts/api';
-import { messagingAPI } from './src/services/messaging/api';
+import React from "react";
+import { render, fireEvent, waitFor } from "@testing-library/react-native";
+import { ContactsScreen } from "./src/screens/Contacts/ContactsScreen";
+import { contactsAPI } from "./src/services/contacts/api";
+import { messagingAPI } from "./src/services/messaging/api";
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
 
-jest.mock('@react-navigation/native', () => ({
+jest.mock("@react-navigation/native", () => ({
   useNavigation: () => ({ navigate: mockNavigate, goBack: mockGoBack }),
   useRoute: () => ({ params: {} }),
-  useFocusEffect: (cb: () => void | (() => void)) => { const React = require('react'); React.useEffect(() => cb(), []); },
+  useFocusEffect: (cb: () => void | (() => void)) => {
+    const React = require("react");
+    React.useEffect(() => cb(), []);
+  },
 }));
-jest.mock('expo-linear-gradient', () => ({
+jest.mock("expo-linear-gradient", () => ({
   LinearGradient: ({ children }: any) => children,
 }));
-jest.mock('react-native-safe-area-context', () => ({
+jest.mock("react-native-safe-area-context", () => ({
   SafeAreaView: ({ children }: any) => children,
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
-jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
-jest.mock('./src/context/ThemeContext', () => ({
+jest.mock("@expo/vector-icons", () => ({ Ionicons: () => null }));
+jest.mock("./src/context/ThemeContext", () => ({
   useTheme: () => ({
     getThemeColors: () => ({
-      background: { gradient: ['#000', '#111'], primary: '#000', secondary: '#111' },
-      text: { primary: '#fff', secondary: '#aaa', tertiary: '#555' },
-      primary: '#6200ee',
+      background: {
+        gradient: ["#000", "#111"],
+        primary: "#000",
+        secondary: "#111",
+      },
+      text: { primary: "#fff", secondary: "#aaa", tertiary: "#555" },
+      primary: "#6200ee",
     }),
     getFontSize: () => 16,
     getLocalizedText: (key: string) => key,
   }),
 }));
-jest.mock('./src/context/AuthContext', () => ({
+jest.mock("./src/context/AuthContext", () => ({
   useAuth: () => ({
     isAuthenticated: true,
     isLoading: false,
-    userId: 'user1',
-    deviceId: 'dev1',
+    userId: "user1",
+    deviceId: "dev1",
     signIn: jest.fn(),
     signOut: jest.fn(),
   }),
 }));
-jest.mock('./src/hooks/useWebSocket', () => ({
+jest.mock("./src/hooks/useWebSocket", () => ({
   useWebSocket: () => ({
-    joinConversationChannel: jest.fn().mockReturnValue({ channel: null, cleanup: jest.fn() }),
+    joinConversationChannel: jest
+      .fn()
+      .mockReturnValue({ channel: null, cleanup: jest.fn() }),
     sendMessage: jest.fn(),
     markAsRead: jest.fn(),
     sendTyping: jest.fn(),
   }),
 }));
-jest.mock('./src/services/TokenService', () => ({
-  TokenService: { getAccessToken: jest.fn().mockResolvedValue('tok') },
+jest.mock("./src/services/TokenService", () => ({
+  TokenService: { getAccessToken: jest.fn().mockResolvedValue("tok") },
 }));
-jest.mock('./src/services/contacts/api', () => ({
+jest.mock("./src/services/contacts/api", () => ({
   contactsAPI: {
     getContacts: jest.fn(),
     getContactRequests: jest.fn(),
@@ -59,93 +69,101 @@ jest.mock('./src/services/contacts/api', () => ({
     refuseContactRequest: jest.fn(),
   },
 }));
-jest.mock('./src/services/messaging/api', () => ({
+jest.mock("./src/services/messaging/api", () => ({
   messagingAPI: {
     createDirectConversation: jest.fn(),
   },
 }));
-jest.mock('./src/components/Contacts/ContactItem', () => ({
+jest.mock("./src/components/Contacts/ContactItem", () => ({
   ContactItem: ({ contact, onPress }: any) => {
-    const { TouchableOpacity, Text } = require('react-native');
+    const { TouchableOpacity, Text } = require("react-native");
     return (
       <TouchableOpacity onPress={() => onPress(contact)}>
-        <Text>{contact.contact_user?.firstName || 'Contact'}</Text>
+        <Text>{contact.contact_user?.firstName || "Contact"}</Text>
       </TouchableOpacity>
     );
   },
 }));
-jest.mock('./src/components/Contacts/AddContactModal', () => ({
+jest.mock("./src/components/Contacts/AddContactModal", () => ({
   AddContactModal: () => null,
 }));
-jest.mock('./src/components/Contacts/EditContactModal', () => ({
+jest.mock("./src/components/Contacts/EditContactModal", () => ({
   EditContactModal: () => null,
 }));
-jest.mock('./src/components/Contacts/SyncContactsModal', () => ({
+jest.mock("./src/components/Contacts/SyncContactsModal", () => ({
   SyncContactsModal: () => null,
 }));
-jest.mock('./src/theme/colors', () => ({
+jest.mock("./src/theme/colors", () => ({
   colors: {
-    background: { gradient: { app: ['#000', '#111'] } },
-    primary: { main: '#6200ee' },
-    text: { light: '#fff' },
-    ui: { success: '#0f0', error: '#f00' },
+    background: { gradient: { app: ["#000", "#111"] } },
+    primary: { main: "#6200ee" },
+    text: { light: "#fff" },
+    ui: { success: "#0f0", error: "#f00" },
   },
 }));
 
 const mockedContactsAPI = contactsAPI as jest.Mocked<typeof contactsAPI>;
 const mockedMessagingAPI = messagingAPI as jest.Mocked<typeof messagingAPI>;
 
-describe('ContactsScreen', () => {
+describe("ContactsScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedContactsAPI.getContacts.mockResolvedValue({ contacts: [] });
     mockedContactsAPI.getContactRequests.mockResolvedValue([]);
   });
 
-  it('renders contacts header', async () => {
+  it("renders contacts header", async () => {
     const { getAllByText } = render(<ContactsScreen />);
-    expect(getAllByText('Contacts').length).toBeGreaterThan(0);
+    expect(getAllByText("Contacts").length).toBeGreaterThan(0);
   });
 
-  it('shows empty state when no contacts', async () => {
+  it("shows empty state when no contacts", async () => {
     const { getByText } = render(<ContactsScreen />);
     await waitFor(() => {
-      expect(getByText('Aucun contact')).toBeTruthy();
+      expect(getByText("Aucun contact")).toBeTruthy();
     });
   });
 
-  it('renders contacts list', async () => {
+  it("renders contacts list", async () => {
     mockedContactsAPI.getContacts.mockResolvedValue({
-      contacts: [{
-        id: 'c1',
-        contact_id: 'u2',
-        contact_user: { id: 'u2', firstName: 'Alice', username: 'alice' },
-        is_favorite: false,
-      }],
+      contacts: [
+        {
+          id: "c1",
+          contact_id: "u2",
+          contact_user: { id: "u2", firstName: "Alice", username: "alice" },
+          is_favorite: false,
+        },
+      ],
     });
     const { getByText } = render(<ContactsScreen />);
     await waitFor(() => {
-      expect(getByText('Alice')).toBeTruthy();
+      expect(getByText("Alice")).toBeTruthy();
     });
   });
 
-  it('navigates to Chat on contact press', async () => {
+  it("navigates to Chat on contact press", async () => {
     mockedContactsAPI.getContacts.mockResolvedValue({
-      contacts: [{
-        id: 'c1',
-        contact_id: 'u2',
-        contact_user: { id: 'u2', firstName: 'Alice', username: 'alice' },
-        is_favorite: false,
-      }],
+      contacts: [
+        {
+          id: "c1",
+          contact_id: "u2",
+          contact_user: { id: "u2", firstName: "Alice", username: "alice" },
+          is_favorite: false,
+        },
+      ],
     });
-    mockedMessagingAPI.createDirectConversation.mockResolvedValue({ id: 'conv1' });
+    mockedMessagingAPI.createDirectConversation.mockResolvedValue({
+      id: "conv1",
+    });
 
     const { getByText } = render(<ContactsScreen />);
-    await waitFor(() => getByText('Alice'));
-    fireEvent.press(getByText('Alice'));
+    await waitFor(() => getByText("Alice"));
+    fireEvent.press(getByText("Alice"));
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('Chat', { conversationId: 'conv1' });
+      expect(mockNavigate).toHaveBeenCalledWith("Chat", {
+        conversationId: "conv1",
+      });
     });
   });
 });

--- a/ConversationsListScreen.test.tsx
+++ b/ConversationsListScreen.test.tsx
@@ -1,93 +1,101 @@
-import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react-native';
-import { ConversationsListScreen } from './src/screens/Chat/ConversationsListScreen';
+import React from "react";
+import { render, fireEvent, waitFor } from "@testing-library/react-native";
+import { ConversationsListScreen } from "./src/screens/Chat/ConversationsListScreen";
 
 const mockNavigate = jest.fn();
 
-jest.mock('@react-navigation/native', () => ({
+jest.mock("@react-navigation/native", () => ({
   useNavigation: () => ({ navigate: mockNavigate, goBack: jest.fn() }),
   useRoute: () => ({ params: {} }),
 }));
-jest.mock('expo-linear-gradient', () => ({
+jest.mock("expo-linear-gradient", () => ({
   LinearGradient: ({ children }: any) => children,
 }));
-jest.mock('react-native-safe-area-context', () => ({
+jest.mock("react-native-safe-area-context", () => ({
   SafeAreaView: ({ children }: any) => children,
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
-jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
-jest.mock('expo-haptics', () => ({
+jest.mock("@expo/vector-icons", () => ({ Ionicons: () => null }));
+jest.mock("expo-haptics", () => ({
   impactAsync: jest.fn(),
   notificationAsync: jest.fn(),
-  ImpactFeedbackStyle: { Light: 'light', Medium: 'medium', Heavy: 'heavy' },
-  NotificationFeedbackType: { Success: 'success' },
+  ImpactFeedbackStyle: { Light: "light", Medium: "medium", Heavy: "heavy" },
+  NotificationFeedbackType: { Success: "success" },
 }));
-jest.mock('./src/context/ThemeContext', () => ({
+jest.mock("./src/context/ThemeContext", () => ({
   useTheme: () => ({
     getThemeColors: () => ({
-      background: { gradient: ['#000', '#111'], primary: '#000', secondary: '#111' },
-      text: { primary: '#fff', secondary: '#aaa', tertiary: '#555' },
-      primary: '#6200ee',
+      background: {
+        gradient: ["#000", "#111"],
+        primary: "#000",
+        secondary: "#111",
+      },
+      text: { primary: "#fff", secondary: "#aaa", tertiary: "#555" },
+      primary: "#6200ee",
     }),
     getFontSize: () => 16,
     getLocalizedText: (key: string) => key,
   }),
 }));
-jest.mock('./src/context/AuthContext', () => ({
+jest.mock("./src/context/AuthContext", () => ({
   useAuth: () => ({
     isAuthenticated: true,
     isLoading: false,
-    userId: 'user1',
-    deviceId: 'dev1',
+    userId: "user1",
+    deviceId: "dev1",
     signIn: jest.fn(),
     signOut: jest.fn(),
   }),
 }));
-jest.mock('./src/hooks/useWebSocket', () => ({
+jest.mock("./src/hooks/useWebSocket", () => ({
   useWebSocket: () => ({
-    joinConversationChannel: jest.fn().mockReturnValue({ channel: null, cleanup: jest.fn() }),
+    joinConversationChannel: jest
+      .fn()
+      .mockReturnValue({ channel: null, cleanup: jest.fn() }),
     sendMessage: jest.fn(),
     markAsRead: jest.fn(),
     sendTyping: jest.fn(),
   }),
 }));
-jest.mock('./src/services/TokenService', () => ({
-  TokenService: { getAccessToken: jest.fn().mockResolvedValue('tok') },
+jest.mock("./src/services/TokenService", () => ({
+  TokenService: { getAccessToken: jest.fn().mockResolvedValue("tok") },
 }));
-jest.mock('./src/services/messaging/api', () => ({
+jest.mock("./src/services/messaging/api", () => ({
   messagingAPI: {
     searchMessagesGlobal: jest.fn().mockResolvedValue(null),
   },
 }));
-jest.mock('./src/store/conversationsStore', () => ({
-  useConversationsStore: (selector: any) => selector({
-    conversations: [],
-    status: 'empty',
-    fetchConversations: jest.fn().mockResolvedValue(undefined),
-    refreshConversations: jest.fn().mockResolvedValue(undefined),
-    applyConversationUpdate: jest.fn(),
-    applyNewMessage: jest.fn(),
-    deleteConversation: jest.fn().mockResolvedValue(undefined),
-    archiveConversation: jest.fn(),
-    muteConversation: jest.fn().mockResolvedValue(undefined),
-    pinConversation: jest.fn(),
-    markAsUnread: jest.fn(),
-    clearManualUnread: jest.fn(),
-    loadManuallyUnreadIds: jest.fn(),
-  }),
+jest.mock("./src/store/conversationsStore", () => ({
+  useConversationsStore: (selector: any) =>
+    selector({
+      conversations: [],
+      status: "empty",
+      fetchConversations: jest.fn().mockResolvedValue(undefined),
+      refreshConversations: jest.fn().mockResolvedValue(undefined),
+      applyConversationUpdate: jest.fn(),
+      applyNewMessage: jest.fn(),
+      deleteConversation: jest.fn().mockResolvedValue(undefined),
+      archiveConversation: jest.fn(),
+      muteConversation: jest.fn().mockResolvedValue(undefined),
+      pinConversation: jest.fn(),
+      markAsUnread: jest.fn(),
+      clearManualUnread: jest.fn(),
+      loadManuallyUnreadIds: jest.fn(),
+    }),
 }));
-jest.mock('./src/components/Chat/SwipeableConversationItem', () => ({
+jest.mock("./src/components/Chat/SwipeableConversationItem", () => ({
   SwipeableConversationItem: ({ conversation, onPress }: any) => {
-    const { TouchableOpacity, Text } = require('react-native');
+    const { TouchableOpacity, Text } = require("react-native");
     return (
       <TouchableOpacity onPress={() => onPress(conversation.id)}>
-        <Text>{conversation.display_name || 'Conversation'}</Text>
+        <Text>{conversation.display_name || "Conversation"}</Text>
       </TouchableOpacity>
     );
   },
 }));
-jest.mock('./src/components/Chat/EmptyState', () => ({
+jest.mock("./src/components/Chat/EmptyState", () => ({
   EmptyState: ({ onNewConversation }: any) => {
-    const { TouchableOpacity, Text } = require('react-native');
+    const { TouchableOpacity, Text } = require("react-native");
     return (
       <TouchableOpacity onPress={onNewConversation}>
         <Text>Nouvelle conversation</Text>
@@ -95,52 +103,54 @@ jest.mock('./src/components/Chat/EmptyState', () => ({
     );
   },
 }));
-jest.mock('./src/components/Chat/SkeletonLoader', () => ({
+jest.mock("./src/components/Chat/SkeletonLoader", () => ({
   ConversationSkeleton: () => null,
 }));
-jest.mock('./src/components/Navigation/BottomTabBar', () => ({
+jest.mock("./src/components/Navigation/BottomTabBar", () => ({
   BottomTabBar: () => null,
 }));
-jest.mock('./src/components/Chat/NewConversationModal', () => ({
+jest.mock("./src/components/Chat/NewConversationModal", () => ({
   NewConversationModal: () => null,
 }));
-jest.mock('./src/components/Toast/Toast', () => () => null);
-jest.mock('./src/theme/colors', () => ({
+jest.mock("./src/components/Toast/Toast", () => () => null);
+jest.mock("./src/theme/colors", () => ({
   colors: {
-    background: { gradient: { app: ['#000', '#111'] } },
-    primary: { main: '#6200ee' },
-    text: { light: '#fff' },
-    ui: { error: '#f00' },
-    secondary: { main: '#03dac6' },
+    background: { gradient: { app: ["#000", "#111"] } },
+    primary: { main: "#6200ee" },
+    text: { light: "#fff" },
+    ui: { error: "#f00" },
+    secondary: { main: "#03dac6" },
   },
 }));
 
-describe('ConversationsListScreen', () => {
+describe("ConversationsListScreen", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it('renders without crashing', () => {
+  it("renders without crashing", () => {
     const { toJSON } = render(<ConversationsListScreen />);
     expect(toJSON()).toBeTruthy();
   });
 
-  it('renders search bar', () => {
+  it("renders search bar", () => {
     const { getByPlaceholderText } = render(<ConversationsListScreen />);
-    expect(getByPlaceholderText('Rechercher des messages ou utilisateurs')).toBeTruthy();
+    expect(
+      getByPlaceholderText("Rechercher des messages ou utilisateurs"),
+    ).toBeTruthy();
   });
 
-  it('renders empty state when no conversations', () => {
+  it("renders empty state when no conversations", () => {
     const { getByText } = render(<ConversationsListScreen />);
-    expect(getByText('Nouvelle conversation')).toBeTruthy();
+    expect(getByText("Nouvelle conversation")).toBeTruthy();
   });
 
-  it('renders Edit button', () => {
+  it("renders Edit button", () => {
     const { getByText } = render(<ConversationsListScreen />);
-    expect(getByText('Modifier')).toBeTruthy();
+    expect(getByText("Modifier")).toBeTruthy();
   });
 
-  it('toggles edit mode on Edit press', () => {
+  it("toggles edit mode on Edit press", () => {
     const { getByText } = render(<ConversationsListScreen />);
-    fireEvent.press(getByText('Modifier'));
-    expect(getByText('Annuler')).toBeTruthy();
+    fireEvent.press(getByText("Modifier"));
+    expect(getByText("Annuler")).toBeTruthy();
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@yudiel/react-qr-scanner": "^2.5.1",
         "expo": "~54.0.33",
         "expo-av": "~16.0.8",
+        "expo-blur": "~15.0.8",
         "expo-camera": "~17.0.10",
         "expo-clipboard": "~8.0.8",
         "expo-constants": "~18.0.13",
@@ -7393,6 +7394,17 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-blur": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-blur/-/expo-blur-15.0.8.tgz",
+      "integrity": "sha512-rWyE1NBRZEu9WD+X+5l7gyPRszw7n12cW3IRNAb5i6KFzaBp8cxqT5oeaphJapqURvcqhkOZn2k5EtBSbsuU7w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-camera": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@yudiel/react-qr-scanner": "^2.5.1",
     "expo": "~54.0.33",
     "expo-av": "~16.0.8",
+    "expo-blur": "~15.0.8",
     "expo-camera": "~17.0.10",
     "expo-clipboard": "~8.0.8",
     "expo-constants": "~18.0.13",

--- a/src/components/Navigation/BottomTabBar.tsx
+++ b/src/components/Navigation/BottomTabBar.tsx
@@ -1,5 +1,6 @@
 /**
  * BottomTabBar - Bottom navigation bar component
+ * WHISPR-1194: pilule flottante avec effet glassmorphism (BlurView).
  */
 
 import React from "react";
@@ -8,23 +9,31 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
+  Image,
   Platform,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { LinearGradient } from "expo-linear-gradient";
+import { BlurView } from "expo-blur";
 import { Ionicons } from "@expo/vector-icons";
 import { navigate } from "../../navigation/navigationRef";
 import { colors } from "../../theme/colors";
 import { useConversationsStore } from "../../store/conversationsStore";
+import {
+  FLOATING_TAB_BAR_BORDER_RADIUS as PILL_BORDER_RADIUS,
+  FLOATING_TAB_BAR_BOTTOM_OFFSET as PILL_BOTTOM_OFFSET,
+  FLOATING_TAB_BAR_HORIZONTAL_MARGIN as PILL_HORIZONTAL_MARGIN,
+  FLOATING_TAB_BAR_PILL_HEIGHT as PILL_HEIGHT,
+} from "./floatingTabBarLayout";
 
 // Extract color values for StyleSheet.create() to avoid runtime resolution issues
 const TEXT_LIGHT_COLOR = colors.text.light;
 const PRIMARY_MAIN_COLOR = colors.primary.main;
-const GRADIENT_APP_COLORS = colors.background.gradient.app;
 
 interface TabItem {
   name: string;
-  icon: keyof typeof Ionicons.glyphMap;
+  icon?: keyof typeof Ionicons.glyphMap;
+  useLogo?: boolean;
+  logoVariant?: "single" | "double";
   route: string;
   badgeKey?: "chats";
 }
@@ -34,11 +43,12 @@ const tabs: TabItem[] = [
   { name: "Appels", icon: "call-outline", route: "Calls" },
   {
     name: "Discussions",
-    icon: "chatbubble-ellipses-outline",
+    useLogo: true,
+    logoVariant: "double",
     route: "ConversationsList",
     badgeKey: "chats",
   },
-  { name: "Réglages", icon: "settings-outline", route: "Settings" },
+  { name: "Réglages", useLogo: true, logoVariant: "single", route: "Settings" },
 ];
 
 type Props = {
@@ -55,126 +65,172 @@ export const BottomTabBar: React.FC<Props> = ({ currentRouteName }) => {
   );
   const unreadCounts = { chats: chatsUnread };
 
+  const insets = useSafeAreaInsets();
+
   const handleTabPress = (tabRoute: string) => {
     if (currentRouteName !== tabRoute) {
       navigate(tabRoute as any);
     }
   };
 
-  const isActive = (tabRoute: string) => {
-    return currentRouteName === tabRoute;
-  };
+  const isActive = (tabRoute: string) => currentRouteName === tabRoute;
 
   const visible = tabs.some((t) => t.route === currentRouteName);
-
-  const insets = useSafeAreaInsets();
-  const bottomInset = Platform.OS === "web" ? 0 : insets.bottom;
+  if (!visible) return null;
 
   return (
     <View
-      style={[styles.container, !visible ? styles.containerHidden : null]}
-      pointerEvents={visible ? "auto" : "none"}
+      pointerEvents="box-none"
+      style={[
+        styles.floatingContainer,
+        { bottom: PILL_BOTTOM_OFFSET + insets.bottom },
+      ]}
     >
-      <LinearGradient
-        colors={GRADIENT_APP_COLORS}
-        start={{ x: 0, y: 0 }}
-        end={{ x: 1, y: 1 }}
-        style={[
-          styles.gradientBackground,
-          { paddingBottom: visible ? bottomInset : 0 },
-          !visible ? styles.gradientBackgroundHidden : null,
-        ]}
-      >
-        <View
-          style={[
-            styles.tabBar,
-            { borderTopColor: "rgba(255, 255, 255, 0.1)" },
-          ]}
-        >
-          {tabs.map((tab) => {
-            const active = isActive(tab.route);
-            const badgeCount =
-              tab.badgeKey &&
-              unreadCounts[tab.badgeKey] &&
-              unreadCounts[tab.badgeKey] > 0
-                ? unreadCounts[tab.badgeKey]
-                : 0;
+      <View style={styles.shadowFrame}>
+        <View style={styles.pillClip}>
+          <BlurView
+            intensity={Platform.OS === "ios" ? 60 : 80}
+            tint="dark"
+            style={styles.pillBlur}
+          >
+            <View style={styles.pillBorderOverlay}>
+              <View style={styles.tabRow}>
+                {tabs.map((tab) => {
+                  const active = isActive(tab.route);
+                  const badgeCount =
+                    tab.badgeKey &&
+                    unreadCounts[tab.badgeKey] &&
+                    unreadCounts[tab.badgeKey] > 0
+                      ? unreadCounts[tab.badgeKey]
+                      : 0;
 
-            return (
-              <TouchableOpacity
-                key={tab.name}
-                style={styles.tab}
-                onPress={() => handleTabPress(tab.route)}
-                activeOpacity={0.7}
-              >
-                <View style={styles.iconContainer}>
-                  <Ionicons
-                    name={tab.icon}
-                    size={24}
-                    color={
-                      active ? TEXT_LIGHT_COLOR : "rgba(255, 255, 255, 0.6)"
-                    }
-                  />
-                  {badgeCount > 0 && (
-                    <View
-                      style={[
-                        styles.badge,
-                        {
-                          backgroundColor: PRIMARY_MAIN_COLOR,
-                          borderColor: "transparent",
-                        },
-                      ]}
+                  return (
+                    <TouchableOpacity
+                      key={tab.name}
+                      style={styles.tab}
+                      onPress={() => handleTabPress(tab.route)}
+                      activeOpacity={0.7}
                     >
-                      <Text style={styles.badgeText}>
-                        {badgeCount > 99 ? "99+" : String(badgeCount)}
+                      <View style={styles.iconContainer}>
+                        {tab.useLogo ? (
+                          <View style={styles.logoContainer}>
+                            {tab.logoVariant === "double" ? (
+                              <View style={styles.doubleLogoContainer}>
+                                <View style={styles.logoBack}>
+                                  <Image
+                                    source={require("../../../assets/images/logo-icon.png")}
+                                    style={styles.logoImageBack}
+                                    resizeMode="contain"
+                                  />
+                                </View>
+                                <View style={styles.logoFront}>
+                                  <Image
+                                    source={require("../../../assets/images/logo-icon.png")}
+                                    style={styles.logoImageFront}
+                                    resizeMode="contain"
+                                  />
+                                  {badgeCount > 0 && (
+                                    <View
+                                      style={[
+                                        styles.badge,
+                                        {
+                                          backgroundColor: PRIMARY_MAIN_COLOR,
+                                          borderColor: "transparent",
+                                        },
+                                      ]}
+                                    >
+                                      <Text style={styles.badgeText}>
+                                        {badgeCount > 99
+                                          ? "99+"
+                                          : String(badgeCount)}
+                                      </Text>
+                                    </View>
+                                  )}
+                                </View>
+                              </View>
+                            ) : (
+                              <Image
+                                source={require("../../../assets/images/logo-icon.png")}
+                                style={styles.logoImage}
+                                resizeMode="contain"
+                              />
+                            )}
+                          </View>
+                        ) : tab.icon ? (
+                          <Ionicons
+                            name={tab.icon}
+                            size={24}
+                            color={
+                              active
+                                ? PRIMARY_MAIN_COLOR
+                                : "rgba(255, 255, 255, 0.6)"
+                            }
+                          />
+                        ) : null}
+                      </View>
+                      <Text
+                        style={[
+                          styles.tabLabel,
+                          {
+                            color: active
+                              ? PRIMARY_MAIN_COLOR
+                              : "rgba(255, 255, 255, 0.7)",
+                            fontWeight: active ? "600" : "500",
+                          },
+                        ]}
+                      >
+                        {tab.name}
                       </Text>
-                    </View>
-                  )}
-                </View>
-                <Text
-                  style={[
-                    styles.tabLabel,
-                    {
-                      color: active
-                        ? TEXT_LIGHT_COLOR
-                        : "rgba(255, 255, 255, 0.7)",
-                      fontWeight: active ? "600" : "500",
-                    },
-                  ]}
-                >
-                  {tab.name}
-                </Text>
-              </TouchableOpacity>
-            );
-          })}
+                    </TouchableOpacity>
+                  );
+                })}
+              </View>
+            </View>
+          </BlurView>
         </View>
-      </LinearGradient>
+      </View>
     </View>
   );
 };
 
 const styles = StyleSheet.create({
-  container: {
-    borderTopWidth: 0,
+  floatingContainer: {
+    position: "absolute",
+    left: PILL_HORIZONTAL_MARGIN,
+    right: PILL_HORIZONTAL_MARGIN,
+    // `bottom` est calculé dynamiquement (insets.bottom + offset) côté composant.
   },
-  containerHidden: {
-    height: 0,
-    paddingBottom: 0,
-    opacity: 0,
+  // Le shadow doit vivre sur un conteneur SANS overflow:hidden, sinon
+  // l'ombre est clippée sur iOS et l'élévation Android disparaît.
+  shadowFrame: {
+    borderRadius: PILL_BORDER_RADIUS,
+    shadowColor: "#000",
+    shadowOpacity: 0.32,
+    shadowRadius: 18,
+    shadowOffset: { width: 0, height: 8 },
+    elevation: 12,
+    backgroundColor: "transparent",
+  },
+  // Clipping séparé du shadow pour que les coins arrondis appliquent au blur.
+  pillClip: {
+    borderRadius: PILL_BORDER_RADIUS,
     overflow: "hidden",
   },
-  gradientBackground: {
-    borderTopWidth: 1,
+  pillBlur: {
+    borderRadius: PILL_BORDER_RADIUS,
   },
-  gradientBackgroundHidden: {
-    borderTopWidth: 0,
+  // Le rendu BlurView Android est très translucide ; on appuie l'effet verre
+  // avec un fond semi-opaque + une bordure blanche subtile.
+  pillBorderOverlay: {
+    borderRadius: PILL_BORDER_RADIUS,
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.18)",
+    backgroundColor: "rgba(20, 25, 50, 0.35)",
   },
-  tabBar: {
+  tabRow: {
     flexDirection: "row",
-    height: 60,
+    height: PILL_HEIGHT,
     paddingHorizontal: 4,
-    borderTopWidth: 1,
-    backgroundColor: "transparent",
   },
   tab: {
     flex: 1,
@@ -190,10 +246,51 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
   },
+  logoContainer: {
+    width: 32,
+    height: 32,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: "transparent",
+  },
+  logoImage: {
+    width: 24,
+    height: 24,
+    tintColor: undefined,
+  },
+  doubleLogoContainer: {
+    width: 48,
+    height: 32,
+    position: "relative",
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: "transparent",
+  },
+  logoBack: {
+    position: "absolute",
+    left: 0,
+    top: 0,
+    zIndex: 1,
+  },
+  logoFront: {
+    position: "absolute",
+    right: 0,
+    top: 0,
+    zIndex: 2,
+  },
+  logoImageBack: {
+    width: 28,
+    height: 28,
+    opacity: 0.7,
+  },
+  logoImageFront: {
+    width: 28,
+    height: 28,
+  },
   badge: {
     position: "absolute",
-    top: 0,
-    right: 8,
+    top: -2,
+    right: -2,
     minWidth: 16,
     height: 16,
     borderRadius: 8,

--- a/src/components/Navigation/floatingTabBarLayout.ts
+++ b/src/components/Navigation/floatingTabBarLayout.ts
@@ -1,0 +1,20 @@
+/**
+ * Constantes partagées de la pilule flottante (WHISPR-1194). Vit dans un
+ * fichier sans dépendance pour pouvoir être consommé depuis les écrans sans
+ * traîner le module BottomTabBar entier (et son `navigationRef`) dans les
+ * suites de tests.
+ */
+
+export const FLOATING_TAB_BAR_PILL_HEIGHT = 64;
+export const FLOATING_TAB_BAR_HORIZONTAL_MARGIN = 16;
+export const FLOATING_TAB_BAR_BOTTOM_OFFSET = 12;
+export const FLOATING_TAB_BAR_BORDER_RADIUS = 32;
+
+/**
+ * Espace vertical à réserver en bas du contenu scrollable des écrans hébergeant
+ * la pilule (Contacts / Calls / Discussions / Réglages) pour qu'aucun élément
+ * ne se retrouve coincé sous la barre flottante. À combiner avec
+ * `useSafeAreaInsets().bottom` côté consommateur.
+ */
+export const FLOATING_TAB_BAR_RESERVED_SPACE =
+  FLOATING_TAB_BAR_PILL_HEIGHT + FLOATING_TAB_BAR_BOTTOM_OFFSET + 8;

--- a/src/screens/Calls/CallHistoryScreen.tsx
+++ b/src/screens/Calls/CallHistoryScreen.tsx
@@ -1,7 +1,9 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { Text, FlatList, StyleSheet, RefreshControl, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { callsApi } from "../../services/calls/callsApi";
 import type { Call, CallStatus } from "../../types/calls";
+import { FLOATING_TAB_BAR_RESERVED_SPACE } from "../../components/Navigation/floatingTabBarLayout";
 
 /**
  * List of past calls for the current user. Pull-to-refresh rehydrates
@@ -10,6 +12,7 @@ import type { Call, CallStatus } from "../../types/calls";
 export const CallHistoryScreen: React.FC = () => {
   const [calls, setCalls] = useState<Call[]>([]);
   const [loading, setLoading] = useState(false);
+  const insets = useSafeAreaInsets();
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -32,6 +35,9 @@ export const CallHistoryScreen: React.FC = () => {
       data={calls}
       keyExtractor={(c) => c.id}
       refreshControl={<RefreshControl refreshing={loading} onRefresh={load} />}
+      contentContainerStyle={{
+        paddingBottom: insets.bottom + FLOATING_TAB_BAR_RESERVED_SPACE,
+      }}
       renderItem={({ item }) => (
         <View style={styles.row}>
           <Text style={styles.title}>

--- a/src/screens/Chat/ConversationsListScreen.tsx
+++ b/src/screens/Chat/ConversationsListScreen.tsx
@@ -14,7 +14,11 @@ import {
   TextInput,
   Platform,
 } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import {
+  SafeAreaView,
+  useSafeAreaInsets,
+} from "react-native-safe-area-context";
+import { FLOATING_TAB_BAR_RESERVED_SPACE } from "../../components/Navigation/floatingTabBarLayout";
 import { LinearGradient } from "expo-linear-gradient";
 import { useNavigation } from "@react-navigation/native";
 import { StackNavigationProp } from "@react-navigation/stack";
@@ -41,6 +45,7 @@ type NavigationProp = StackNavigationProp<AuthStackParamList, "Chat">;
 
 export const ConversationsListScreen: React.FC = () => {
   const navigation = useNavigation<NavigationProp>();
+  const insets = useSafeAreaInsets();
 
   // Store
   const conversations = useConversationsStore((s) => s.conversations);
@@ -395,7 +400,10 @@ export const ConversationsListScreen: React.FC = () => {
         data={filteredAndSortedConversations}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
-        contentContainerStyle={styles.listContent}
+        contentContainerStyle={[
+          styles.listContent,
+          { paddingBottom: insets.bottom + FLOATING_TAB_BAR_RESERVED_SPACE },
+        ]}
         style={styles.list}
         removeClippedSubviews={false}
         maxToRenderPerBatch={10}

--- a/src/screens/Contacts/ContactsScreen.tsx
+++ b/src/screens/Contacts/ContactsScreen.tsx
@@ -16,7 +16,11 @@ import {
   TextInput,
   Alert,
 } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import {
+  SafeAreaView,
+  useSafeAreaInsets,
+} from "react-native-safe-area-context";
+import { FLOATING_TAB_BAR_RESERVED_SPACE } from "../../components/Navigation/floatingTabBarLayout";
 import { LinearGradient } from "expo-linear-gradient";
 import { useFocusEffect, useNavigation } from "@react-navigation/native";
 import type { StackNavigationProp } from "@react-navigation/stack";
@@ -50,6 +54,7 @@ declare module "@expo/vector-icons";
 export const ContactsScreen: React.FC = () => {
   const navigation =
     useNavigation<StackNavigationProp<AuthStackParamList, "Contacts">>();
+  const insets = useSafeAreaInsets();
   const [contacts, setContacts] = useState<Contact[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -655,7 +660,12 @@ export const ContactsScreen: React.FC = () => {
                 tintColor={colors.text.light}
               />
             }
-            contentContainerStyle={styles.listContent}
+            contentContainerStyle={[
+              styles.listContent,
+              {
+                paddingBottom: insets.bottom + FLOATING_TAB_BAR_RESERVED_SPACE,
+              },
+            ]}
           />
         )}
 

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -30,6 +30,7 @@ import {
   NotificationSettings,
 } from "../../services/NotificationService";
 import { SettingsChoiceAlert } from "./SettingsChoiceAlert";
+import { FLOATING_TAB_BAR_RESERVED_SPACE } from "../../components/Navigation/floatingTabBarLayout";
 import {
   DEFAULT_MODERATION_MODEL,
   getModerationModelVersion,
@@ -570,7 +571,9 @@ export const SettingsScreen: React.FC = () => {
         style={styles.scrollView}
         contentContainerStyle={[
           styles.scrollContent,
-          { paddingBottom: 40 + insets.bottom },
+          {
+            paddingBottom: 40 + insets.bottom + FLOATING_TAB_BAR_RESERVED_SPACE,
+          },
         ]}
         showsVerticalScrollIndicator={__DEV__}
         keyboardShouldPersistTaps="handled"


### PR DESCRIPTION
…assmorphism

WHISPR-1194 : remplace la barre pleine largeur en LinearGradient par une pilule flottante avec effet verre dépoli (BlurView), inspirée des apps iOS modernes (Telegram, app Téléphone iOS 26).

- Ajoute expo-blur (~15.0.8 SDK 54) à package.json.
- BottomTabBar : pilule absolue (left/right 16, bottom safeArea+12), borderRadius 32, BlurView intensity 60/80 selon plateforme + bordure blanche translucide et fond semi-opaque pour appuyer l'effet verre. Le shadow vit sur un wrapper sans overflow:hidden afin de ne pas être clippé. Les 4 onglets, leurs labels, leur état actif et le badge unread sur Discussions sont conservés.
- floatingTabBarLayout.ts : constantes partagées (hauteur, marges, offset) isolées dans un module sans dépendance, évitant de tirer BottomTabBar et son navigationRef dans les suites de tests des écrans.
- ConversationsListScreen / ContactsScreen / CallHistoryScreen / SettingsScreen : ajoutent FLOATING_TAB_BAR_RESERVED_SPACE + insets.bottom au paddingBottom de leur FlatList/ScrollView pour que le dernier item ne reste pas coincé sous la pilule.
- Ajoute le mock useSafeAreaInsets dans ConversationsListScreen.test et ContactsScreen.test (sinon les nouveaux insets explosent au render).

Tests : 77/77 suites · 682/682 verts. Lint 0 errors. Type check propre.