### PR TITLE
chore(a11y): ajouter accessibilityLabel/Role sur les contrôles à fort…

### DIFF
--- a/src/components/Chat/MessageInput.tsx
+++ b/src/components/Chat/MessageInput.tsx
@@ -522,6 +522,10 @@ export const MessageInput: React.FC<MessageInputProps> = ({
           <TouchableOpacity
             onPress={replyingTo ? onCancelReply : onCancelEdit}
             style={styles.cancelReplyButton}
+            accessibilityRole="button"
+            accessibilityLabel={
+              replyingTo ? "Annuler la réponse" : "Annuler la modification"
+            }
           >
             <Ionicons
               name="close"
@@ -538,6 +542,8 @@ export const MessageInput: React.FC<MessageInputProps> = ({
               onPress={cancelRecording}
               style={styles.attachButton}
               activeOpacity={0.7}
+              accessibilityRole="button"
+              accessibilityLabel="Annuler l'enregistrement vocal"
             >
               <Ionicons
                 name="trash-outline"
@@ -551,7 +557,12 @@ export const MessageInput: React.FC<MessageInputProps> = ({
                 {formatRecordingTime(recordingDuration)}
               </Text>
             </View>
-            <TouchableOpacity onPress={stopRecording} activeOpacity={0.7}>
+            <TouchableOpacity
+              onPress={stopRecording}
+              activeOpacity={0.7}
+              accessibilityRole="button"
+              accessibilityLabel="Envoyer le message vocal"
+            >
               <LinearGradient
                 colors={["#FFB07B", "#F04882"]}
                 start={{ x: 0, y: 0 }}
@@ -570,6 +581,8 @@ export const MessageInput: React.FC<MessageInputProps> = ({
                   onPress={handleOpenCamera}
                   style={styles.attachButton}
                   activeOpacity={0.7}
+                  accessibilityRole="button"
+                  accessibilityLabel="Prendre une photo"
                 >
                   <Ionicons
                     name="camera-outline"
@@ -581,6 +594,8 @@ export const MessageInput: React.FC<MessageInputProps> = ({
                   onPress={handlePickImage}
                   style={styles.attachButton}
                   activeOpacity={0.7}
+                  accessibilityRole="button"
+                  accessibilityLabel="Joindre une image"
                 >
                   <Ionicons
                     name="image-outline"
@@ -592,6 +607,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
                   onPress={handleOpenEmojiPicker}
                   style={styles.attachButton}
                   activeOpacity={0.7}
+                  accessibilityRole="button"
                   accessibilityLabel="Ouvrir le clavier emoji"
                 >
                   <Ionicons
@@ -667,6 +683,8 @@ export const MessageInput: React.FC<MessageInputProps> = ({
                             style={styles.mentionItem}
                             onPress={() => handleMentionSelect(member)}
                             activeOpacity={0.7}
+                            accessibilityRole="button"
+                            accessibilityLabel={`Mentionner ${member.display_name}`}
                           >
                             <Avatar
                               size={32}
@@ -706,6 +724,13 @@ export const MessageInput: React.FC<MessageInputProps> = ({
                 onLongPress={handleLongPressSend}
                 delayLongPress={500}
                 activeOpacity={0.7}
+                accessibilityRole="button"
+                accessibilityLabel={
+                  editingMessage
+                    ? "Enregistrer la modification"
+                    : "Envoyer le message"
+                }
+                accessibilityHint="Maintenir pour programmer l'envoi"
               >
                 <LinearGradient
                   colors={["#FFB07B", "#F04882"]}
@@ -722,6 +747,9 @@ export const MessageInput: React.FC<MessageInputProps> = ({
                 onLongPress={startRecording}
                 delayLongPress={Platform.OS === "web" ? 200 : 300}
                 activeOpacity={0.7}
+                accessibilityRole="button"
+                accessibilityLabel="Enregistrer un message vocal"
+                accessibilityHint="Maintenir pour démarrer l'enregistrement"
                 style={
                   // iOS Safari: block native context menu / text-selection
                   // popup from stealing the long-press gesture.

--- a/src/components/Navigation/BottomTabBar.tsx
+++ b/src/components/Navigation/BottomTabBar.tsx
@@ -147,6 +147,17 @@ export const BottomTabBar: React.FC<Props> = ({ currentRouteName }) => {
                       style={styles.tab}
                       onPress={() => handleTabPress(tab.route)}
                       activeOpacity={0.7}
+                      accessibilityRole="tab"
+                      accessibilityState={{ selected: active }}
+                      accessibilityLabel={
+                        badgeCount > 0
+                          ? `${tab.name}, ${badgeCount} ${
+                              badgeCount > 1
+                                ? "messages non lus"
+                                : "message non lu"
+                            }`
+                          : tab.name
+                      }
                     >
                       <View style={styles.iconContainer}>
                         {tab.useLogo ? (

--- a/src/screens/Chat/ChatHeader.tsx
+++ b/src/screens/Chat/ChatHeader.tsx
@@ -57,6 +57,8 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
           }
         }}
         style={styles.backButton}
+        accessibilityRole="button"
+        accessibilityLabel="Retour"
       >
         <Ionicons
           name="arrow-back"
@@ -163,6 +165,8 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
           <TouchableOpacity
             onPress={onScheduledPress}
             style={styles.actionButton}
+            accessibilityRole="button"
+            accessibilityLabel="Messages programmés"
           >
             <Ionicons
               name="timer-outline"
@@ -172,7 +176,12 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
           </TouchableOpacity>
         )}
         {onSearchPress && (
-          <TouchableOpacity onPress={onSearchPress} style={styles.actionButton}>
+          <TouchableOpacity
+            onPress={onSearchPress}
+            style={styles.actionButton}
+            accessibilityRole="button"
+            accessibilityLabel="Rechercher dans la conversation"
+          >
             <Ionicons
               name="search"
               size={22}
@@ -185,6 +194,8 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
             onInfoPress?.();
           }}
           style={styles.actionButton}
+          accessibilityRole="button"
+          accessibilityLabel="Détails de la conversation"
         >
           <Ionicons
             name="information-circle-outline"


### PR DESCRIPTION
… trafic

WHISPR-1111. Audit Tudy : 705 TouchableOpacity dans src/, ratio < 4% de labels accessibles. On commence par les surfaces les plus utilisées (BottomTabBar, ChatHeader, MessageInput, action buttons send/record/media) pour rendre l'app utilisable au lecteur d'écran.

- BottomTabBar : accessibilityRole "tab" + accessibilityState selected, label dynamique "Discussions, 3 messages non lus" quand badge présent.
- ChatHeader : back, scheduled, search, info → role "button" + label fr. Audio/video étaient déjà labellisés.
- MessageInput : cancel reply/edit, cancel/send recording, camera, image, emoji (role manquant), mention item, send/edit, mic record. Labels sensibles au contexte (envoyer vs enregistrer la modification, etc.)
  + accessibilityHint sur les boutons à long-press.

Tests : 77/77 verts. Lint 0 errors. Type check propre.