### PR TITLE
ci(release): aligner actions/checkout sur v5 dans release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true


### PR DESCRIPTION
WHISPR-1119. Le reste de la suite CI (cd, codeql, docker, expo-frontend-ci, labeler, trivy) utilise déjà `actions/checkout@v5` ; release.yml restait en v4 et serait le seul concerné par la dépréciation Node 20 → 24 prévue en juin 2026 sur les runners GitHub Actions.

Audit complémentaire :
- node-version dans expo-frontend-ci.yml déjà sur "22" (cf. ticket "PAS 24")
- actions/setup-node@v5, sonarqube-scan-action@v6, upload-artifact@v4 déjà à jour
- actions/cache n'est pas utilisé dans ce repo
- docker/* (login, setup-buildx, build-push, metadata) sont sur leurs majeures courantes (v3/v5) — pas de bump nécessaire

Aucun changement de comportement attendu : v5 conserve l'API publique de v4 et tourne sur Node 20+.