### PR TITLE
fix(auth): clear callsStore au signOut pour éviter les fuites entre c…

### DIFF
--- a/callsStore.test.ts
+++ b/callsStore.test.ts
@@ -114,4 +114,60 @@ describe("callsStore — track publish on connect", () => {
     // Active call still set so the user sees the in-call UI and can retry.
     expect(useCallsStore.getState().active).not.toBeNull();
   });
+
+  // WHISPR-1198 — reset() est appelé par AuthContext.signOut pour empêcher
+  // les fuites d'état d'appel entre deux comptes successifs sur le device.
+  describe("reset (WHISPR-1198)", () => {
+    it("clears active and incoming when nothing is in flight", () => {
+      useCallsStore.getState().reset();
+      expect(useCallsStore.getState().active).toBeNull();
+      expect(useCallsStore.getState().incoming).toBeNull();
+    });
+
+    it("disconnects the LiveKit room and nulls active when an active call exists", () => {
+      const disconnect = jest.fn();
+      useCallsStore.setState({
+        active: {
+          callId: "c-leak",
+          status: "connected",
+          liveKitUrl: "wss://lk",
+          liveKitToken: "tok",
+          type: "audio",
+          room: { disconnect } as any,
+        },
+        incoming: {
+          callId: "c-ring",
+          initiatorId: "u-other",
+          conversationId: "conv-1",
+          type: "video",
+        },
+      });
+
+      useCallsStore.getState().reset();
+
+      expect(disconnect).toHaveBeenCalledTimes(1);
+      expect(useCallsStore.getState().active).toBeNull();
+      expect(useCallsStore.getState().incoming).toBeNull();
+    });
+
+    it("swallows disconnect errors so signOut never throws", () => {
+      const disconnect = jest.fn(() => {
+        throw new Error("livekit dead");
+      });
+      useCallsStore.setState({
+        active: {
+          callId: "c-leak",
+          status: "connected",
+          liveKitUrl: "wss://lk",
+          liveKitToken: "tok",
+          type: "audio",
+          room: { disconnect } as any,
+        },
+        incoming: null,
+      });
+
+      expect(() => useCallsStore.getState().reset()).not.toThrow();
+      expect(useCallsStore.getState().active).toBeNull();
+    });
+  });
 });

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -15,6 +15,7 @@ import { destroySharedSocket } from "../services/messaging/websocket";
 import { useConversationsStore } from "../store/conversationsStore";
 import { usePresenceStore } from "../store/presenceStore";
 import { useModerationStore } from "../store/moderationStore";
+import { useCallsStore } from "../store/callsStore";
 import { cacheService } from "../services/messaging/cache";
 import { offlineQueue } from "../services/offlineQueue";
 import { onSessionExpired } from "../services/sessionEvents";
@@ -90,6 +91,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     useConversationsStore.getState().reset();
     usePresenceStore.getState().reset();
     useModerationStore.getState().reset();
+    useCallsStore.getState().reset();
     await cacheService.clearCache();
     await offlineQueue.clearAll();
     await AsyncStorage.removeItem("@whispr/manually_unread_ids");

--- a/src/store/callsStore.ts
+++ b/src/store/callsStore.ts
@@ -50,6 +50,7 @@ interface CallsState {
   declineIncoming: () => Promise<void>;
   end: () => Promise<void>;
   setIncoming: (incoming: IncomingCallInfo | null) => void;
+  reset: () => void;
 }
 
 export const useCallsStore = create<CallsState>((set, get) => ({
@@ -134,4 +135,20 @@ export const useCallsStore = create<CallsState>((set, get) => ({
   },
 
   setIncoming: (incoming) => set({ incoming }),
+
+  // WHISPR-1198: appelé par AuthContext.signOut pour empêcher l'état d'appel
+  // (token LiveKit, callId, ringer fantôme) de fuir d'un compte vers le
+  // suivant sur le même device. Best-effort sur la déconnexion LiveKit : la
+  // session côté backend est de toute façon morte, on ne dépend pas du succès.
+  reset: () => {
+    const a = get().active;
+    if (a?.room) {
+      try {
+        a.room.disconnect();
+      } catch {
+        // ignore — best-effort cleanup pendant le signOut
+      }
+    }
+    set({ active: null, incoming: null });
+  },
 }));


### PR DESCRIPTION
…omptes

WHISPR-1198. Trouvé en static bug-hunt sur le flow auth/session : `AuthContext.signOut` reset déjà conversationsStore / presenceStore / moderationStore mais oublie `useCallsStore`, qui n'avait d'ailleurs même pas d'action `reset`.

Conséquence : si le compte A se déconnecte avec un `active` peuplé (token LiveKit, callId, room) ou un `incoming` ringer en cours, le compte B qui se connecte ensuite hérite des valeurs en mémoire et peut tenter de se reconnecter à un appel mort, ou voir un ringer fantôme.

Fix
- callsStore.ts : nouvelle action `reset()` qui best-effort déconnecte la Room LiveKit (try/catch — la session est déjà morte) puis remet active et incoming à null.
- AuthContext.tsx : appel `useCallsStore.getState().reset()` à côté des autres resets dans signOut.

Tests : 3 nouveaux specs (clear vide, disconnect + clear, swallow des erreurs disconnect). Suite complète 77/77 · 685/685 verts.