### PR TITLE
fix(settings): laisse la page Settings défiler sur web

### DIFF
--- a/SettingsScreen.test.tsx
+++ b/SettingsScreen.test.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Platform, StyleSheet } from "react-native";
 import { render, waitFor } from "@testing-library/react-native";
 import { SettingsScreen } from "./src/screens/Settings/SettingsScreen";
 
@@ -113,5 +114,22 @@ describe("SettingsScreen", () => {
     await waitFor(() => {
       expect(getByText("settings.logout")).toBeTruthy();
     });
+  });
+
+  it("constrains the ScrollView height on web so the page can scroll (WHISPR-1199)", async () => {
+    const originalOS = Platform.OS;
+    Object.defineProperty(Platform, "OS", { value: "web", configurable: true });
+    try {
+      const { getByTestId } = render(<SettingsScreen />);
+      const scroll = await waitFor(() => getByTestId("settings-scroll"));
+      const flat = StyleSheet.flatten(scroll.props.style);
+      expect(flat.height).toBe("100%");
+      expect(flat.minHeight).toBe(0);
+    } finally {
+      Object.defineProperty(Platform, "OS", {
+        value: originalOS,
+        configurable: true,
+      });
+    }
   });
 });

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -560,15 +560,25 @@ export const SettingsScreen: React.FC = () => {
     </View>
   );
 
+  // WHISPR-1199 : sur React Native Web, la chaîne flex:1 du Stack.Screen ne
+  // contraint pas toujours la hauteur du LinearGradient — le ScrollView ne
+  // génère alors plus d'overflow scrollable. On force la hauteur viewport
+  // côté web ; minHeight:0 permet à l'enfant flex de réellement shrinker.
+  const webContainerStyle =
+    Platform.OS === "web" ? { height: "100%" as const } : null;
+  const webScrollStyle =
+    Platform.OS === "web" ? { height: "100%" as const, minHeight: 0 } : null;
+
   return (
     <LinearGradient
       colors={themeColors.background.gradient}
       start={{ x: 0, y: 0 }}
       end={{ x: 1, y: 1 }}
-      style={styles.container}
+      style={[styles.container, webContainerStyle]}
     >
       <ScrollView
-        style={styles.scrollView}
+        testID="settings-scroll"
+        style={[styles.scrollView, webScrollStyle]}
         contentContainerStyle={[
           styles.scrollContent,
           {


### PR DESCRIPTION
Sur React Native Web, la chaîne flex:1 du Stack.Screen ne contraignait pas toujours la hauteur du LinearGradient parent du ScrollView, ce qui empêchait l'overflow scrollable de se déclencher. On applique côté web height:100% sur le conteneur et height:100% + minHeight:0 sur le ScrollView pour court-circuiter le problème, sans toucher au natif.

Closes WHISPR-1199