### PR TITLE
fix(calls): remonte l'erreur d'acceptation d'appel à l'utilisateur

### DIFF
--- a/IncomingCallScreen.test.tsx
+++ b/IncomingCallScreen.test.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import React from "react";
+import { Alert } from "react-native";
+import { render, fireEvent } from "@testing-library/react-native";
 
 const mockReset = jest.fn();
 const mockGoBack = jest.fn();
 const mockCanGoBack = jest.fn().mockReturnValue(true);
 
-jest.mock('@react-navigation/native', () => ({
+jest.mock("@react-navigation/native", () => ({
   useNavigation: () => ({
     reset: mockReset,
     goBack: mockGoBack,
@@ -15,55 +16,57 @@ jest.mock('@react-navigation/native', () => ({
 
 const mockAcceptIncoming = jest.fn().mockResolvedValue(undefined);
 const mockDeclineIncoming = jest.fn().mockResolvedValue(undefined);
+const mockSetIncoming = jest.fn();
 
 let mockIncoming: any = {
-  callId: 'c1',
-  initiatorId: 'user-alice',
-  conversationId: 'conv1',
-  type: 'audio',
+  callId: "c1",
+  initiatorId: "user-alice",
+  conversationId: "conv1",
+  type: "audio",
 };
 
-jest.mock('./src/store/callsStore', () => ({
+jest.mock("./src/store/callsStore", () => ({
   useCallsStore: (selector: any) =>
     selector({
       incoming: mockIncoming,
       acceptIncoming: mockAcceptIncoming,
       declineIncoming: mockDeclineIncoming,
+      setIncoming: mockSetIncoming,
     }),
 }));
 
-import { IncomingCallScreen } from './src/screens/Calls/IncomingCallScreen';
+import { IncomingCallScreen } from "./src/screens/Calls/IncomingCallScreen";
 
-describe('IncomingCallScreen', () => {
+describe("IncomingCallScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIncoming = {
-      callId: 'c1',
-      initiatorId: 'user-alice',
-      conversationId: 'conv1',
-      type: 'audio',
+      callId: "c1",
+      initiatorId: "user-alice",
+      conversationId: "conv1",
+      type: "audio",
     };
   });
 
-  it('matches snapshot', () => {
+  it("matches snapshot", () => {
     const { toJSON } = render(<IncomingCallScreen />);
     expect(toJSON()).toMatchSnapshot();
   });
 
-  it('renders caller id and accept/decline buttons', () => {
+  it("renders caller id and accept/decline buttons", () => {
     const { getByLabelText, getByText } = render(<IncomingCallScreen />);
-    expect(getByText('user-alice')).toBeTruthy();
+    expect(getByText("user-alice")).toBeTruthy();
     expect(getByLabelText("Accepter l'appel")).toBeTruthy();
     expect(getByLabelText("Refuser l'appel")).toBeTruthy();
   });
 
-  it('renders nothing when there is no incoming call', () => {
+  it("renders nothing when there is no incoming call", () => {
     mockIncoming = null;
     const { toJSON } = render(<IncomingCallScreen />);
     expect(toJSON()).toBeNull();
   });
 
-  it('calls acceptIncoming and navigates to InCall when Accept is pressed', async () => {
+  it("calls acceptIncoming and navigates to InCall when Accept is pressed", async () => {
     const { getByLabelText } = render(<IncomingCallScreen />);
     fireEvent.press(getByLabelText("Accepter l'appel"));
     await Promise.resolve();
@@ -71,16 +74,42 @@ describe('IncomingCallScreen', () => {
     expect(mockAcceptIncoming).toHaveBeenCalledTimes(1);
     expect(mockReset).toHaveBeenCalledWith({
       index: 0,
-      routes: [{ name: 'InCall' }],
+      routes: [{ name: "InCall" }],
     });
   });
 
-  it('calls declineIncoming and goes back when Decline is pressed', async () => {
+  it("calls declineIncoming and goes back when Decline is pressed", async () => {
     const { getByLabelText } = render(<IncomingCallScreen />);
     fireEvent.press(getByLabelText("Refuser l'appel"));
     await Promise.resolve();
     await Promise.resolve();
     expect(mockDeclineIncoming).toHaveBeenCalledTimes(1);
     expect(mockGoBack).toHaveBeenCalled();
+  });
+
+  it("shows an alert and dismisses the modal when accept fails (WHISPR-1200)", async () => {
+    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    mockAcceptIncoming.mockRejectedValueOnce(
+      new Error("livekit-connect: WebSocket failed"),
+    );
+    try {
+      const { getByLabelText } = render(<IncomingCallScreen />);
+      fireEvent.press(getByLabelText("Accepter l'appel"));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockAcceptIncoming).toHaveBeenCalledTimes(1);
+      expect(mockReset).not.toHaveBeenCalled();
+      expect(alertSpy).toHaveBeenCalledWith(
+        "Impossible de prendre l'appel",
+        "livekit-connect: WebSocket failed",
+      );
+      expect(mockSetIncoming).toHaveBeenCalledWith(null);
+      expect(mockGoBack).toHaveBeenCalled();
+    } finally {
+      alertSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
   });
 });

--- a/callsStore.test.ts
+++ b/callsStore.test.ts
@@ -115,6 +115,46 @@ describe("callsStore — track publish on connect", () => {
     expect(useCallsStore.getState().active).not.toBeNull();
   });
 
+  // WHISPR-1200 — la couche UI a besoin de distinguer un échec API d'un
+  // échec LiveKit pour afficher un message utile. acceptIncoming doit donc
+  // tagguer chaque étape avec un préfixe stable.
+  it("tags accept-api errors so the UI can surface them (WHISPR-1200)", async () => {
+    const callsApi = require("./src/services/calls/callsApi").callsApi as {
+      accept: jest.Mock;
+    };
+    callsApi.accept.mockRejectedValueOnce(new Error("403 Forbidden"));
+    useCallsStore.setState({
+      incoming: {
+        callId: "c1",
+        initiatorId: "u2",
+        conversationId: "conv-1",
+        type: "audio",
+      },
+    });
+
+    await expect(useCallsStore.getState().acceptIncoming()).rejects.toThrow(
+      /^accept-api: /,
+    );
+  });
+
+  it("tags livekit-connect errors so the UI can surface them (WHISPR-1200)", async () => {
+    mockProvider.connect.mockRejectedValueOnce(
+      new Error("WebSocket connection failed"),
+    );
+    useCallsStore.setState({
+      incoming: {
+        callId: "c1",
+        initiatorId: "u2",
+        conversationId: "conv-1",
+        type: "audio",
+      },
+    });
+
+    await expect(useCallsStore.getState().acceptIncoming()).rejects.toThrow(
+      /^livekit-connect: /,
+    );
+  });
+
   // WHISPR-1198 — reset() est appelé par AuthContext.signOut pour empêcher
   // les fuites d'état d'appel entre deux comptes successifs sur le device.
   describe("reset (WHISPR-1198)", () => {

--- a/src/screens/Calls/IncomingCallScreen.tsx
+++ b/src/screens/Calls/IncomingCallScreen.tsx
@@ -1,11 +1,28 @@
 import React from "react";
-import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  Alert,
+  Platform,
+} from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import type { StackNavigationProp } from "@react-navigation/stack";
 import { useCallsStore } from "../../store/callsStore";
 import type { AuthStackParamList } from "../../navigation/AuthNavigator";
 
 type Nav = StackNavigationProp<AuthStackParamList>;
+
+const showAcceptError = (message: string) => {
+  const title = "Impossible de prendre l'appel";
+  if (Platform.OS === "web") {
+    // window.alert est synchrone sur web ; Alert.alert RN ne s'affiche pas.
+    if (typeof window !== "undefined") window.alert(`${title}\n\n${message}`);
+    return;
+  }
+  Alert.alert(title, message);
+};
 
 /**
  * Full-screen incoming call UI. Shown as a modal over the current stack
@@ -16,6 +33,7 @@ export const IncomingCallScreen: React.FC = () => {
   const incoming = useCallsStore((s) => s.incoming);
   const acceptIncoming = useCallsStore((s) => s.acceptIncoming);
   const declineIncoming = useCallsStore((s) => s.declineIncoming);
+  const setIncoming = useCallsStore((s) => s.setIncoming);
   const navigation = useNavigation<Nav>();
 
   const onAccept = async () => {
@@ -26,7 +44,19 @@ export const IncomingCallScreen: React.FC = () => {
         routes: [{ name: "InCall" }],
       });
     } catch (err) {
+      // WHISPR-1200 : on ne peut plus avaler l'erreur silencieusement, sinon
+      // l'utilisateur reste coincé sur la modale. callsStore tague l'étape
+      // (`accept-api: ...` vs `livekit-connect: ...`) pour aider au diagnostic.
+      const message = err instanceof Error ? err.message : "Erreur inconnue";
       console.error("Failed to accept call", err);
+      showAcceptError(message);
+      // Dismiss la modale : le call peut être dans un état incohérent côté
+      // serveur, on rend la main à l'utilisateur plutôt que de le laisser
+      // bloqué sur un bouton qui ne réagit plus.
+      setIncoming(null);
+      if (navigation.canGoBack()) {
+        navigation.goBack();
+      }
     }
   };
 

--- a/src/store/callsStore.ts
+++ b/src/store/callsStore.ts
@@ -92,12 +92,25 @@ export const useCallsStore = create<CallsState>((set, get) => ({
   acceptIncoming: async () => {
     const inc = get().incoming;
     if (!inc) return;
-    const resp = await callsApi.accept(inc.callId);
+    // WHISPR-1200 : on tague chaque étape pour que la couche UI puisse
+    // distinguer un échec API (call introuvable, droits, etc.) d'un échec
+    // LiveKit (URL injoignable, token invalide, WebRTC non supporté).
+    let resp;
+    try {
+      resp = await callsApi.accept(inc.callId);
+    } catch (err) {
+      throw new Error(`accept-api: ${(err as Error).message}`);
+    }
     const provider = getCallsLiveKit();
-    const room = await provider.connect({
-      url: resp.livekit_url,
-      token: resp.livekit_token,
-    });
+    let room;
+    try {
+      room = await provider.connect({
+        url: resp.livekit_url,
+        token: resp.livekit_token,
+      });
+    } catch (err) {
+      throw new Error(`livekit-connect: ${(err as Error).message}`);
+    }
     try {
       await provider.enableMic(true);
       if (inc.type === "video") {


### PR DESCRIPTION
Sur l'écran IncomingCallScreen, le bouton Accepter avalait silencieusement toutes les erreurs (console.error uniquement, pas de navigation, pas de reset). L'utilisateur restait bloqué sur la modale sans aucun feedback.

- callsStore.acceptIncoming tague désormais chaque étape :
  * accept-api: <message>  → échec de l'appel REST /calls/:id/accept
  * livekit-connect: <message> → échec de room.connect côté WebRTC Cela permet à la couche UI et aux logs de distinguer un problème backend d'un problème réseau / WebRTC.

- IncomingCallScreen.onAccept affiche désormais une Alert avec le message taggé, ferme la modale (incoming → null + goBack) et rend la main à l'utilisateur au lieu de le laisser sur un bouton inerte.

Tests : couvre accept-api error, livekit-connect error, et le chemin "accept échoue → alert + goBack + setIncoming(null)".

Closes WHISPR-1200