### PR TITLE
fix(cd): drop emoji prefix from auto-generated commit messages

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -170,9 +170,9 @@ jobs:
           SHORT_SHA=$(printf "%.7s" "$COMMIT_SHA")
 
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            COMMIT_MSG="🔧 chore(deploy/mobile-web): update image to ${SHORT_SHA} (manual trigger)"
+            COMMIT_MSG="chore(deploy/mobile-web): update image to ${SHORT_SHA} (manual trigger)"
           else
-            COMMIT_MSG="🔧 chore(deploy/mobile-web): update image to ${SHORT_SHA}"
+            COMMIT_MSG="chore(deploy/mobile-web): update image to ${SHORT_SHA}"
           fi
 
           git add k8s/whispr/preprod/mobile-web/deployment.yaml


### PR DESCRIPTION
## Summary

Removes the `🔧 ` emoji prefix from the auto-generated CD commit messages on the mobile-web image bump. Aligns with the rule that commits should not contain emojis.

Same change just landed on 5 backend repos (notification-service, calls-service, messaging-service, media-service, auth-service).