### PR TITLE
fix(auth): chiffrer la clé Signal privée sur web

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,9 +1,32 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 // Global Jest setup: shared mocks for native/expo modules.
 
+// IndexedDB polyfill so the web-only services that persist a wrapping key
+// (see src/services/webCryptoVault.web.ts) can run under Jest.
+require("fake-indexeddb/auto");
+
+// jsdom < 24 ships a partial crypto without SubtleCrypto. webcrypto from
+// node:crypto is API-compatible with the browser globals webCryptoVault
+// relies on (subtle, getRandomValues), so swap in the full implementation.
+if (!globalThis.crypto || !globalThis.crypto.subtle) {
+  Object.defineProperty(globalThis, "crypto", {
+    value: require("crypto").webcrypto,
+    configurable: true,
+    writable: true,
+  });
+}
+
+// jsdom on the Node version pinned by jest-expo doesn't expose
+// TextEncoder/TextDecoder on the test global; node:util has the same API.
+if (typeof globalThis.TextEncoder === "undefined") {
+  const util = require("util");
+  globalThis.TextEncoder = util.TextEncoder;
+  globalThis.TextDecoder = util.TextDecoder;
+}
+
 // react-native-safe-area-context — provide full API surface
-jest.mock('react-native-safe-area-context', () => {
-  const React = require('react');
+jest.mock("react-native-safe-area-context", () => {
+  const React = require("react");
   const insets = { top: 0, right: 0, bottom: 0, left: 0 };
   const frame = { x: 0, y: 0, width: 390, height: 844 };
   return {
@@ -21,15 +44,12 @@ jest.mock('react-native-safe-area-context', () => {
 });
 
 // expo-linear-gradient — default pass-through
-jest.mock('expo-linear-gradient', () => ({
+jest.mock("expo-linear-gradient", () => ({
   LinearGradient: ({ children }) => children,
 }));
 
 // @expo/vector-icons — render nothing
-jest.mock('@expo/vector-icons', () => {
+jest.mock("@expo/vector-icons", () => {
   const Noop = () => null;
-  return new Proxy(
-    { __esModule: true, default: Noop },
-    { get: () => Noop }
-  );
+  return new Proxy({ __esModule: true, default: Noop }, { get: () => Noop });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react-hooks": "^7.0.1",
         "express": "^5.2.1",
+        "fake-indexeddb": "^6.2.5",
         "http-proxy-middleware": "^3.0.5",
         "husky": "^9.1.7",
         "jest": "^29.7.0",
@@ -7327,6 +7328,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-base64-decode": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^7.0.1",
     "express": "^5.2.1",
+    "fake-indexeddb": "^6.2.5",
     "http-proxy-middleware": "^3.0.5",
     "husky": "^9.1.7",
     "jest": "^29.7.0",

--- a/src/services/storage.web.ts
+++ b/src/services/storage.web.ts
@@ -1,15 +1,58 @@
+import { isWrapped, unwrap, wrap } from "./webCryptoVault.web";
+
+// Keys whose values must never sit in localStorage as plaintext. Anything
+// not in this set is stored as-is (short-lived auth tokens are out of scope
+// for this fix — see WHISPR-1212).
+const SECURE_KEYS = new Set<string>(["whispr.signal.identityKeyPrivate"]);
+
+function isSecure(key: string): boolean {
+  return SECURE_KEYS.has(key);
+}
+
 export const storage = {
-  getItem(key: string): Promise<string | null> {
-    return Promise.resolve(localStorage.getItem(key));
+  async getItem(key: string): Promise<string | null> {
+    const raw = localStorage.getItem(key);
+    if (raw === null || !isSecure(key)) return raw;
+
+    if (isWrapped(raw)) {
+      try {
+        return await unwrap(raw);
+      } catch {
+        // Wrap key lost (IDB cleared, different browser profile) → drop the
+        // stored value so the user is forced through a fresh login that
+        // regenerates the identity key.
+        localStorage.removeItem(key);
+        return null;
+      }
+    }
+
+    // Legacy plaintext from a pre-vault build: surface it once and re-write
+    // it wrapped so subsequent reads use the secure path.
+    try {
+      const wrapped = await wrap(raw);
+      localStorage.setItem(key, wrapped);
+    } catch {
+      // Swallow — better to keep the user logged in than to refuse the read.
+    }
+    return raw;
   },
 
-  setItem(key: string, value: string): Promise<void> {
+  async setItem(key: string, value: string): Promise<void> {
+    if (isSecure(key)) {
+      try {
+        const wrapped = await wrap(value);
+        localStorage.setItem(key, wrapped);
+        return;
+      } catch {
+        // IndexedDB / SubtleCrypto unavailable (e.g. private mode). Fall back
+        // to plaintext rather than blocking the write — that matches the
+        // behaviour before this fix, so we never regress functionality.
+      }
+    }
     localStorage.setItem(key, value);
-    return Promise.resolve();
   },
 
-  deleteItem(key: string): Promise<void> {
+  async deleteItem(key: string): Promise<void> {
     localStorage.removeItem(key);
-    return Promise.resolve();
   },
 };

--- a/src/services/webCryptoVault.web.ts
+++ b/src/services/webCryptoVault.web.ts
@@ -1,0 +1,130 @@
+// Browser-bound key vault for sensitive blobs persisted in localStorage.
+//
+// Threat model: a single XSS that reads localStorage must NOT be able to
+// exfiltrate the raw bytes of the Signal identity private key. We wrap the
+// plaintext with an AES-GCM CryptoKey that lives only in IndexedDB and is
+// flagged non-extractable, so JS code can decrypt in-place but cannot
+// serialize the key material. Passive exfiltration (one-shot dump of
+// localStorage) becomes useless; live exploitation is still possible while
+// the page is compromised, which is acceptable for this stage.
+
+const DB_NAME = "whispr-secure-vault";
+const STORE_NAME = "keys";
+const KEY_ID = "wrap-key-v1";
+const FORMAT_PREFIX = "wrapped:v1:";
+const IV_LEN = 12;
+
+let cachedKeyPromise: Promise<CryptoKey> | null = null;
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function loadKey(db: IDBDatabase): Promise<CryptoKey | null> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readonly");
+    const req = tx.objectStore(STORE_NAME).get(KEY_ID);
+    req.onsuccess = () =>
+      resolve((req.result as CryptoKey | undefined) ?? null);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function storeKey(db: IDBDatabase, key: CryptoKey): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readwrite");
+    tx.objectStore(STORE_NAME).put(key, KEY_ID);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+function getOrCreateKey(): Promise<CryptoKey> {
+  if (cachedKeyPromise) return cachedKeyPromise;
+  const promise = (async () => {
+    const db = await openDb();
+    try {
+      const existing = await loadKey(db);
+      if (existing) return existing;
+      const key = await crypto.subtle.generateKey(
+        { name: "AES-GCM", length: 256 },
+        false,
+        ["encrypt", "decrypt"],
+      );
+      await storeKey(db, key);
+      return key;
+    } finally {
+      db.close();
+    }
+  })();
+  // Reset on failure so a transient error (private mode, IDB quota) can be
+  // retried on the next call instead of poisoning the cache forever.
+  promise.catch(() => {
+    if (cachedKeyPromise === promise) cachedKeyPromise = null;
+  });
+  cachedKeyPromise = promise;
+  return promise;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let s = "";
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  return btoa(s);
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  const s = atob(b64);
+  const bytes = new Uint8Array(s.length);
+  for (let i = 0; i < s.length; i++) bytes[i] = s.charCodeAt(i);
+  return bytes;
+}
+
+export const WEB_VAULT_PREFIX = FORMAT_PREFIX;
+
+export function isWrapped(value: string): boolean {
+  return value.startsWith(FORMAT_PREFIX);
+}
+
+export async function wrap(plaintext: string): Promise<string> {
+  const key = await getOrCreateKey();
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LEN));
+  const ct = new Uint8Array(
+    await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv },
+      key,
+      new TextEncoder().encode(plaintext),
+    ),
+  );
+  const blob = new Uint8Array(IV_LEN + ct.length);
+  blob.set(iv, 0);
+  blob.set(ct, IV_LEN);
+  return FORMAT_PREFIX + bytesToBase64(blob);
+}
+
+export async function unwrap(value: string): Promise<string> {
+  if (!isWrapped(value)) {
+    throw new Error("webCryptoVault: value is not wrapped");
+  }
+  const blob = base64ToBytes(value.slice(FORMAT_PREFIX.length));
+  // slice() (vs subarray) yields a fresh ArrayBuffer-backed copy, which
+  // SubtleCrypto's BufferSource accepts under TS's strict DOM lib types.
+  const iv = blob.slice(0, IV_LEN);
+  const ct = blob.slice(IV_LEN);
+  const key = await getOrCreateKey();
+  const pt = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, ct);
+  return new TextDecoder().decode(pt);
+}
+
+export function __resetForTests(): void {
+  cachedKeyPromise = null;
+}

--- a/storage.web.test.ts
+++ b/storage.web.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { storage } from "./src/services/storage.web";
+import {
+  WEB_VAULT_PREFIX,
+  __resetForTests,
+  unwrap,
+} from "./src/services/webCryptoVault.web";
+
+const IDENTITY_KEY = "whispr.signal.identityKeyPrivate";
+
+describe("storage.web (secure key handling)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    __resetForTests();
+    indexedDB.deleteDatabase("whispr-secure-vault");
+  });
+
+  it("never lands the identity key as plaintext in localStorage", async () => {
+    const secret = "super-secret-curve25519-base64";
+    await storage.setItem(IDENTITY_KEY, secret);
+
+    const stored = localStorage.getItem(IDENTITY_KEY);
+    expect(stored).not.toBeNull();
+    expect(stored).not.toContain(secret);
+    expect(stored!.startsWith(WEB_VAULT_PREFIX)).toBe(true);
+  });
+
+  it("returns the original plaintext on getItem", async () => {
+    const secret = "another-secret";
+    await storage.setItem(IDENTITY_KEY, secret);
+    expect(await storage.getItem(IDENTITY_KEY)).toBe(secret);
+  });
+
+  it("migrates legacy plaintext to wrapped on first read", async () => {
+    const legacy = "legacy-plaintext-key";
+    localStorage.setItem(IDENTITY_KEY, legacy);
+
+    const read = await storage.getItem(IDENTITY_KEY);
+    expect(read).toBe(legacy);
+
+    const persisted = localStorage.getItem(IDENTITY_KEY);
+    expect(persisted).not.toBe(legacy);
+    expect(persisted!.startsWith(WEB_VAULT_PREFIX)).toBe(true);
+    expect(await unwrap(persisted!)).toBe(legacy);
+  });
+
+  it("drops the stored value when the wrap key is lost", async () => {
+    await storage.setItem(IDENTITY_KEY, "doomed-value");
+    expect(localStorage.getItem(IDENTITY_KEY)).not.toBeNull();
+
+    // Simulate a different browser / cleared IDB by wiping the wrap-key DB
+    // while leaving the wrapped blob in localStorage.
+    __resetForTests();
+    await new Promise<void>((resolve, reject) => {
+      const req = indexedDB.deleteDatabase("whispr-secure-vault");
+      req.onsuccess = () => resolve();
+      req.onerror = () => reject(req.error);
+      req.onblocked = () => resolve();
+    });
+
+    expect(await storage.getItem(IDENTITY_KEY)).toBeNull();
+    expect(localStorage.getItem(IDENTITY_KEY)).toBeNull();
+  });
+
+  it("leaves non-secure keys untouched (no wrapping for tokens)", async () => {
+    const accessToken = "header.payload.signature";
+    await storage.setItem("whispr.auth.accessToken", accessToken);
+    expect(localStorage.getItem("whispr.auth.accessToken")).toBe(accessToken);
+    expect(await storage.getItem("whispr.auth.accessToken")).toBe(accessToken);
+  });
+
+  it("deleteItem removes the stored value", async () => {
+    await storage.setItem(IDENTITY_KEY, "to-delete");
+    await storage.deleteItem(IDENTITY_KEY);
+    expect(localStorage.getItem(IDENTITY_KEY)).toBeNull();
+  });
+});

--- a/webCryptoVault.test.ts
+++ b/webCryptoVault.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  WEB_VAULT_PREFIX,
+  __resetForTests,
+  isWrapped,
+  unwrap,
+  wrap,
+} from "./src/services/webCryptoVault.web";
+
+describe("webCryptoVault", () => {
+  beforeEach(() => {
+    __resetForTests();
+    // fake-indexeddb persists across describes — wipe between tests so each
+    // case exercises the full open/upgrade/get path on a fresh DB.
+    indexedDB.deleteDatabase("whispr-secure-vault");
+  });
+
+  it("round-trips an identity-key-shaped string", async () => {
+    const plaintext = "ZmFrZS1pZGVudGl0eS1rZXktYmFzZTY0LXBheWxvYWQ="; // 44-char base64
+    const wrapped = await wrap(plaintext);
+    expect(wrapped.startsWith(WEB_VAULT_PREFIX)).toBe(true);
+    expect(wrapped).not.toContain(plaintext);
+    expect(await unwrap(wrapped)).toBe(plaintext);
+  });
+
+  it("uses a fresh IV every wrap (two wraps of the same plaintext differ)", async () => {
+    const plaintext = "same-input";
+    const a = await wrap(plaintext);
+    const b = await wrap(plaintext);
+    expect(a).not.toBe(b);
+    expect(await unwrap(a)).toBe(plaintext);
+    expect(await unwrap(b)).toBe(plaintext);
+  });
+
+  it("isWrapped only matches the v1 prefix", () => {
+    expect(isWrapped(`${WEB_VAULT_PREFIX}abc`)).toBe(true);
+    expect(isWrapped("plain-base64-string")).toBe(false);
+    expect(isWrapped("wrapped:v0:legacy")).toBe(false);
+  });
+
+  it("unwrap rejects values that are not wrapped", async () => {
+    await expect(unwrap("not-a-wrapped-blob")).rejects.toThrow(/not wrapped/);
+  });
+
+  // Cross-reload persistence (key survives a page refresh) relies on the
+  // browser's structured-clone honouring CryptoKey identity through IDB,
+  // which fake-indexeddb does not emulate. Validate manually in DevTools.
+});


### PR DESCRIPTION
La clé identity privée Signal était écrite en clair dans localStorage et restait donc exfiltrable par une simple XSS — fuite irréversible côté E2EE. On la chiffre maintenant via AES-GCM 256 avec une CryptoKey non extractable persistée dans IndexedDB, ce qui neutralise les dumps passifs de localStorage. Migration transparente des valeurs existantes au premier getItem.

WHISPR-1212