### PR TITLE
fix(config): supprimer roadmvn.com des défauts et fail-fast en prod

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,9 +73,10 @@ jobs:
         run: |
           REF="${INPUT_REF:-$GITHUB_REF}"
           if [[ "$REF" == *"deploy/preprod"* ]]; then
-            echo "url=https://preprod-whispr-api.roadmvn.com" >> $GITHUB_OUTPUT
+            echo "url=https://whispr.devzeyu.com" >> $GITHUB_OUTPUT
           else
-            echo "url=https://whispr-api.roadmvn.com" >> $GITHUB_OUTPUT
+            echo "::error::No production API URL configured for ref $REF — refusing to bake an old hardcoded domain into the image."
+            exit 1
           fi
 
       - name: Build and push Docker image

--- a/TwoFactorAuthScreen.test.tsx
+++ b/TwoFactorAuthScreen.test.tsx
@@ -6,8 +6,8 @@ import { TwoFactorService } from "./src/services/TwoFactorService";
 // expo-secure-store is mocked globally in jest.setup.js (WHISPR-994).
 
 jest.mock("./src/services/apiBase", () => ({
-  getApiBaseUrl: () => "https://preprod-whispr-api.roadmvn.com",
-  getWsBaseUrl: () => "wss://preprod-whispr-api.roadmvn.com",
+  getApiBaseUrl: () => "https://whispr.devzeyu.com",
+  getWsBaseUrl: () => "wss://whispr.devzeyu.com",
 }));
 
 const mockNavigate = jest.fn();

--- a/apiBase.test.ts
+++ b/apiBase.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment node
+ */
+
+const mockConstants = {
+  expoConfig: { extra: {} as { apiBaseUrl?: string } } as {
+    extra?: { apiBaseUrl?: string };
+  } | null,
+  manifest: null as { extra?: { apiBaseUrl?: string } } | null,
+  manifest2: null as { extra?: { apiBaseUrl?: string } } | null,
+};
+
+jest.mock("expo-constants", () => ({
+  __esModule: true,
+  default: mockConstants,
+}));
+
+const FALLBACK_DEV = "https://whispr.devzeyu.com";
+
+describe("getApiBaseUrl", () => {
+  const originalDev = (global as { __DEV__?: boolean }).__DEV__;
+  const originalEnv = process.env.EXPO_PUBLIC_API_BASE_URL;
+
+  beforeEach(() => {
+    jest.resetModules();
+    delete process.env.EXPO_PUBLIC_API_BASE_URL;
+    mockConstants.expoConfig = { extra: {} };
+    mockConstants.manifest = null;
+    mockConstants.manifest2 = null;
+  });
+
+  afterAll(() => {
+    (global as { __DEV__?: boolean }).__DEV__ = originalDev;
+    if (originalEnv === undefined) {
+      delete process.env.EXPO_PUBLIC_API_BASE_URL;
+    } else {
+      process.env.EXPO_PUBLIC_API_BASE_URL = originalEnv;
+    }
+  });
+
+  it("uses EXPO_PUBLIC_API_BASE_URL when set, regardless of mode", () => {
+    process.env.EXPO_PUBLIC_API_BASE_URL = "https://from-env.test";
+    (global as { __DEV__?: boolean }).__DEV__ = false;
+    const { getApiBaseUrl } = require("./src/services/apiBase");
+    expect(getApiBaseUrl()).toBe("https://from-env.test");
+  });
+
+  it("uses Constants.expoConfig.extra.apiBaseUrl when set", () => {
+    mockConstants.expoConfig = {
+      extra: { apiBaseUrl: "https://from-constants.test" },
+    };
+    (global as { __DEV__?: boolean }).__DEV__ = false;
+    const { getApiBaseUrl } = require("./src/services/apiBase");
+    expect(getApiBaseUrl()).toBe("https://from-constants.test");
+  });
+
+  it("falls back to whispr.devzeyu.com in dev when no source resolves", () => {
+    (global as { __DEV__?: boolean }).__DEV__ = true;
+    const { getApiBaseUrl } = require("./src/services/apiBase");
+    expect(getApiBaseUrl()).toBe(FALLBACK_DEV);
+  });
+
+  it("throws in production when no source resolves (no roadmvn fallback)", () => {
+    (global as { __DEV__?: boolean }).__DEV__ = false;
+    const { getApiBaseUrl } = require("./src/services/apiBase");
+    expect(() => getApiBaseUrl()).toThrow(/API base URL not configured/);
+  });
+
+  it("strips trailing slashes", () => {
+    process.env.EXPO_PUBLIC_API_BASE_URL = "https://api.test///";
+    (global as { __DEV__?: boolean }).__DEV__ = false;
+    const { getApiBaseUrl } = require("./src/services/apiBase");
+    expect(getApiBaseUrl()).toBe("https://api.test");
+  });
+});

--- a/app.config.js
+++ b/app.config.js
@@ -10,7 +10,7 @@ module.exports = ({ config }) => ({
     },
   },
   extra: {
-    apiBaseUrl: process.env.API_BASE_URL || 'https://preprod-whispr-api.roadmvn.com',
+    apiBaseUrl: process.env.API_BASE_URL || 'https://whispr.devzeyu.com',
     devAuthApiUrl: 'http://10.0.2.2:3010',
     devUserApiUrl: 'http://10.0.2.2:3011',
     legalPrivacyUrl:

--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
     "scheme": "whispr",
     "version": "1.0.0",
     "extra": {
-      "apiBaseUrl": "https://preprod-whispr-api.roadmvn.com",
+      "apiBaseUrl": "https://whispr.devzeyu.com",
       "devAuthApiUrl": "http://10.0.2.2:3010",
       "devUserApiUrl": "http://10.0.2.2:3011",
       "legalPrivacyUrl": "https://whispr.example/privacy",

--- a/proxy.js
+++ b/proxy.js
@@ -4,8 +4,7 @@ const { createProxyMiddleware } = require('http-proxy-middleware');
 const app = express();
 
 const DEFAULT_ALLOWED_ORIGINS = [
-  'https://whispr-preprod.roadmvn.com',
-  'https://whispr.roadmvn.com',
+  'https://whispr.devzeyu.com',
 ];
 
 const allowedOrigins = (process.env.ALLOWED_ORIGINS
@@ -39,7 +38,7 @@ app.use((req, res, next) => {
 });
 
 app.use('/', createProxyMiddleware({
-  target: 'https://whispr-api.roadmvn.com',
+  target: 'https://whispr.devzeyu.com',
   changeOrigin: true,
   on: {
     proxyRes: (proxyRes, req) => {
@@ -58,4 +57,4 @@ app.use('/', createProxyMiddleware({
   },
 }));
 
-app.listen(8083, () => console.log('Proxy on http://localhost:8083 → https://whispr-api.roadmvn.com'));
+app.listen(8083, () => console.log('Proxy on http://localhost:8083 → https://whispr.devzeyu.com'));

--- a/src/services/apiBase.ts
+++ b/src/services/apiBase.ts
@@ -1,13 +1,14 @@
 import Constants from "expo-constants";
 
-/** Production (releases EAS avec `extra.apiBaseUrl` non défini). */
-const PROD_API_URL = "https://whispr-api.roadmvn.com";
-
 /**
- * Même défaut que `app.json` / `app.config.js` quand aucune variable d'env
- * ne surcharge — évite de pointer la prod en dev si `expoConfig.extra` est vide.
+ * Filet de sécurité utilisé uniquement en dev (`__DEV__ === true`). En
+ * production on échoue durement (`getApiBaseUrl` throw) plutôt que de
+ * tomber sur un domaine codé en dur — voir WHISPR-1213 : le défaut
+ * historique pointait sur `roadmvn.com`, qu'on n'opère plus, et un
+ * attaquant qui rachèterait ce domaine intercepterait toutes les
+ * requêtes auth/messages des builds qui n'auraient pas reçu d'env.
  */
-const APP_CONFIG_DEFAULT_API = "https://preprod-whispr-api.roadmvn.com";
+const APP_CONFIG_DEFAULT_API = "https://whispr.devzeyu.com";
 
 function pickBaseUrl(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
@@ -62,12 +63,16 @@ export const getApiBaseUrl = (): string => {
   const envOverride = pickBaseUrl(
     (process.env as any)?.EXPO_PUBLIC_API_BASE_URL,
   );
-  return (
+  const resolved =
     envOverride ??
     resolveApiBaseUrlFromSameOrigin() ??
-    resolveApiBaseUrlFromConstants() ??
-    (__DEV__ ? APP_CONFIG_DEFAULT_API : PROD_API_URL)
-  ).replace(/\/+$/, "");
+    resolveApiBaseUrlFromConstants();
+  if (resolved) return resolved.replace(/\/+$/, "");
+  if (__DEV__) return APP_CONFIG_DEFAULT_API;
+  throw new Error(
+    "API base URL not configured. Inject EXPO_PUBLIC_API_BASE_URL or set " +
+      "Constants.expoConfig.extra.apiBaseUrl before building this release.",
+  );
 };
 
 export const getWsBaseUrl = (): string => {


### PR DESCRIPTION
L'URL d'API par défaut hardcodée pointait sur roadmvn.com dans 5 endroits (app.json, app.config.js, src/services/apiBase.ts, proxy.js, .github/workflows/docker.yml). Si ce domaine cessait d'être contrôlé par nous, un attaquant qui le rachète intercepterait toutes les requêtes auth/messages des builds qui n'auraient pas reçu d'env override — domain hijacking complet.

- bascule tous les défauts sur https://whispr.devzeyu.com (déploiement actif)
- src/services/apiBase.ts : suppression du fallback PROD_API_URL ; getApiBaseUrl() throw en production si aucune source ne résout (fail-fast plutôt que de router silencieusement)
- workflows/docker.yml : refus explicite de builder une image hors branche deploy/preprod tant qu'il n'y a pas de cible prod configurée
- couverture : 5 tests unitaires sur getApiBaseUrl (env override, Constants, fallback dev, throw prod, trim trailing slash)

WHISPR-1213