### PR TITLE
fix(contacts): calculer is_blocked depuis getBlockedUsers au lieu de …

### DIFF
--- a/contactsApi.test.ts
+++ b/contactsApi.test.ts
@@ -235,13 +235,15 @@ describe("contactsAPI.searchUsers", () => {
   });
 
   it("merges username + name results and deduplicates", async () => {
-    // 1st call: getContacts (for contactIds enrichment)
+    // getContacts (for contactIds enrichment)
     mockFetch.mockResolvedValueOnce(mockResponse({ body: [] }));
-    // 2nd call: /search/username
+    // getBlockedUsers (WHISPR-1215 — for is_blocked enrichment)
+    mockFetch.mockResolvedValueOnce(mockResponse({ body: [] }));
+    // /search/username
     mockFetch.mockResolvedValueOnce(
       mockResponse({ body: { id: "u-1", username: "ada" } }),
     );
-    // 3rd call: /search/name (returns same user + a new one)
+    // /search/name (returns same user + a new one)
     mockFetch.mockResolvedValueOnce(
       mockResponse({
         body: {
@@ -259,6 +261,7 @@ describe("contactsAPI.searchUsers", () => {
 
   it("also calls /search/phone when the query looks like a phone number", async () => {
     mockFetch.mockResolvedValueOnce(mockResponse({ body: [] })); // getContacts
+    mockFetch.mockResolvedValueOnce(mockResponse({ body: [] })); // getBlockedUsers (WHISPR-1215)
     mockFetch.mockResolvedValueOnce(mockResponse({ status: 404 })); // username
     mockFetch.mockResolvedValueOnce(mockResponse({ status: 404 })); // name
     mockFetch.mockResolvedValueOnce(
@@ -273,6 +276,42 @@ describe("contactsAPI.searchUsers", () => {
     );
     expect(phoneCall).toBeDefined();
   });
+
+  it("flags is_blocked=true on search hits that are in the blocked list (WHISPR-1215)", async () => {
+    // getContacts
+    mockFetch.mockResolvedValueOnce(mockResponse({ body: [] }));
+    // getBlockedUsers — u-1 is blocked, u-2 is not
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        body: [
+          {
+            id: "b-1",
+            blockerId: "me",
+            blockedId: "u-1",
+            createdAt: "2026-01-01T00:00:00Z",
+          },
+        ],
+      }),
+    );
+    // /search/username
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 404 }));
+    // /search/name
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        body: {
+          results: [
+            { id: "u-1", username: "ada" },
+            { id: "u-2", username: "grace" },
+          ],
+        },
+      }),
+    );
+
+    const results = await contactsAPI.searchUsers({ username: "ada" });
+    const byId = Object.fromEntries(results.map((r) => [r.user.id, r]));
+    expect(byId["u-1"]?.is_blocked).toBe(true);
+    expect(byId["u-2"]?.is_blocked).toBe(false);
+  });
 });
 
 describe("contactsAPI.importPhoneContacts", () => {
@@ -281,6 +320,8 @@ describe("contactsAPI.importPhoneContacts", () => {
   });
 
   it("uses the batch endpoint when it succeeds", async () => {
+    // getBlockedUsers (WHISPR-1215)
+    mockFetch.mockResolvedValueOnce(mockResponse({ body: [] }));
     mockFetch.mockResolvedValueOnce(
       mockResponse({
         body: {
@@ -294,8 +335,11 @@ describe("contactsAPI.importPhoneContacts", () => {
     ]);
     expect(results).toHaveLength(1);
 
-    const [url, init] = mockFetch.mock.calls[0];
-    expect(url).toBe(`${BASE}/search/phone/batch`);
+    const batchCall = mockFetch.mock.calls.find(([url]) =>
+      String(url).includes("/search/phone/batch"),
+    );
+    expect(batchCall).toBeDefined();
+    const [, init] = batchCall!;
     expect(init.method).toBe("POST");
     expect(JSON.parse(init.body)).toEqual({
       phoneNumbers: ["+33600000000"],
@@ -303,6 +347,8 @@ describe("contactsAPI.importPhoneContacts", () => {
   });
 
   it("falls back to sequential lookups when the batch endpoint 404s", async () => {
+    // getBlockedUsers (WHISPR-1215)
+    mockFetch.mockResolvedValueOnce(mockResponse({ body: [] }));
     // batch call
     mockFetch.mockResolvedValueOnce(mockResponse({ status: 404 }));
     // sequential calls (one per phone number)
@@ -318,6 +364,42 @@ describe("contactsAPI.importPhoneContacts", () => {
       { phoneNumber: "+33700000000" } as any,
     ]);
     expect(results.map((r) => r.user.id).sort()).toEqual(["u-1", "u-2"]);
+  });
+
+  it("flags imported users as is_blocked when they're in the blocked list (WHISPR-1215)", async () => {
+    // getBlockedUsers — u-1 is blocked
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        body: [
+          {
+            id: "b-1",
+            blockerId: "me",
+            blockedId: "u-1",
+            createdAt: "2026-01-01T00:00:00Z",
+          },
+        ],
+      }),
+    );
+    // batch
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        body: {
+          results: [
+            { id: "u-1", username: "ada" },
+            { id: "u-2", username: "grace" },
+          ],
+        },
+      }),
+    );
+
+    const results = await contactsAPI.importPhoneContacts([
+      { phoneNumber: "+33600000000" } as any,
+      { phoneNumber: "+33700000000" } as any,
+    ]);
+
+    const byId = Object.fromEntries(results.map((r) => [r.user.id, r]));
+    expect(byId["u-1"]?.is_blocked).toBe(true);
+    expect(byId["u-2"]?.is_blocked).toBe(false);
   });
 });
 
@@ -336,12 +418,40 @@ describe("contactsAPI.getUserPreviewById", () => {
     mockFetch.mockResolvedValueOnce(
       mockResponse({ body: [{ id: "c-1", contactId: "u-1" }] }),
     );
+    // getBlockedUsers call (WHISPR-1215)
+    mockFetch.mockResolvedValueOnce(mockResponse({ body: [] }));
     primeUserEnrichment(1);
 
     const result = await contactsAPI.getUserPreviewById("u-1");
     expect(result).not.toBeNull();
     expect(result?.user.id).toBe("u-1");
     expect(result?.is_contact).toBe(true);
+    expect(result?.is_blocked).toBe(false);
+  });
+
+  it("flags is_blocked=true when the previewed user is blocked (WHISPR-1215)", async () => {
+    // fetchUserById
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ body: { id: "u-1", username: "ada" } }),
+    );
+    // getContacts
+    mockFetch.mockResolvedValueOnce(mockResponse({ body: [] }));
+    // getBlockedUsers — u-1 IS blocked
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        body: [
+          {
+            id: "b-1",
+            blockerId: "me",
+            blockedId: "u-1",
+            createdAt: "2026-01-01T00:00:00Z",
+          },
+        ],
+      }),
+    );
+
+    const result = await contactsAPI.getUserPreviewById("u-1");
+    expect(result?.is_blocked).toBe(true);
   });
 });
 

--- a/src/services/contacts/api.ts
+++ b/src/services/contacts/api.ts
@@ -137,6 +137,7 @@ const fetchUserById = async (userId: string): Promise<User | null> => {
 const buildSearchResult = (
   u: any,
   contactIds?: Set<string>,
+  blockedIds?: Set<string>,
 ): UserSearchResult => {
   const userId = u.id ?? u.userId;
   return {
@@ -156,7 +157,10 @@ const buildSearchResult = (
       is_active: u.isActive ?? u.is_active ?? true,
     },
     is_contact: contactIds ? contactIds.has(userId) : false,
-    is_blocked: false,
+    // WHISPR-1215 — couvre le sens "je l'ai bloqué". Le sens inverse
+    // ("il m'a bloqué") demande un flag côté serveur et fait l'objet d'un
+    // ticket séparé.
+    is_blocked: blockedIds ? blockedIds.has(userId) : false,
   };
 };
 
@@ -374,14 +378,15 @@ export const contactsAPI = {
   async getUserPreviewById(userId: string): Promise<UserSearchResult | null> {
     const user = await fetchUserById(userId);
     if (!user) return null;
-    let contactIds: Set<string>;
-    try {
-      const { contacts } = await this.getContacts();
-      contactIds = new Set(contacts.map((c) => c.contact_id));
-    } catch {
-      contactIds = new Set();
-    }
-    return buildSearchResult(user, contactIds);
+    const [contactIds, blockedIds] = await Promise.all([
+      this.getContacts()
+        .then(({ contacts }) => new Set(contacts.map((c) => c.contact_id)))
+        .catch(() => new Set<string>()),
+      this.getBlockedUsers()
+        .then(({ blocked }) => new Set(blocked.map((b) => b.blocked_user_id)))
+        .catch(() => new Set<string>()),
+    ]);
+    return buildSearchResult(user, contactIds, blockedIds);
   },
 
   async searchUsers(params: UserSearchParams): Promise<UserSearchResult[]> {
@@ -390,14 +395,16 @@ export const contactsAPI = {
       return [];
     }
 
-    // Fetch current contacts to mark search results
-    let contactIds: Set<string>;
-    try {
-      const { contacts } = await this.getContacts();
-      contactIds = new Set(contacts.map((c) => c.contact_id));
-    } catch {
-      contactIds = new Set();
-    }
+    // WHISPR-1215 — fetch contacts and blocked users in parallel so each
+    // result carries the real is_blocked flag (was hard-coded to false).
+    const [contactIds, blockedIds] = await Promise.all([
+      this.getContacts()
+        .then(({ contacts }) => new Set(contacts.map((c) => c.contact_id)))
+        .catch(() => new Set<string>()),
+      this.getBlockedUsers()
+        .then(({ blocked }) => new Set(blocked.map((b) => b.blocked_user_id)))
+        .catch(() => new Set<string>()),
+    ]);
 
     // Run all search strategies in parallel for fuzzy matching
     const searches: Promise<UserSearchResult[]>[] = [];
@@ -414,7 +421,7 @@ export const contactsAPI = {
           if (!r.ok) return [];
           const user = await r.json().catch(() => null);
           if (!user?.id && !user?.userId) return [];
-          return [buildSearchResult(user, contactIds)];
+          return [buildSearchResult(user, contactIds, blockedIds)];
         })
         .catch(() => []),
     );
@@ -437,7 +444,7 @@ export const contactsAPI = {
               : [];
           return items
             .filter((u: any) => u?.id || u?.userId)
-            .map((u: any) => buildSearchResult(u, contactIds));
+            .map((u: any) => buildSearchResult(u, contactIds, blockedIds));
         })
         .catch(() => []),
     );
@@ -463,7 +470,7 @@ export const contactsAPI = {
                 : [];
             return items
               .filter((u: any) => u?.id || u?.userId)
-              .map((u: any) => buildSearchResult(u, contactIds));
+              .map((u: any) => buildSearchResult(u, contactIds, blockedIds));
           })
           .catch(() => []),
       );
@@ -498,6 +505,12 @@ export const contactsAPI = {
 
     if (!phoneNumbers.length) return [];
 
+    // WHISPR-1215 — pull the user's blocked list once, before issuing the
+    // search calls, so each result reflects the real is_blocked state.
+    const blockedIds = await this.getBlockedUsers()
+      .then(({ blocked }) => new Set(blocked.map((b) => b.blocked_user_id)))
+      .catch(() => new Set<string>());
+
     // Try batch endpoint first
     try {
       const batchResponse = await fetch(`${API_BASE_URL}/search/phone/batch`, {
@@ -520,7 +533,7 @@ export const contactsAPI = {
           const id = u?.id ?? u?.userId;
           if (id && !seen.has(id)) {
             seen.add(id);
-            results.push(buildSearchResult(u));
+            results.push(buildSearchResult(u, undefined, blockedIds));
           }
         }
         return results;
@@ -556,7 +569,7 @@ export const contactsAPI = {
           const id = u?.id ?? u?.userId;
           if (id && !seen.has(id)) {
             seen.add(id);
-            results.push(buildSearchResult(u));
+            results.push(buildSearchResult(u, undefined, blockedIds));
           }
         }
       } catch {


### PR DESCRIPTION
…le figer

buildSearchResult mettait is_blocked=false en dur pour tous les résultats de recherche, peu importe la réalité côté serveur. Conséquence : l'utilisateur pouvait sélectionner quelqu'un qu'il avait bloqué et tenter d'ouvrir une conversation — le serveur rejetait, mais l'UI ne prévenait pas en amont. La fonction de blocage devenait cosmétique.

- buildSearchResult : nouveau paramètre blockedIds (Set<string>) ; si fourni, is_blocked = blockedIds.has(userId).
- searchUsers / getUserPreviewById : fetch en parallèle (Promise.all) de getContacts() et getBlockedUsers() avant chaque recherche, set passé à tous les buildSearchResult dérivés.
- importPhoneContacts : fetch séquentiel de getBlockedUsers() avant les endpoints batch / sequential.
- L'UI consommatrice (AddContactModal, SyncContactsModal, QRCodeScannerScreen) gérait déjà is_blocked correctement — désactivation du bouton "envoyer message" / filtrage du résultat. Aucun changement nécessaire côté UI.

Sens couvert : "j'ai bloqué l'autre". Le sens "il m'a bloqué" demande un flag côté API (search renvoie l'info), à traiter dans un ticket séparé côté backend.

Tests : 3 nouveaux (search avec un user bloqué, import avec un user bloqué, preview d'un user bloqué). Existants mis à jour pour mocker le fetch /blocked-users supplémentaire. 714 tests verts.

WHISPR-1215