### PR TITLE
fix(auth): purger toutes les clés AsyncStorage au signOut

### DIFF
--- a/AppResetService.test.ts
+++ b/AppResetService.test.ts
@@ -1,0 +1,120 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const mockGetAllKeys = jest.fn<Promise<string[]>, []>();
+const mockMultiRemove = jest.fn<Promise<void>, [string[]]>();
+
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  __esModule: true,
+  default: {
+    getAllKeys: (...args: any[]) => mockGetAllKeys(...args),
+    multiRemove: (...args: any[]) => mockMultiRemove(...args),
+  },
+}));
+
+const mockClearAll = jest.fn<Promise<void>, []>();
+jest.mock("./src/services/TokenService", () => ({
+  TokenService: {
+    clearAll: (...args: any[]) => mockClearAll(...args),
+  },
+}));
+
+import { AppResetService } from "./src/services/AppResetService";
+
+beforeEach(() => {
+  mockGetAllKeys.mockReset();
+  mockMultiRemove.mockReset();
+  mockClearAll.mockReset();
+  mockMultiRemove.mockResolvedValue(undefined);
+  mockClearAll.mockResolvedValue(undefined);
+});
+
+describe("AppResetService.resetAppData (WHISPR-1221)", () => {
+  it("removes every whispr-prefixed key, preserves theme/language, ignores third-party keys", async () => {
+    mockGetAllKeys.mockResolvedValue([
+      // ours — all should be removed
+      "whispr.profile.v1",
+      "whispr.conversations.cache",
+      "whispr.conversations.cache.timestamp",
+      "whispr.offline.message.queue",
+      "whispr.device.id",
+      "whispr.signal.identityKeyPrivate",
+      "whispr.auth.accessToken",
+      "@whispr/manually_unread_ids",
+      "@whispr/profile_setup_done",
+      "@whispr/pending_avatar_media_id:user-123",
+      "@whispr_settings_app",
+      "@whispr_settings_messaging",
+      "@whispr_settings_notifications",
+      "@whispr_settings_privacy",
+      "@whispr_settings_security",
+      // preserved
+      "whispr.globalSettings.v1",
+      // third-party — must NOT be touched
+      "expo-storage:abc",
+      "metro-cache-key",
+      "RCTFollowPropertyAccessKey",
+    ]);
+
+    await AppResetService.resetAppData();
+
+    expect(mockMultiRemove).toHaveBeenCalledTimes(1);
+    const removed = mockMultiRemove.mock.calls[0][0].sort();
+    expect(removed).not.toContain("whispr.globalSettings.v1");
+    expect(removed).not.toContain("expo-storage:abc");
+    expect(removed).not.toContain("metro-cache-key");
+    expect(removed).not.toContain("RCTFollowPropertyAccessKey");
+    expect(removed).toContain("@whispr_settings_privacy");
+    expect(removed).toContain("@whispr/manually_unread_ids");
+    expect(removed).toContain("whispr.signal.identityKeyPrivate");
+    expect(removed).toContain("whispr.auth.accessToken");
+    expect(removed).toContain("whispr.offline.message.queue");
+    expect(removed).toContain("@whispr/pending_avatar_media_id:user-123");
+  });
+
+  it("calls TokenService.clearAll() to wipe SecureStore-backed values", async () => {
+    mockGetAllKeys.mockResolvedValue([]);
+
+    await AppResetService.resetAppData();
+
+    expect(mockClearAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips multiRemove when no owned keys exist (avoids the empty-array warning)", async () => {
+    mockGetAllKeys.mockResolvedValue([
+      "expo-storage:abc",
+      "RCTFollowPropertyAccessKey",
+    ]);
+
+    await AppResetService.resetAppData();
+
+    expect(mockMultiRemove).not.toHaveBeenCalled();
+    expect(mockClearAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("still wipes tokens when AsyncStorage.getAllKeys throws", async () => {
+    mockGetAllKeys.mockRejectedValue(new Error("storage broken"));
+
+    await AppResetService.resetAppData();
+
+    // Failure on the bulk-remove path must not block the secure-store cleanup.
+    expect(mockClearAll).toHaveBeenCalledTimes(1);
+    expect(mockMultiRemove).not.toHaveBeenCalled();
+  });
+
+  it("preserves keys with tricky prefixes that overlap whispr (defense in depth)", async () => {
+    mockGetAllKeys.mockResolvedValue([
+      // looks like ours but isn't (no prefix match: starts with "wh", not "whispr.")
+      "whisperGarden",
+      "whispr",
+    ]);
+
+    await AppResetService.resetAppData();
+
+    // "whispr" alone has no dot/at-suffix — should be skipped (prefix is "whispr.").
+    if (mockMultiRemove.mock.calls.length > 0) {
+      const removed = mockMultiRemove.mock.calls[0][0];
+      expect(removed).not.toContain("whisperGarden");
+      expect(removed).not.toContain("whispr");
+    }
+  });
+});

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -6,18 +6,14 @@ import React, {
   useRef,
   useState,
 } from "react";
-import AsyncStorage from "@react-native-async-storage/async-storage";
 import { AuthService } from "../services/AuthService";
-import { TokenService } from "../services/TokenService";
-import { profileSetupFlag } from "../services/profileSetupFlag";
+import { AppResetService } from "../services/AppResetService";
 import { tokenRefreshScheduler } from "../services/TokenRefreshScheduler";
 import { destroySharedSocket } from "../services/messaging/websocket";
 import { useConversationsStore } from "../store/conversationsStore";
 import { usePresenceStore } from "../store/presenceStore";
 import { useModerationStore } from "../store/moderationStore";
 import { useCallsStore } from "../store/callsStore";
-import { cacheService } from "../services/messaging/cache";
-import { offlineQueue } from "../services/offlineQueue";
 import { onSessionExpired } from "../services/sessionEvents";
 import { useBadgeSync } from "../hooks/useBadgeSync";
 
@@ -87,24 +83,27 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     // Tear down WebSocket before clearing auth state
     destroySharedSocket();
 
-    // Reset stores and caches to prevent data leaking between users
+    // Reset in-memory Zustand state so screens unmount with a clean slate.
+    // The on-disk caches are wiped by AppResetService below, but the
+    // resident state needs an explicit reset since the stores aren't
+    // persisted via AsyncStorage middleware.
     useConversationsStore.getState().reset();
     usePresenceStore.getState().reset();
     useModerationStore.getState().reset();
     useCallsStore.getState().reset();
-    await cacheService.clearCache();
-    await offlineQueue.clearAll();
-    await AsyncStorage.removeItem("@whispr/manually_unread_ids");
-    await profileSetupFlag.clear();
 
+    // Best-effort server-side logout. Swallow failures so the local
+    // cleanup still happens if the server is unreachable.
     if (state.deviceId && state.userId) {
-      await AuthService.logout(state.deviceId, state.userId);
-    } else {
-      await TokenService.clearTokens();
+      await AuthService.logout(state.deviceId, state.userId).catch(() => {});
     }
-    // Drop the per-device Signal identity private key — it is bound to the
-    // session that just ended and must not leak into the next account.
-    await TokenService.clearIdentityPrivateKey();
+
+    // WHISPR-1221 — sweep every per-account key under our prefixes
+    // (settings, caches, queued messages, manually-unread set, profile
+    // setup flag, tokens, Signal identity key, …). Allowlist preserves
+    // theme + language only.
+    await AppResetService.resetAppData();
+
     setState({
       isAuthenticated: false,
       isLoading: false,

--- a/src/services/AppResetService.ts
+++ b/src/services/AppResetService.ts
@@ -1,18 +1,53 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { TokenService } from "./TokenService";
 
-const ASYNC_STORAGE_KEYS = [
-  "whispr.profile.v1",
-  "whispr.conversations.cache",
-  "whispr.conversations.cache.timestamp",
-] as const;
+// Keys that survive a sign-out. The list must stay tight: anything not in
+// here that lives under one of the OWNED_PREFIXES will be wiped on logout.
+//
+// `whispr.globalSettings.v1` carries the language and theme — preferences
+// that aren't tied to a specific account and that users would resent
+// having to re-set after every sign-out.
+const PRESERVED_KEYS: ReadonlySet<string> = new Set([
+  "whispr.globalSettings.v1",
+]);
+
+// Every key written by this app uses one of these prefixes. Anything
+// outside the prefixes belongs to React Native or a vendor library and
+// MUST NOT be touched (Expo Constants caches, Metro state, etc.).
+const OWNED_PREFIXES: readonly string[] = ["whispr.", "@whispr"];
+
+function isOwned(key: string): boolean {
+  return OWNED_PREFIXES.some((prefix) => key.startsWith(prefix));
+}
 
 export const AppResetService = {
+  /**
+   * Wipe per-account state. Called from `AuthContext.signOut()` to make sure
+   * a fresh login on the same device starts from a clean slate (no stale
+   * settings, no leftover caches, no previous user's identity material).
+   *
+   * Two-step cleanup:
+   *   1. `AsyncStorage.getAllKeys()` filtered by prefix + allowlist. This
+   *      catches every `whispr.*` / `@whispr*` key automatically — caches
+   *      that get added later are covered without an audit.
+   *   2. `TokenService.clearAll()` so the secure-store / encrypted-vault
+   *      backed values (access/refresh tokens + Signal identity private
+   *      key) are removed via the right backend on each platform.
+   */
   async resetAppData(): Promise<void> {
-    await Promise.all([
-      TokenService.clearTokens(),
-      AsyncStorage.removeItem("whispr.device.id"),
-      ...ASYNC_STORAGE_KEYS.map((k) => AsyncStorage.removeItem(k)),
-    ]);
+    try {
+      const keys = await AsyncStorage.getAllKeys();
+      const toRemove = keys.filter(
+        (key) => isOwned(key) && !PRESERVED_KEYS.has(key),
+      );
+      if (toRemove.length > 0) {
+        await AsyncStorage.multiRemove(toRemove);
+      }
+    } catch {
+      // Best-effort: if AsyncStorage is unavailable, fall through to the
+      // token cleanup so at minimum the session credentials are gone.
+    }
+
+    await TokenService.clearAll();
   },
 };


### PR DESCRIPTION
AuthContext.signOut() ne nettoyait que quelques clés à la main (@whispr/manually_unread_ids, profileSetupFlag, tokens, identity key). Beaucoup d'autres restaient pour le compte suivant qui se connectait sur le même device : @whispr_settings_*, whispr.profile.v1, le cache conversations, l'offline queue, le pendingAvatarKey du MyProfile, etc. Sur device partagé, le compte B héritait des préférences UI et caches du compte A.

- AppResetService.resetAppData() : sweep AsyncStorage.getAllKeys() → multiRemove pour toute clé qui commence par "whispr." ou "@whispr". Allowlist explicite : "whispr.globalSettings.v1" (langue + thème, préférences device-locales sans lien au compte).
- TokenService.clearAll() conservé en fallback pour les valeurs en SecureStore (natif) / vault chiffré (web 1212).
- AuthContext.signOut() : remplace les nettoyages éparpillés par un seul appel AppResetService.resetAppData(). Stores Zustand toujours reset() en mémoire (pas persistés sur disque).
- 5 tests AppResetService : sweep complet avec préservation de l'allowlist, ignore les clés tierces (Expo / RN), fail-soft si AsyncStorage casse, edge cases de préfixe.

WHISPR-1221