### PR TITLE
fix(notifications): user_id explicite + await unregister borné au logout

### DIFF
--- a/AuthService.test.ts
+++ b/AuthService.test.ts
@@ -242,6 +242,54 @@ describe("AuthService.logout", () => {
 
     expect(mockedToken.clearTokens).toHaveBeenCalled();
   });
+
+  // WHISPR-1217 — closes the shared-device race where the next user could
+  // sign in before the previous user's device row was unregistered.
+  it("awaits unregisterDevice before clearing tokens (no fire-and-forget)", async () => {
+    mockedToken.getAccessToken.mockResolvedValue("at");
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 204 }));
+
+    const order: string[] = [];
+    const mockedNotif = require("./src/services/NotificationService")
+      .NotificationService as any;
+    mockedNotif.unregisterDevice.mockImplementation(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+      order.push("unregister-resolved");
+    });
+    mockedToken.clearTokens.mockImplementation(async () => {
+      order.push("tokens-cleared");
+    });
+
+    await AuthService.logout("dev-1", "user-1");
+
+    // unregister MUST have settled before tokens are cleared, otherwise a
+    // racing signIn on the same device would re-register before the old
+    // row is gone.
+    expect(order).toEqual(["unregister-resolved", "tokens-cleared"]);
+  });
+
+  it("times out the unregister at 5s instead of blocking logout forever", async () => {
+    jest.useFakeTimers();
+    mockedToken.getAccessToken.mockResolvedValue("at");
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 204 }));
+
+    const mockedNotif = require("./src/services/NotificationService")
+      .NotificationService as any;
+    // Hang forever — simulates a stalled connection.
+    mockedNotif.unregisterDevice.mockImplementation(
+      () => new Promise(() => {}),
+    );
+
+    const logoutPromise = AuthService.logout("dev-1", "user-1");
+
+    // Advance past the 5s ceiling so the timeout reject fires.
+    await jest.advanceTimersByTimeAsync(6000);
+
+    await expect(logoutPromise).resolves.toBeUndefined();
+    expect(mockedToken.clearTokens).toHaveBeenCalled();
+
+    jest.useRealTimers();
+  });
 });
 
 describe("AuthService.validateSession", () => {

--- a/NotificationService.test.ts
+++ b/NotificationService.test.ts
@@ -115,7 +115,7 @@ describe("NotificationService.unmuteConversation", () => {
 });
 
 describe("NotificationService.registerDevice / unregisterDevice", () => {
-  it("POSTs the token with device_id, platform, app_version", async () => {
+  it("POSTs the token with device_id, platform, app_version, user_id", async () => {
     const mockedDevice = require("./src/services/DeviceService")
       .DeviceService as any;
     mockedDevice.getOrCreateDeviceId.mockResolvedValue("dev-xyz");
@@ -123,6 +123,7 @@ describe("NotificationService.registerDevice / unregisterDevice", () => {
 
     await NotificationService.registerDevice({
       token: "fcm-tok",
+      userId: "user-42",
       platform: "android",
       appVersion: "1.2.3",
     });
@@ -135,6 +136,7 @@ describe("NotificationService.registerDevice / unregisterDevice", () => {
       fcm_token: "fcm-tok",
       platform: "android",
       app_version: "1.2.3",
+      user_id: "user-42",
     });
   });
 

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -99,7 +99,10 @@ export const AuthService = {
 
     await TokenService.saveTokens(tokens);
     sessionDead = false;
-    NotificationService.initPushRegistration().catch(() => {});
+    const userId = TokenService.decodeAccessToken(tokens.accessToken)?.sub;
+    if (userId) {
+      NotificationService.initPushRegistration(userId).catch(() => {});
+    }
     return tokens;
   },
 
@@ -120,7 +123,10 @@ export const AuthService = {
 
     await TokenService.saveTokens(tokens);
     sessionDead = false;
-    NotificationService.initPushRegistration().catch(() => {});
+    const userId = TokenService.decodeAccessToken(tokens.accessToken)?.sub;
+    if (userId) {
+      NotificationService.initPushRegistration(userId).catch(() => {});
+    }
     return tokens;
   },
 
@@ -199,8 +205,24 @@ export const AuthService = {
 
   async logout(deviceId: string, userId: string): Promise<void> {
     const token = await TokenService.getAccessToken();
-    await NotificationService.unregisterDevice(deviceId).catch(() => {});
+
+    // WHISPR-1217 — properly await the unregister so a fresh login on the
+    // same device can't race ahead while the server still has the previous
+    // user's row. We bound the wait at 5 s so a hung connection can't
+    // block logout indefinitely. Failures are logged (vs. swallowed
+    // silently) so shared-device misroute reports are debuggable.
+    try {
+      await Promise.race([
+        NotificationService.unregisterDevice(deviceId),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("UNREGISTER_TIMEOUT")), 5000),
+        ),
+      ]);
+    } catch (err) {
+      console.warn("[AuthService] unregisterDevice failed:", err);
+    }
     NotificationService.tearDownPushRegistration();
+
     await apiFetch("/logout", {
       method: "POST",
       token: token ?? undefined,

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -102,6 +102,11 @@ export interface BadgeCountResponse {
 
 export interface RegisterDeviceParams {
   token: string;
+  // WHISPR-1217 — passed explicitly from initPushRegistration so the
+  // backend can assert body.user_id == claims.sub. Today the backend
+  // overwrites it with the JWT sub anyway, but the field is in place
+  // so a future tightening doesn't need a coordinated client release.
+  userId: string;
   platform?: "android" | "ios";
   deviceId?: string;
   appVersion?: string;
@@ -197,6 +202,7 @@ export const NotificationService = {
         fcm_token: params.token,
         platform,
         app_version: appVersion,
+        user_id: params.userId,
       }),
     });
   },
@@ -219,7 +225,7 @@ export const NotificationService = {
    *
    * No-op sur web ou si `expo-notifications` n'est pas disponible.
    */
-  async initPushRegistration(): Promise<void> {
+  async initPushRegistration(userId: string): Promise<void> {
     const mod = loadExpoNotifications();
     if (!mod) return;
 
@@ -232,15 +238,19 @@ export const NotificationService = {
 
       const native = await mod.getDevicePushTokenAsync();
       if (native?.data) {
-        await NotificationService.registerDevice({ token: native.data });
+        await NotificationService.registerDevice({
+          token: native.data,
+          userId,
+        });
       }
 
       if (!tokenRotationSub) {
         tokenRotationSub = mod.addPushTokenListener((t) => {
           if (t?.data) {
-            NotificationService.registerDevice({ token: t.data }).catch(
-              () => {},
-            );
+            NotificationService.registerDevice({
+              token: t.data,
+              userId,
+            }).catch(() => {});
           }
         });
       }


### PR DESCRIPTION
Race sur device partagé : logout fire-and-forget sur unregisterDevice permettait à l'utilisateur suivant de se connecter avant que la ligne device de l'ancien soit supprimée — symptôme : appels/messages destinés à B sonnaient sur l'appareil de A.

- registerDevice : nouveau paramètre `userId` requis, propagé dans le body en `user_id`. Le backend l'ignore aujourd'hui (récupéré du JWT sub puis écrasé), mais la ligne est en place pour qu'un futur durci côté notification-service (validation user_id == claims.sub) n'ait pas besoin de release client coordonné.
- initPushRegistration(userId) : signature qui exige le userId au moment de l'appel. AuthService.register/login le décode du accessToken via TokenService.decodeAccessToken().sub.
- AuthService.logout : `await` réel via Promise.race avec timeout 5 s. Échec / timeout loggé en console.warn (vs. .catch(() => {}) muet) pour rendre les bug reports "shared device misroute" debuggables.
- Le retry-on-next-boot mentionné dans le ticket est laissé en follow-up : il demande de persister un access token déjà signé out pour ré-authentifier le DELETE, soit un compromis sécu/complexité qui dépasse 1217.

3 nouveaux tests (registerDevice body avec user_id, logout attend unregister avant clearTokens, logout timeout ne bloque pas indéfiniment). 721 tests verts.

WHISPR-1217