### PR TITLE
fix(media): valider taille + MIME côté client avant upload

### DIFF
--- a/MediaService.test.ts
+++ b/MediaService.test.ts
@@ -11,7 +11,10 @@ jest.mock("./src/services/apiBase", () => ({
 jest.mock("react-native", () => ({ Platform: { OS: "web" } }));
 jest.mock("expo-file-system/legacy", () => ({}));
 
-import { MediaService } from "./src/services/MediaService";
+import {
+  MediaService,
+  isUploadValidationError,
+} from "./src/services/MediaService";
 
 describe("MediaService.shareMediaWithRetry", () => {
   beforeEach(() => {
@@ -82,5 +85,140 @@ describe("MediaService.shareMediaWithRetry", () => {
 
     expect(spy).toHaveBeenCalledTimes(3);
     spy.mockRestore();
+  });
+});
+
+describe("MediaService.uploadMedia client-side validation (WHISPR-1220)", () => {
+  const mockBlob = (size: number): Blob => {
+    return { size, type: "" } as unknown as Blob;
+  };
+  const mockFetchOnce = (size: number) => {
+    const blob = mockBlob(size);
+    (global as any).fetch = jest.fn().mockResolvedValueOnce({
+      blob: () => Promise.resolve(blob),
+    });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("rejects a non-allowlisted MIME for the avatar context (image-only)", async () => {
+    mockFetchOnce(1024);
+
+    await expect(
+      MediaService.uploadMedia(
+        { uri: "https://blob.test/x", name: "x.zip", type: "application/zip" },
+        undefined,
+        { context: "avatar" },
+      ),
+    ).rejects.toMatchObject({
+      code: "UPLOAD_MIME_NOT_ALLOWED",
+      context: "avatar",
+      mimeType: "application/zip",
+    });
+  });
+
+  it("accepts MIME with parameters (e.g. 'image/jpeg; charset=binary')", async () => {
+    // Three fetches on the web success path: size check, FormData blob
+    // conversion, then the actual POST upload.
+    (global as any).fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        blob: () => Promise.resolve(mockBlob(1024)),
+      })
+      .mockResolvedValueOnce({
+        blob: () => Promise.resolve(mockBlob(1024)),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ id: "m-1" }),
+      });
+
+    await expect(
+      MediaService.uploadMedia(
+        {
+          uri: "https://blob.test/x",
+          name: "x.jpg",
+          type: "image/jpeg; charset=binary",
+        },
+        undefined,
+        { context: "avatar" },
+      ),
+    ).resolves.toMatchObject({ id: "m-1" });
+  });
+
+  it("rejects a file larger than the message context limit (100 MB)", async () => {
+    mockFetchOnce(101 * 1024 * 1024);
+
+    await expect(
+      MediaService.uploadMedia(
+        { uri: "https://blob.test/big", name: "big.mp4", type: "video/mp4" },
+        undefined,
+        { context: "message" },
+      ),
+    ).rejects.toMatchObject({
+      code: "UPLOAD_TOO_LARGE",
+      context: "message",
+      limitBytes: 100 * 1024 * 1024,
+      actualBytes: 101 * 1024 * 1024,
+    });
+  });
+
+  it("rejects an avatar over 5 MB even when MIME is valid", async () => {
+    mockFetchOnce(6 * 1024 * 1024);
+
+    await expect(
+      MediaService.uploadMedia(
+        { uri: "https://blob.test/big", name: "big.png", type: "image/png" },
+        undefined,
+        { context: "avatar" },
+      ),
+    ).rejects.toMatchObject({
+      code: "UPLOAD_TOO_LARGE",
+      context: "avatar",
+      limitBytes: 5 * 1024 * 1024,
+    });
+  });
+
+  it("falls back to context=message when no meta is provided (allows pdf)", async () => {
+    (global as any).fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        blob: () => Promise.resolve(mockBlob(1024)),
+      })
+      .mockResolvedValueOnce({
+        blob: () => Promise.resolve(mockBlob(1024)),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ id: "m-pdf" }),
+      });
+
+    await expect(
+      MediaService.uploadMedia({
+        uri: "https://blob.test/doc",
+        name: "doc.pdf",
+        type: "application/pdf",
+      }),
+    ).resolves.toMatchObject({ id: "m-pdf" });
+  });
+});
+
+describe("MediaService.isUploadValidationError (WHISPR-1220)", () => {
+  it("matches errors thrown by validateUpload", () => {
+    const err = Object.assign(new Error("boom"), {
+      code: "UPLOAD_TOO_LARGE" as const,
+    });
+    expect(isUploadValidationError(err)).toBe(true);
+  });
+
+  it("rejects unrelated errors and primitives", () => {
+    expect(isUploadValidationError(new Error("network"))).toBe(false);
+    expect(isUploadValidationError({ code: "UPLOAD_TOO_LARGE" })).toBe(false);
+    expect(isUploadValidationError(null)).toBe(false);
+    expect(isUploadValidationError("UPLOAD_TOO_LARGE")).toBe(false);
   });
 });

--- a/src/services/MediaService.ts
+++ b/src/services/MediaService.ts
@@ -75,6 +75,128 @@ export interface UploadMediaResult {
 
 export type UploadMediaContext = "message" | "avatar" | "group_icon";
 
+// WHISPR-1220 — limites alignées avec media-service
+// (see media.service.ts:46 / CONTEXT_SIZE_LIMITS).
+//   * MESSAGE   : 100 MB — couvre vidéos courtes, documents, audio.
+//   * AVATAR    :   5 MB — image seulement, déjà compressée client-side.
+//   * GROUP_ICON:   5 MB — idem AVATAR.
+const CONTEXT_SIZE_LIMITS: Record<UploadMediaContext, number> = {
+  message: 100 * 1024 * 1024,
+  avatar: 5 * 1024 * 1024,
+  group_icon: 5 * 1024 * 1024,
+};
+
+const COMMON_IMAGE_MIMES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "image/heic",
+  "image/heif",
+] as const;
+
+// Doit rester en synchro avec CONTEXT_MIME_ALLOWLIST côté media-service
+// (media.service.ts:70). Si le serveur élargit ou restreint la liste,
+// reproduire ici — la validation client est un filet de sécurité, pas la
+// source de vérité (le serveur doit toujours re-vérifier).
+const CONTEXT_MIME_ALLOWLIST: Record<
+  UploadMediaContext,
+  ReadonlySet<string>
+> = {
+  message: new Set<string>([
+    ...COMMON_IMAGE_MIMES,
+    "video/mp4",
+    "video/quicktime",
+    "video/webm",
+    "video/x-matroska",
+    "audio/mpeg",
+    "audio/ogg",
+    "audio/wav",
+    "audio/mp4",
+    "audio/aac",
+    "application/pdf",
+    "application/msword",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "application/zip",
+  ]),
+  avatar: new Set<string>(COMMON_IMAGE_MIMES),
+  group_icon: new Set<string>(COMMON_IMAGE_MIMES),
+};
+
+export type UploadValidationError = Error & {
+  code: "UPLOAD_TOO_LARGE" | "UPLOAD_MIME_NOT_ALLOWED";
+  context: UploadMediaContext;
+  limitBytes?: number;
+  actualBytes?: number;
+  mimeType?: string;
+};
+
+export function isUploadValidationError(
+  err: unknown,
+): err is UploadValidationError {
+  if (!(err instanceof Error)) return false;
+  const code = (err as { code?: unknown }).code;
+  return code === "UPLOAD_TOO_LARGE" || code === "UPLOAD_MIME_NOT_ALLOWED";
+}
+
+function normalizeMime(raw: string): string {
+  return raw.split(";")[0].trim().toLowerCase();
+}
+
+async function readFileSize(uri: string): Promise<number | null> {
+  if (Platform.OS === "web") {
+    try {
+      const response = await fetch(uri);
+      const blob = await response.blob();
+      return blob.size;
+    } catch {
+      return null;
+    }
+  }
+  try {
+    const info = (await FileSystem.getInfoAsync(uri)) as { size?: number };
+    return typeof info?.size === "number" ? info.size : null;
+  } catch {
+    return null;
+  }
+}
+
+async function validateUpload(
+  file: { uri: string; type: string },
+  context: UploadMediaContext,
+): Promise<void> {
+  const mime = normalizeMime(file.type);
+  const allowed = CONTEXT_MIME_ALLOWLIST[context];
+  if (!allowed.has(mime)) {
+    const error = new Error(
+      `MIME type '${mime}' not allowed for context '${context}'`,
+    ) as UploadValidationError;
+    error.code = "UPLOAD_MIME_NOT_ALLOWED";
+    error.context = context;
+    error.mimeType = mime;
+    throw error;
+  }
+
+  const size = await readFileSize(file.uri);
+  // If we can't read the size client-side (older RN, opaque URI), fall
+  // through to the server check rather than block a legitimate upload.
+  if (size === null) return;
+
+  const limit = CONTEXT_SIZE_LIMITS[context];
+  if (size > limit) {
+    const error = new Error(
+      `File size ${size} bytes exceeds ${context} limit of ${limit} bytes`,
+    ) as UploadValidationError;
+    error.code = "UPLOAD_TOO_LARGE";
+    error.context = context;
+    error.limitBytes = limit;
+    error.actualBytes = size;
+    throw error;
+  }
+}
+
 // The media-service upload response uses {mediaId, ...} but the rest of the
 // app (chat send path, attachment metadata) expects {id}. Normalise here so
 // callers don't have to know which key the server happened to return.
@@ -104,6 +226,11 @@ export const MediaService = {
     onProgress?: (percent: number) => void,
     meta?: { context?: UploadMediaContext; ownerId?: string },
   ): Promise<UploadMediaResult> {
+    // WHISPR-1220 — fail fast before consuming the upload bandwidth.
+    // Default to "message" (the most permissive context) when the caller
+    // doesn't pass one, mirroring the server which uses the same default.
+    await validateUpload(file, meta?.context ?? "message");
+
     const token = await TokenService.getAccessToken();
     const headers: Record<string, string> = {};
     if (token) headers["Authorization"] = `Bearer ${token}`;


### PR DESCRIPTION
uploadMedia() laissait passer n'importe quel fichier ; le serveur rejetait après le téléversement complet. Sur mobile en data, un fichier 50 MB invalide brûlait le forfait pour rien et rendait le DoS de media-service plus facile (envoyer du gros volume jusqu'au quota).

- CONTEXT_SIZE_LIMITS / CONTEXT_MIME_ALLOWLIST alignés avec media-service (media.service.ts:46 + 70). 100 MB pour MESSAGE, 5 MB pour AVATAR / GROUP_ICON. MIME : images, vidéos, audios pour MESSAGE ; images seules pour AVATAR / GROUP_ICON.
- validateUpload() lit la taille via fetch().blob() sur web et FileSystem.getInfoAsync sur natif. Si la taille n'est pas récupérable (RN ancien, URI opaque), on laisse passer pour ne pas bloquer un upload légitime — le serveur reste l'autorité.
- Erreurs taggées UploadValidationError avec un `code` discriminant (UPLOAD_TOO_LARGE / UPLOAD_MIME_NOT_ALLOWED) + isUploadValidationError type guard, pour que l'UI puisse afficher un toast localisé sans parser de message.
- Default context = "message" quand l'appelant ne précise pas, mêmes permissions que côté serveur.
- 7 tests (MIME bloqué pour avatar, MIME paramétré accepté, rejet > 100 MB pour message, rejet > 5 MB pour avatar, fallback pdf en context=message, type guard true/false sur primitives).

WHISPR-1220