### PR TITLE
fix(auth): backoff exponentiel sur refresh transitoire + fail-fast ap…

### DIFF
--- a/AuthService.test.ts
+++ b/AuthService.test.ts
@@ -221,6 +221,107 @@ describe("AuthService.refreshTokens", () => {
   });
 });
 
+describe("AuthService.refreshTokens transient backoff (WHISPR-1218)", () => {
+  it("a single 503 enters cooldown — next call fails fast without hitting the network", async () => {
+    mockedToken.getRefreshToken.mockResolvedValue("rt");
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ status: 503, body: { message: "down" } }),
+    );
+
+    await expect(AuthService.refreshTokens()).rejects.toThrow();
+    expect(mockedEmitSessionExpired).not.toHaveBeenCalled();
+
+    // Second call within the cooldown window — must NOT issue a new fetch.
+    mockFetch.mockClear();
+    await expect(AuthService.refreshTokens()).rejects.toThrow(
+      "AUTH_UNREACHABLE",
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("after MAX_TRANSIENT_FAILURES (3) consecutive 503, declares auth_unreachable", async () => {
+    jest.useFakeTimers();
+    mockedToken.getRefreshToken.mockResolvedValue("rt");
+
+    // Three 503s, with a fake-timer advance between each to clear the cooldown.
+    for (let i = 0; i < 3; i++) {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({ status: 503, body: { message: "down" } }),
+      );
+      await expect(AuthService.refreshTokens()).rejects.toThrow();
+      // Skip past the exponential backoff (max 4 s on attempt 3).
+      await jest.advanceTimersByTimeAsync(10_000);
+    }
+
+    expect(mockedEmitSessionExpired).toHaveBeenCalledWith("auth_unreachable");
+    // Subsequent calls fast-fail with SESSION_EXPIRED (sessionDead path).
+    await expect(AuthService.refreshTokens()).rejects.toThrow(
+      "SESSION_EXPIRED",
+    );
+
+    jest.useRealTimers();
+  });
+
+  it("network error (status undefined) counts as a transient failure", async () => {
+    mockedToken.getRefreshToken.mockResolvedValue("rt");
+    // Throw a bare Error (no .status) — mimics fetch network rejection that
+    // apiFetch would re-throw.
+    mockFetch.mockRejectedValueOnce(new Error("connection refused"));
+
+    await expect(AuthService.refreshTokens()).rejects.toThrow();
+
+    // Cooldown is now active — refresh fast-fails without network.
+    mockFetch.mockClear();
+    await expect(AuthService.refreshTokens()).rejects.toThrow(
+      "AUTH_UNREACHABLE",
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("a successful refresh after a transient failure clears the backoff state", async () => {
+    jest.useFakeTimers();
+    mockedToken.getRefreshToken.mockResolvedValue("rt");
+
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 503 }));
+    await expect(AuthService.refreshTokens()).rejects.toThrow();
+
+    await jest.advanceTimersByTimeAsync(2_000);
+
+    mockFetch.mockResolvedValueOnce(mockResponse({ body: makeTokenPair() }));
+    await expect(AuthService.refreshTokens()).resolves.toBeUndefined();
+
+    // Counter is back to zero — a fresh 503 should be the first transient,
+    // not the fourth (which would trip auth_unreachable).
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 503 }));
+    await expect(AuthService.refreshTokens()).rejects.toThrow();
+    expect(mockedEmitSessionExpired).not.toHaveBeenCalledWith(
+      "auth_unreachable",
+    );
+
+    jest.useRealTimers();
+  });
+
+  it("a 400 (programming-error 4xx) does NOT poison the transient counter", async () => {
+    jest.useFakeTimers();
+    mockedToken.getRefreshToken.mockResolvedValue("rt");
+
+    // Two 400s — shouldn't enter cooldown, shouldn't increment the counter.
+    for (let i = 0; i < 2; i++) {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({ status: 400, body: { message: "bad request" } }),
+      );
+      await expect(AuthService.refreshTokens()).rejects.toThrow();
+    }
+    // Now a third 400 — still no auth_unreachable.
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 400 }));
+    await expect(AuthService.refreshTokens()).rejects.toThrow();
+
+    expect(mockedEmitSessionExpired).not.toHaveBeenCalled();
+
+    jest.useRealTimers();
+  });
+});
+
 describe("AuthService.logout", () => {
   it("POSTs /logout with token and clears tokens afterwards", async () => {
     mockedToken.getAccessToken.mockResolvedValue("at");

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -60,6 +60,27 @@ let refreshPromise: Promise<void> | null = null;
 // refresh loop. Reset on every successful login/register.
 let sessionDead = false;
 
+// WHISPR-1218 — backoff state for transient backend failures (5xx /
+// network). 401/403 still goes straight to sessionDead because that's
+// auth saying "no", not "I'm down".
+const MAX_TRANSIENT_FAILURES = 3;
+const COOLDOWN_BASE_MS = 1000;
+let consecutiveTransientFailures = 0;
+let cooldownUntil = 0;
+
+function resetSessionState(): void {
+  sessionDead = false;
+  consecutiveTransientFailures = 0;
+  cooldownUntil = 0;
+}
+
+// Treat undefined status (network error) and 5xx as transient. Other
+// 4xx (e.g. 400 bad-request) are programming errors and shouldn't poison
+// the backoff counter — let them propagate without state change.
+function isTransientFailure(status: number | undefined): boolean {
+  return status === undefined || status >= 500;
+}
+
 export const AuthService = {
   async requestVerification(
     phoneNumber: string,
@@ -98,7 +119,7 @@ export const AuthService = {
     });
 
     await TokenService.saveTokens(tokens);
-    sessionDead = false;
+    resetSessionState();
     const userId = TokenService.decodeAccessToken(tokens.accessToken)?.sub;
     if (userId) {
       NotificationService.initPushRegistration(userId).catch(() => {});
@@ -122,7 +143,7 @@ export const AuthService = {
     });
 
     await TokenService.saveTokens(tokens);
-    sessionDead = false;
+    resetSessionState();
     const userId = TokenService.decodeAccessToken(tokens.accessToken)?.sub;
     if (userId) {
       NotificationService.initPushRegistration(userId).catch(() => {});
@@ -136,6 +157,13 @@ export const AuthService = {
     // event → every screen that is still mounted fetches again → loop.
     if (sessionDead) {
       throw new Error("SESSION_EXPIRED");
+    }
+    // WHISPR-1218 — short-circuit during the cooldown that follows
+    // transient (5xx / network) failures. Without this, every 401 from
+    // an in-flight HTTP call would re-trigger refresh → 5xx → repeat,
+    // hammering an already-degraded auth-service.
+    if (cooldownUntil > Date.now()) {
+      throw new Error("AUTH_UNREACHABLE");
     }
     if (refreshPromise) return refreshPromise;
 
@@ -154,24 +182,47 @@ export const AuthService = {
             body: JSON.stringify({ refreshToken }),
           });
           await TokenService.saveTokens(tokens);
+          // Healthy response — clear any pending backoff state.
+          consecutiveTransientFailures = 0;
+          cooldownUntil = 0;
         } catch (err) {
-          // Refresh failed (401 / token revoked / fingerprint mismatch).
-          // Clear local tokens once, emit sessionExpired once, and mark the
-          // session dead so subsequent callers short-circuit above.
           const status = (err as { status?: number })?.status;
           console.error(
             "[AuthService] refreshTokens failed, status=",
             status,
             err,
           );
+
           if (status === 401 || status === 403) {
+            // Auth said "no" — session genuinely dead.
             sessionDead = true;
             await TokenService.clearTokens();
             emitSessionExpired("refresh_failed");
             console.warn(
               "[AuthService] tokens cleared, sessionExpired event emitted",
             );
+          } else if (isTransientFailure(status)) {
+            // 5xx or network — auth-service is unreachable, not refusing.
+            consecutiveTransientFailures += 1;
+            if (consecutiveTransientFailures >= MAX_TRANSIENT_FAILURES) {
+              // Stop hammering — declare unreachable and bounce the user.
+              sessionDead = true;
+              emitSessionExpired("auth_unreachable");
+              console.warn(
+                "[AuthService] auth-service unreachable after",
+                consecutiveTransientFailures,
+                "attempts; sessionExpired emitted",
+              );
+            } else {
+              // Exponential backoff: 1 s, 2 s, 4 s.
+              cooldownUntil =
+                Date.now() +
+                COOLDOWN_BASE_MS *
+                  Math.pow(2, consecutiveTransientFailures - 1);
+            }
           }
+          // Other 4xx (400/404/etc.) are bugs, not retry-worthy — let
+          // them propagate without poisoning the backoff state.
           throw err;
         }
       } finally {


### PR DESCRIPTION
…rès 3 échecs

Avant : refreshTokens ne marquait sessionDead que sur 401/403. Pour 5xx ou erreurs réseau, le rejet remontait sans changer d'état — donc le prochain 401 d'une requête HTTP en vol re-déclenchait refresh → re-503 → tempête de requêtes vers un auth-service déjà KO.

- Compteur consecutiveTransientFailures + cooldownUntil module-level.
- Échec transitoire (status undefined ou >= 500) : incrémenter le compteur et ouvrir un cooldown exponentiel (1 s, 2 s, 4 s). Pendant le cooldown, refreshTokens throw "AUTH_UNREACHABLE" sans réseau.
- Au seuil de 3 échecs consécutifs : sessionDead = true et emit sessionExpired("auth_unreachable") — l'utilisateur est bouncé vers login plutôt que de boucler indéfiniment.
- 401/403 : comportement inchangé (sessionDead immédiat, emit "refresh_failed").
- Autres 4xx (400/404…) : laissés passer sans toucher au compteur — ce sont des bugs, pas des conditions transitoires.
- Succès : reset du compteur et du cooldown.
- resetSessionState() centralise le reset, appelé depuis register et login (avant : sessionDead = false en ligne).

5 nouveaux tests : 503 unique → cooldown ; 3×503 → auth_unreachable ; network error compté comme transient ; reset après succès ; 400 ne poison pas le compteur. 733 tests verts.

WHISPR-1218