### PR TITLE
fix(offline-queue): mutex sur drainAll + UUID client_message_id à l'e…

### DIFF
--- a/offlineQueue.test.ts
+++ b/offlineQueue.test.ts
@@ -105,6 +105,102 @@ describe("offlineQueue.drainAll (WHISPR-1060)", () => {
   });
 });
 
+describe("offlineQueue.drainAll concurrency lock (WHISPR-1219)", () => {
+  it("rejects a concurrent invocation with skipped=true and only sends each message once", async () => {
+    await offlineQueue.enqueue(makeMessage({ client_random: 51 }));
+    await offlineQueue.enqueue(makeMessage({ client_random: 52 }));
+
+    let resolveFirst: () => void = () => {};
+    const sendFn = jest.fn(
+      (_msg: QueuedMessage) =>
+        new Promise<void>((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+
+    // Start the first drain — it will await sendFn for the first message.
+    const first = offlineQueue.drainAll(sendFn);
+    // Yield so the first drain reaches the `await sendFn(...)`.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Second drain fires while the first is in flight. It must short-circuit.
+    const second = await offlineQueue.drainAll(sendFn);
+    expect(second).toEqual({ sent: 0, failed: 0, skipped: true });
+
+    // Now let the first drain finish.
+    resolveFirst();
+    // Resolve any remaining sendFn calls in the loop.
+    sendFn.mockImplementation(() => Promise.resolve());
+    const firstResult = await first;
+
+    expect(firstResult).toEqual({ sent: 2, failed: 0 });
+    // sendFn was called for each of the 2 messages — never doubled by the
+    // concurrent call.
+    expect(sendFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases the lock after a successful drain so the next call can run", async () => {
+    await offlineQueue.enqueue(makeMessage({ client_random: 61 }));
+    const sendFn = jest.fn().mockResolvedValue(undefined);
+
+    const first = await offlineQueue.drainAll(sendFn);
+    expect(first).toEqual({ sent: 1, failed: 0 });
+
+    // Re-enqueue and drain again — second call must NOT report skipped.
+    await offlineQueue.enqueue(makeMessage({ client_random: 62 }));
+    const second = await offlineQueue.drainAll(sendFn);
+    expect(second.skipped).toBeUndefined();
+    expect(second.sent).toBe(1);
+  });
+
+  it("releases the lock when sendFn throws synchronously inside the promise", async () => {
+    await offlineQueue.enqueue(makeMessage({ client_random: 71 }));
+    // sendFn always rejects → all messages stay pending, but the lock
+    // must still be released.
+    const sendFn = jest.fn().mockRejectedValue(new Error("network"));
+    await offlineQueue.drainAll(sendFn);
+
+    // Subsequent drain: sendFn will succeed this time. If the lock had
+    // leaked, this call would short-circuit with skipped=true.
+    sendFn.mockResolvedValue(undefined);
+    const result = await offlineQueue.drainAll(sendFn);
+    expect(result.skipped).toBeUndefined();
+    expect(result.sent).toBe(1);
+  });
+});
+
+describe("offlineQueue.enqueue client_message_id (WHISPR-1219)", () => {
+  it("auto-generates a UUID v4 client_message_id when not provided", async () => {
+    await offlineQueue.enqueue(makeMessage({ client_random: 81 }));
+    const [persisted] = await offlineQueue.getAll();
+
+    expect(persisted.client_message_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it("preserves an explicit client_message_id passed in by the caller", async () => {
+    await offlineQueue.enqueue(
+      makeMessage({
+        client_random: 82,
+        client_message_id: "00000000-0000-4000-8000-000000000000",
+      }),
+    );
+    const [persisted] = await offlineQueue.getAll();
+    expect(persisted.client_message_id).toBe(
+      "00000000-0000-4000-8000-000000000000",
+    );
+  });
+
+  it("gives different UUIDs to two messages enqueued back-to-back", async () => {
+    await offlineQueue.enqueue(makeMessage({ client_random: 83 }));
+    await offlineQueue.enqueue(makeMessage({ client_random: 84 }));
+    const [a, b] = await offlineQueue.getAll();
+    expect(a.client_message_id).not.toEqual(b.client_message_id);
+  });
+});
+
 describe("offlineQueue.getAll", () => {
   it("returns an empty array when nothing is persisted", async () => {
     await expect(offlineQueue.getAll()).resolves.toEqual([]);

--- a/src/hooks/useOfflineQueueDrainer.ts
+++ b/src/hooks/useOfflineQueueDrainer.ts
@@ -31,16 +31,20 @@ export function useOfflineQueueDrainer(): void {
       if (inFlight.current) return;
       inFlight.current = true;
       try {
-        const { sent, failed } = await offlineQueue.drainAll(async (queued) => {
-          await messagingAPI.sendMessage(queued.conversation_id, {
-            content: queued.content,
-            message_type: queued.message_type,
-            client_random: queued.client_random,
-            metadata: {},
-            reply_to_id: queued.reply_to_id,
-          });
-        });
-        if (sent > 0 || failed > 0) {
+        const { sent, failed, skipped } = await offlineQueue.drainAll(
+          async (queued) => {
+            await messagingAPI.sendMessage(queued.conversation_id, {
+              content: queued.content,
+              message_type: queued.message_type,
+              client_random: queued.client_random,
+              metadata: queued.client_message_id
+                ? { client_message_id: queued.client_message_id }
+                : {},
+              reply_to_id: queued.reply_to_id,
+            });
+          },
+        );
+        if (!skipped && (sent > 0 || failed > 0)) {
           logger.info(
             "offlineQueueDrainer",
             `Drained offline queue: ${sent} sent, ${failed} still pending`,

--- a/src/services/offlineQueue.ts
+++ b/src/services/offlineQueue.ts
@@ -5,6 +5,7 @@
  */
 
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as ExpoCrypto from "expo-crypto";
 
 const QUEUE_KEY = "whispr.offline.message.queue";
 
@@ -14,8 +15,51 @@ export interface QueuedMessage {
   content: string;
   message_type: "text" | "media" | "system";
   client_random: number;
+  // WHISPR-1219 — UUID v4 generated at enqueue. Today messaging-service
+  // dedupes on (sender_id, client_random) via a unique index, but
+  // client_random is only ~20 bits → real birthday-collision risk past a
+  // few hundred messages from the same sender. The UUID ships in the
+  // body so backend can migrate the dedupe key without coordinating a
+  // client release.
+  client_message_id?: string;
   reply_to_id?: string;
   queued_at: string; // ISO timestamp
+}
+
+function generateUUID(): string {
+  // Mirrors DeviceService.generateUUID — same fallback chain. RN ≥ 0.74
+  // and modern web have crypto.randomUUID natively; expo-crypto is the
+  // backstop on older runtimes and in jest where the global is polyfilled.
+  const g = globalThis as unknown as {
+    crypto?: { randomUUID?: () => string };
+  };
+  if (typeof g.crypto?.randomUUID === "function") {
+    return g.crypto.randomUUID();
+  }
+  if (typeof ExpoCrypto.randomUUID === "function") {
+    return ExpoCrypto.randomUUID();
+  }
+  const bytes = ExpoCrypto.getRandomBytes(16);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join(
+    "",
+  );
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
+
+// WHISPR-1219 — module-level mutex around drainAll. Concurrent triggers
+// (manual call + WS reconnect arriving in the same tick) used to send
+// the same message twice. Second invocation now short-circuits and
+// returns `skipped: true` so callers can tell apart "drained nothing"
+// from "another drain is already in flight".
+let drainPromise: Promise<{ sent: number; failed: number }> | null = null;
+
+export interface DrainResult {
+  sent: number;
+  failed: number;
+  /** True iff another drainAll() was already in flight when this one started. */
+  skipped?: boolean;
 }
 
 export const offlineQueue = {
@@ -35,9 +79,13 @@ export const offlineQueue = {
       // Avoid duplicates by client_random
       if (current.some((m) => m.client_random === message.client_random))
         return;
+      const persisted: QueuedMessage = {
+        ...message,
+        client_message_id: message.client_message_id ?? generateUUID(),
+      };
       await AsyncStorage.setItem(
         QUEUE_KEY,
-        JSON.stringify([...current, message]),
+        JSON.stringify([...current, persisted]),
       );
     } catch (error) {
       console.error("[offlineQueue] enqueue error:", error);
@@ -80,23 +128,38 @@ export const offlineQueue = {
    * sends right after reconnect would otherwise race the server's rate
    * limiter, and preserving insertion order matters for chat UX.
    *
+   * WHISPR-1219: concurrent invocations are rejected via a module-level
+   * mutex. The second caller gets `{ sent: 0, failed: 0, skipped: true }`
+   * immediately so each message is sent exactly once even if multiple
+   * triggers fire on the same tick (manual button + WS reconnect).
+   *
    * Returns the counts so callers can log or surface them.
    */
   async drainAll(
     sendFn: (message: QueuedMessage) => Promise<unknown>,
-  ): Promise<{ sent: number; failed: number }> {
-    const pending = await this.getAll();
-    let sent = 0;
-    let failed = 0;
-    for (const queued of pending) {
-      try {
-        await sendFn(queued);
-        await this.remove(queued.client_random);
-        sent += 1;
-      } catch {
-        failed += 1;
-      }
+  ): Promise<DrainResult> {
+    if (drainPromise) {
+      return { sent: 0, failed: 0, skipped: true };
     }
-    return { sent, failed };
+    drainPromise = (async () => {
+      const pending = await this.getAll();
+      let sent = 0;
+      let failed = 0;
+      for (const queued of pending) {
+        try {
+          await sendFn(queued);
+          await this.remove(queued.client_random);
+          sent += 1;
+        } catch {
+          failed += 1;
+        }
+      }
+      return { sent, failed };
+    })();
+    try {
+      return await drainPromise;
+    } finally {
+      drainPromise = null;
+    }
   },
 };


### PR DESCRIPTION
…nqueue

Deux déclencheurs concurrents (manuel + reconnexion WS dans le même tick) renvoyaient le même message deux fois. La dédup serveur via (sender_id, client_random) sauvait l'utilisateur final, mais on payait l'aller-retour HTTP en double et l'erreur 409 polluait les logs.

- drainAll wrap dans un mutex module-level (drainPromise). Une 2e invocation rentre, voit le promise actif, retourne { sent: 0, failed: 0, skipped: true } sans toucher à la file. Le drain en vol continue seul → chaque message envoyé une seule fois.
- DrainResult exporté avec skipped optionnel pour permettre aux callers (useOfflineQueueDrainer) de différencier "rien à drainer" de "déjà en cours".
- enqueue génère un UUID v4 client_message_id si manquant. Aujourd'hui messaging-service dédup sur (sender_id, client_random) via index unique, mais client_random n'a que ~20 bits — collisions par anniversaire passées 1k messages d'un même expéditeur. Le UUID ship dans metadata.client_message_id pour que le serveur puisse migrer l'index sans release client coordonné.
- Helper generateUUID local (mêmes fallback que DeviceService : globalThis.crypto.randomUUID puis ExpoCrypto.randomUUID puis bytes manuels). À extraire en util si une 3e service en a besoin.
- useOfflineQueueDrainer passe metadata.client_message_id quand présent + log uniquement quand !skipped (la concurrent call sera loggée par celle qui drain vraiment).

6 nouveaux tests : drain concurrent → 1 envoi par message ; lock relâché après succès / après rejet ; UUID auto-généré ; UUID respecté si fourni ; UUIDs distincts entre 2 messages. 739 tests verts.

WHISPR-1219