### PR TITLE
fix(auth,build): casser le cycle NotificationService↔AuthService et p…

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -1,7 +1,14 @@
 const base = require('./app.json');
 
+// EAS owner / projectId pilotables par env (.env.local) pour permettre à
+// chaque dev de builder le dev-client avec son propre compte EAS sans
+// modifier app.json (qui est partagé). Fallback : valeurs équipe.
+const easOwnerOverride = process.env.EAS_OWNER;
+const easProjectIdOverride = process.env.EAS_PROJECT_ID;
+
 module.exports = ({ config }) => ({
   ...base.expo,
+  ...(easOwnerOverride ? { owner: easOwnerOverride } : {}),
   ios: {
     ...base.expo.ios,
     infoPlist: {
@@ -10,6 +17,7 @@ module.exports = ({ config }) => ({
     },
   },
   extra: {
+    ...base.expo.extra,
     apiBaseUrl: process.env.API_BASE_URL || 'https://whispr.devzeyu.com',
     devAuthApiUrl: 'http://10.0.2.2:3010',
     devUserApiUrl: 'http://10.0.2.2:3011',
@@ -19,7 +27,8 @@ module.exports = ({ config }) => ({
       process.env.EXPO_PUBLIC_LEGAL_TERMS_URL || 'https://whispr.example/terms',
     appVersion: '1.0.0',
     eas: {
-      projectId: '203ca2cd-9035-489b-9c0d-ca4a1bfb2d36',
+      projectId:
+        easProjectIdOverride || '203ca2cd-9035-489b-9c0d-ca4a1bfb2d36',
     },
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "expo-image-picker": "^17.0.8",
         "expo-linear-gradient": "^15.0.7",
         "expo-notifications": "~0.32.12",
-        "expo-permissions": "^14.4.0",
         "expo-secure-store": "~15.0.8",
         "expo-splash-screen": "~31.0.13",
         "expo-status-bar": "~3.0.9",
@@ -7742,15 +7741,6 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/expo-permissions": {
-      "version": "14.4.0",
-      "resolved": "https://registry.npmjs.org/expo-permissions/-/expo-permissions-14.4.0.tgz",
-      "integrity": "sha512-oAcnJ7dlZhpBydK73cwomA2xofizayVUz+FW5REl7dMu7MYyeN/3aqhlpZ3mYddrxvG161bqu97MQr01UixUnw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*"
       }
     },
     "node_modules/expo-secure-store": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "expo-image-picker": "^17.0.8",
     "expo-linear-gradient": "^15.0.7",
     "expo-notifications": "~0.32.12",
-    "expo-permissions": "^14.4.0",
     "expo-secure-store": "~15.0.8",
     "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.9",

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -1,9 +1,18 @@
 import { TokenService } from "./TokenService";
 import { DeviceService } from "./DeviceService";
 import { SignalKeyService } from "./SignalKeyService";
-import { NotificationService } from "./NotificationService";
 import { getApiBaseUrl } from "./apiBase";
 import { emitSessionExpired } from "./sessionEvents";
+
+// NotificationService.handle401 appelle AuthService.refreshTokens : un
+// import statique réciproque crée un cycle module qui, sous Hermes /
+// Metro dev-client, peut résoudre l'un des deux côtés à `undefined` au
+// premier accès. On charge NotificationService à la demande pour casser
+// le cycle ; les sites d'appel sont fire-and-forget, le coût est nul.
+function notificationService(): typeof import("./NotificationService").NotificationService {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return require("./NotificationService").NotificationService;
+}
 import type {
   AuthPurpose,
   TokenPair,
@@ -122,7 +131,9 @@ export const AuthService = {
     resetSessionState();
     const userId = TokenService.decodeAccessToken(tokens.accessToken)?.sub;
     if (userId) {
-      NotificationService.initPushRegistration(userId).catch(() => {});
+      notificationService()
+        .initPushRegistration(userId)
+        .catch(() => {});
     }
     return tokens;
   },
@@ -146,7 +157,9 @@ export const AuthService = {
     resetSessionState();
     const userId = TokenService.decodeAccessToken(tokens.accessToken)?.sub;
     if (userId) {
-      NotificationService.initPushRegistration(userId).catch(() => {});
+      notificationService()
+        .initPushRegistration(userId)
+        .catch(() => {});
     }
     return tokens;
   },
@@ -262,9 +275,10 @@ export const AuthService = {
     // user's row. We bound the wait at 5 s so a hung connection can't
     // block logout indefinitely. Failures are logged (vs. swallowed
     // silently) so shared-device misroute reports are debuggable.
+    const notif = notificationService();
     try {
       await Promise.race([
-        NotificationService.unregisterDevice(deviceId),
+        notif.unregisterDevice(deviceId),
         new Promise<never>((_, reject) =>
           setTimeout(() => reject(new Error("UNREGISTER_TIMEOUT")), 5000),
         ),
@@ -272,7 +286,7 @@ export const AuthService = {
     } catch (err) {
       console.warn("[AuthService] unregisterDevice failed:", err);
     }
-    NotificationService.tearDownPushRegistration();
+    notif.tearDownPushRegistration();
 
     await apiFetch("/logout", {
       method: "POST",


### PR DESCRIPTION
…ermettre l'override EAS par env

- AuthService : remplacer l'import statique de NotificationService par un require() lazy. Le cycle (Notification.handle401 → AuthService.refreshTokens ; AuthService.login/logout → Notification.*) résolvait l'un des deux côtés à `undefined` au premier accès sous Hermes, ce qui empêchait l'enregistrement push après login dans le dev-client.
- app.config.js : owner et eas.projectId pilotables par EAS_OWNER / EAS_PROJECT_ID (.env.local). Permet à chaque dev de builder le dev-client avec son propre compte EAS sans modifier app.json (partagé). Fallback : valeurs équipe (203ca2cd-…). Spread défensif de base.expo.extra ajouté.
- package.json : suppression de expo-permissions (déprécié, plus importé).