### PR TITLE
feat(auth): rendre le pseudo requis lors de l'inscription (ProfileSetup)

### DIFF
--- a/ProfileSetupScreen.test.tsx
+++ b/ProfileSetupScreen.test.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react-native';
-import { ProfileSetupScreen } from './src/screens/Auth/ProfileSetupScreen';
-import { profileSetupFlag } from './src/services/profileSetupFlag';
+import React from "react";
+import { Alert } from "react-native";
+import { render, fireEvent, waitFor } from "@testing-library/react-native";
+import { ProfileSetupScreen } from "./src/screens/Auth/ProfileSetupScreen";
+import { profileSetupFlag } from "./src/services/profileSetupFlag";
 
 const mockReset = jest.fn();
 const mockNavigate = jest.fn();
 
-jest.mock('./src/services/profileSetupFlag', () => ({
+jest.mock("./src/services/profileSetupFlag", () => ({
   profileSetupFlag: {
     get: jest.fn().mockResolvedValue(null),
     markPending: jest.fn().mockResolvedValue(undefined),
@@ -15,54 +16,90 @@ jest.mock('./src/services/profileSetupFlag', () => ({
   },
 }));
 
-jest.mock('@react-navigation/native', () => ({
-  useNavigation: () => ({ navigate: mockNavigate, goBack: jest.fn(), reset: mockReset }),
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({
+    navigate: mockNavigate,
+    goBack: jest.fn(),
+    reset: mockReset,
+  }),
   useRoute: () => ({ params: {} }),
 }));
-jest.mock('expo-linear-gradient', () => ({
+jest.mock("expo-linear-gradient", () => ({
   LinearGradient: ({ children }: any) => children,
 }));
-jest.mock('expo-image-picker', () => ({
-  requestMediaLibraryPermissionsAsync: jest.fn().mockResolvedValue({ status: 'granted' }),
+jest.mock("expo-image-picker", () => ({
+  requestMediaLibraryPermissionsAsync: jest
+    .fn()
+    .mockResolvedValue({ status: "granted" }),
   launchImageLibraryAsync: jest.fn().mockResolvedValue({ canceled: true }),
 }));
-jest.mock('./src/context/ThemeContext', () => ({
+jest.mock("./src/context/ThemeContext", () => ({
   useTheme: () => ({
     getThemeColors: () => ({
-      background: { gradient: ['#000', '#111'], primary: '#000', secondary: '#111' },
-      text: { primary: '#fff', secondary: '#aaa', tertiary: '#555' },
-      primary: '#6200ee',
+      background: {
+        gradient: ["#000", "#111"],
+        primary: "#000",
+        secondary: "#111",
+      },
+      text: { primary: "#fff", secondary: "#aaa", tertiary: "#555" },
+      primary: "#6200ee",
     }),
     getFontSize: () => 16,
     getLocalizedText: (key: string) => key,
   }),
 }));
-jest.mock('./src/context/AuthContext', () => ({
+jest.mock("./src/context/AuthContext", () => ({
   useAuth: () => ({
     isAuthenticated: true,
     isLoading: false,
-    userId: 'user1',
-    deviceId: 'dev1',
+    userId: "user1",
+    deviceId: "dev1",
     signIn: jest.fn(),
     signOut: jest.fn(),
   }),
 }));
-jest.mock('./src/components', () => ({
+jest.mock("./src/components", () => ({
   Button: ({ title, onPress, disabled }: any) => {
-    const { TouchableOpacity, Text } = require('react-native');
-    return <TouchableOpacity onPress={onPress} disabled={disabled}><Text>{title}</Text></TouchableOpacity>;
+    const { TouchableOpacity, Text } = require("react-native");
+    return (
+      <TouchableOpacity onPress={onPress} disabled={disabled}>
+        <Text>{title}</Text>
+      </TouchableOpacity>
+    );
   },
-  Input: ({ placeholder, value, onChangeText }: any) => {
-    const { TextInput } = require('react-native');
-    return <TextInput placeholder={placeholder} value={value} onChangeText={onChangeText} />;
+  Input: ({ placeholder, value, onChangeText, error }: any) => {
+    const { TextInput, Text, View } = require("react-native");
+    return (
+      <View>
+        <TextInput
+          placeholder={placeholder}
+          value={value}
+          onChangeText={onChangeText}
+        />
+        {error ? <Text testID={`error-${placeholder}`}>{error}</Text> : null}
+      </View>
+    );
   },
 }));
-jest.mock('./src/services/TokenService', () => ({
-  TokenService: { getAccessToken: jest.fn().mockResolvedValue('tok'), decodeAccessToken: jest.fn().mockReturnValue({ sub: 'user1' }) },
+jest.mock("./src/services/TokenService", () => ({
+  TokenService: {
+    getAccessToken: jest.fn().mockResolvedValue("tok"),
+    decodeAccessToken: jest.fn().mockReturnValue({ sub: "user1" }),
+  },
 }));
-const mockGetProfile = jest.fn().mockResolvedValue({ success: true, profile: { firstName: 'John', lastName: 'Doe', username: 'johndoe', phoneNumber: '+33612345678' } });
+const mockGetProfile = jest
+  .fn()
+  .mockResolvedValue({
+    success: true,
+    profile: {
+      firstName: "John",
+      lastName: "Doe",
+      username: "johndoe",
+      phoneNumber: "+33612345678",
+    },
+  });
 const mockUpdateProfile = jest.fn().mockResolvedValue({ success: true });
-jest.mock('./src/services', () => ({
+jest.mock("./src/services", () => ({
   UserService: {
     getInstance: () => ({
       getProfile: mockGetProfile,
@@ -70,86 +107,164 @@ jest.mock('./src/services', () => ({
     }),
   },
 }));
-jest.mock('./src/services/MediaService', () => ({
-  MediaService: { uploadMedia: jest.fn().mockResolvedValue({ id: 'media-1', url: 'https://cdn.test/img.jpg' }) },
+jest.mock("./src/services/MediaService", () => ({
+  MediaService: {
+    uploadMedia: jest
+      .fn()
+      .mockResolvedValue({ id: "media-1", url: "https://cdn.test/img.jpg" }),
+  },
 }));
-jest.mock('./src/services/apiBase', () => ({
-  getApiBaseUrl: () => 'https://api.test.com',
+jest.mock("./src/services/apiBase", () => ({
+  getApiBaseUrl: () => "https://api.test.com",
 }));
-jest.mock('./src/theme', () => ({
-  colors: { text: { light: '#fff' }, primary: { main: '#6200ee' } },
+jest.mock("./src/theme", () => ({
+  colors: { text: { light: "#fff" }, primary: { main: "#6200ee" } },
   spacing: { xl: 24, xs: 4, md: 16, lg: 20, sm: 8, xxxl: 40 },
   typography: { fontSize: { xxl: 28, base: 14, sm: 12 } },
 }));
 
 global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 }) as any;
 
-describe('ProfileSetupScreen', () => {
+describe("ProfileSetupScreen", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it('renders form fields', () => {
+  it("renders form fields", () => {
     const { getByPlaceholderText } = render(<ProfileSetupScreen />);
-    expect(getByPlaceholderText('auth.firstName')).toBeTruthy();
-    expect(getByPlaceholderText('auth.lastName')).toBeTruthy();
-    expect(getByPlaceholderText('Pseudo')).toBeTruthy();
+    expect(getByPlaceholderText("auth.firstName")).toBeTruthy();
+    expect(getByPlaceholderText("auth.lastName")).toBeTruthy();
+    expect(getByPlaceholderText("Pseudo")).toBeTruthy();
   });
 
-  it('renders save button', () => {
+  it("renders save button", () => {
     const { getByText } = render(<ProfileSetupScreen />);
-    expect(getByText('common.save')).toBeTruthy();
+    expect(getByText("common.save")).toBeTruthy();
   });
 
-  it('renders skip button', () => {
+  it("renders skip button", () => {
     const { getByText } = render(<ProfileSetupScreen />);
     expect(getByText(/auth.skip/)).toBeTruthy();
   });
 
-  it('navigates to ConversationsList on skip and marks flag done', async () => {
+  it("skip shows confirmation dialog and only navigates after user confirms", async () => {
+    const alertSpy = jest
+      .spyOn(Alert, "alert")
+      .mockImplementation((_title, _message, buttons) => {
+        // Simulate the user tapping the second button ("Passer")
+        const action = (buttons ?? [])[1];
+        action?.onPress?.();
+      });
+
     const { getByText } = render(<ProfileSetupScreen />);
     fireEvent.press(getByText(/auth.skip/));
+
+    expect(alertSpy).toHaveBeenCalled();
     await waitFor(() => {
-      expect(mockReset).toHaveBeenCalledWith({ index: 0, routes: [{ name: 'ConversationsList' }] });
+      expect(mockReset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: "ConversationsList" }],
+      });
     });
     expect(profileSetupFlag.markDone).toHaveBeenCalled();
+
+    alertSpy.mockRestore();
   });
 
-  it('navigates to ConversationsList on successful save', async () => {
-    const { getByPlaceholderText, getByText, queryByText } = render(<ProfileSetupScreen />);
+  it("skip cancellation does not navigate", () => {
+    const alertSpy = jest
+      .spyOn(Alert, "alert")
+      .mockImplementation((_title, _message, buttons) => {
+        // Simulate the user tapping "Annuler" (first button)
+        const cancel = (buttons ?? [])[0];
+        cancel?.onPress?.();
+      });
+
+    const { getByText } = render(<ProfileSetupScreen />);
+    fireEvent.press(getByText(/auth.skip/));
+
+    expect(alertSpy).toHaveBeenCalled();
+    expect(mockReset).not.toHaveBeenCalled();
+    expect(profileSetupFlag.markDone).not.toHaveBeenCalled();
+
+    alertSpy.mockRestore();
+  });
+
+  it("navigates to ConversationsList on successful save", async () => {
+    const { getByPlaceholderText, getByText, queryByText } = render(
+      <ProfileSetupScreen />,
+    );
     // Wait for polling to complete (profileReady = true, banner disappears)
     await waitFor(() => {
-      expect(queryByText('Préparation de votre compte...')).toBeNull();
+      expect(queryByText("Préparation de votre compte...")).toBeNull();
     });
-    fireEvent.changeText(getByPlaceholderText('auth.firstName'), 'John');
-    fireEvent.changeText(getByPlaceholderText('auth.lastName'), 'Doe');
-    fireEvent.changeText(getByPlaceholderText('Pseudo'), 'johndoe');
-    fireEvent.press(getByText('common.save'));
+    fireEvent.changeText(getByPlaceholderText("auth.firstName"), "John");
+    fireEvent.changeText(getByPlaceholderText("auth.lastName"), "Doe");
+    fireEvent.changeText(getByPlaceholderText("Pseudo"), "johndoe");
+    fireEvent.press(getByText("common.save"));
     await waitFor(() => {
-      expect(mockReset).toHaveBeenCalledWith({ index: 0, routes: [{ name: 'ConversationsList' }] });
+      expect(mockReset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: "ConversationsList" }],
+      });
     });
     expect(profileSetupFlag.markDone).toHaveBeenCalled();
+    expect(mockUpdateProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        username: "johndoe",
+        firstName: "John",
+        lastName: "Doe",
+      }),
+    );
   });
 
-  it('saves with no fields filled without calling updateProfile', async () => {
-    const { getByText, queryByText } = render(<ProfileSetupScreen />);
+  it("blocks save when username is empty and surfaces an explicit error", async () => {
+    const { getByPlaceholderText, getByText, queryByText, queryByTestId } =
+      render(<ProfileSetupScreen />);
     await waitFor(() => {
-      expect(queryByText('Préparation de votre compte...')).toBeNull();
+      expect(queryByText("Préparation de votre compte...")).toBeNull();
     });
-    fireEvent.press(getByText('common.save'));
+    // Fill firstName but leave username empty — should NOT save
+    fireEvent.changeText(getByPlaceholderText("auth.firstName"), "John");
+    fireEvent.press(getByText("common.save"));
+
     await waitFor(() => {
-      expect(mockReset).toHaveBeenCalledWith({ index: 0, routes: [{ name: 'ConversationsList' }] });
+      expect(queryByTestId("error-Pseudo")).toBeTruthy();
     });
+    expect(queryByTestId("error-Pseudo")?.props.children).toMatch(/requis/i);
     expect(mockUpdateProfile).not.toHaveBeenCalled();
+    expect(mockReset).not.toHaveBeenCalled();
   });
 
-  it('saves with only firstName filled', async () => {
-    const { getByPlaceholderText, getByText, queryByText } = render(<ProfileSetupScreen />);
+  it("blocks save when username is shorter than 3 characters", async () => {
+    const { getByPlaceholderText, getByText, queryByText, queryByTestId } =
+      render(<ProfileSetupScreen />);
     await waitFor(() => {
-      expect(queryByText('Préparation de votre compte...')).toBeNull();
+      expect(queryByText("Préparation de votre compte...")).toBeNull();
     });
-    fireEvent.changeText(getByPlaceholderText('auth.firstName'), 'John');
-    fireEvent.press(getByText('common.save'));
+    fireEvent.changeText(getByPlaceholderText("Pseudo"), "ab");
+    fireEvent.press(getByText("common.save"));
+
     await waitFor(() => {
-      expect(mockUpdateProfile).toHaveBeenCalledWith({ firstName: 'John' });
+      expect(queryByTestId("error-Pseudo")).toBeTruthy();
     });
+    expect(queryByTestId("error-Pseudo")?.props.children).toMatch(
+      /3 caractères/i,
+    );
+    expect(mockUpdateProfile).not.toHaveBeenCalled();
+    expect(mockReset).not.toHaveBeenCalled();
+  });
+
+  it("keeps already-typed values when validation fails so the user does not lose input", async () => {
+    const { getByPlaceholderText, getByText, queryByText } = render(
+      <ProfileSetupScreen />,
+    );
+    await waitFor(() => {
+      expect(queryByText("Préparation de votre compte...")).toBeNull();
+    });
+    const firstNameField = getByPlaceholderText("auth.firstName");
+    fireEvent.changeText(firstNameField, "John");
+    fireEvent.press(getByText("common.save"));
+
+    // After the failed submit, the firstName should still be present
+    expect(firstNameField.props.value).toBe("John");
   });
 });

--- a/src/screens/Auth/ProfileSetupScreen.tsx
+++ b/src/screens/Auth/ProfileSetupScreen.tsx
@@ -41,6 +41,24 @@ export const ProfileSetupScreen: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [profileReady, setProfileReady] = useState(false);
   const [phoneNumber, setPhoneNumber] = useState<string | null>(null);
+  const [submitAttempted, setSubmitAttempted] = useState(false);
+
+  // WHISPR-1034 — username est le seul champ obligatoire à l'inscription.
+  // firstName / lastName restent optionnels (parité avec Signal/Telegram :
+  // l'identifiant unique est le numéro + le pseudo, pas le nom civil).
+  const trimmedUsername = username.trim();
+  const isUsernameValid = trimmedUsername.length >= 3;
+  const usernameError = (() => {
+    if (trimmedUsername.length === 0) {
+      return submitAttempted
+        ? "Pseudo requis pour finaliser votre profil"
+        : undefined;
+    }
+    if (trimmedUsername.length < 3) {
+      return "Minimum 3 caractères";
+    }
+    return undefined;
+  })();
 
   const fadeAnim = useRef(new Animated.Value(0)).current;
   const slideAnim = useRef(new Animated.Value(40)).current;
@@ -118,6 +136,10 @@ export const ProfileSetupScreen: React.FC = () => {
   };
 
   const handleSave = async () => {
+    if (!isUsernameValid) {
+      setSubmitAttempted(true);
+      return;
+    }
     setLoading(true);
     try {
       const profileData: Record<string, string> = {};
@@ -176,9 +198,24 @@ export const ProfileSetupScreen: React.FC = () => {
     }
   };
 
-  const handleSkip = async () => {
-    await profileSetupFlag.markDone();
-    navigation.reset({ index: 0, routes: [{ name: "ConversationsList" }] });
+  const handleSkip = () => {
+    Alert.alert(
+      "Compléter plus tard ?",
+      "Vous pourrez configurer votre pseudo et vos informations de profil à tout moment depuis vos paramètres. En attendant vous serez identifié par votre numéro de téléphone.",
+      [
+        { text: "Annuler", style: "cancel" },
+        {
+          text: "Passer",
+          onPress: async () => {
+            await profileSetupFlag.markDone();
+            navigation.reset({
+              index: 0,
+              routes: [{ name: "ConversationsList" }],
+            });
+          },
+        },
+      ],
+    );
   };
 
   return (
@@ -322,8 +359,11 @@ export const ProfileSetupScreen: React.FC = () => {
                 ]}
               >
                 {getLocalizedText("profile.username")}{" "}
-                <Text style={styles.optionalHint}>
-                  ({getLocalizedText("common.optional")})
+                <Text
+                  style={styles.requiredHint}
+                  accessibilityLabel="champ requis"
+                >
+                  *
                 </Text>
               </Text>
               <Input
@@ -332,11 +372,7 @@ export const ProfileSetupScreen: React.FC = () => {
                 onChangeText={(t) => setUsername(normalizeUsername(t))}
                 autoCapitalize="none"
                 containerStyle={styles.inputContainer}
-                error={
-                  username.trim().length > 0 && username.trim().length < 3
-                    ? "Minimum 3 caractères"
-                    : undefined
-                }
+                error={usernameError}
                 helperText="Seuls minuscules, chiffres et _ (auto-corrigé)"
               />
             </View>
@@ -481,6 +517,10 @@ const styles = StyleSheet.create({
   optionalHint: {
     opacity: 0.6,
     fontWeight: "400",
+  },
+  requiredHint: {
+    color: "#ff6b6b",
+    fontWeight: "700",
   },
   readyBanner: {
     flexDirection: "row",


### PR DESCRIPTION
Le pseudo devient le seul champ obligatoire de l'écran d'inscription :
- prénom / nom restent optionnels (parité Signal / Telegram)
- soumission avec pseudo manquant → message "Pseudo requis pour finaliser votre profil" affiché inline, navigation bloquée
- soumission avec pseudo < 3 caractères → message "Minimum 3 caractères"
- l'astérisque rouge à côté du label remplace l'indication "(optional)"
- bouton Skip déclenche désormais une Alert de confirmation rappelant qu'on peut compléter plus tard depuis les paramètres ; pas de skip involontaire en cas de tap accidentel

Couvre WHISPR-1034 : "Modification du profil lors de l'inscription".