### PR TITLE
feat(media): préserver le format natif GIF/HEIC à l'envoi d'image

### DIFF
--- a/imageCompression.test.ts
+++ b/imageCompression.test.ts
@@ -1,9 +1,35 @@
 /**
  * WHISPR-1039: garantit que la compression ne déforme jamais une image.
  * Test unitaire pur sur la fonction de décision `buildResizeAction`.
+ *
+ * WHISPR-1197: garantit que GIF/HEIC ne sont jamais re-encodés.
  */
 
-import { buildResizeAction } from "./src/utils/imageCompression";
+// Mock expo-image-manipulator AVANT l'import du module testé : ainsi on peut
+// observer si compressImage l'appelle (cas JPEG/PNG) ou court-circuite (GIF/HEIC).
+const mockManipulateAsync = jest.fn();
+jest.mock("expo-image-manipulator", () => ({
+  manipulateAsync: (...args: unknown[]) => mockManipulateAsync(...args),
+  SaveFormat: { JPEG: "jpeg", PNG: "png" },
+}));
+
+// Mock Image.getSize pour ne pas dépendre du runtime natif.
+jest.mock("react-native", () => ({
+  Image: {
+    getSize: (
+      _uri: string,
+      onSuccess: (w: number, h: number) => void,
+    ): void => {
+      onSuccess(800, 600);
+    },
+  },
+}));
+
+import {
+  buildResizeAction,
+  compressImage,
+  detectImageFormatFromUri,
+} from "./src/utils/imageCompression";
 
 describe("buildResizeAction (WHISPR-1039)", () => {
   const MAX_W = 1920;
@@ -48,5 +74,86 @@ describe("buildResizeAction (WHISPR-1039)", () => {
       const hasHeight = "height" in resize;
       expect(hasWidth && hasHeight).toBe(false);
     }
+  });
+});
+
+describe("detectImageFormatFromUri (WHISPR-1197)", () => {
+  it.each([
+    ["file:///tmp/photo.gif", "gif"],
+    ["file:///tmp/photo.GIF", "gif"],
+    ["file:///tmp/photo.heic", "heic"],
+    ["file:///tmp/photo.HEIC", "heic"],
+    ["file:///tmp/photo.heif", "heic"],
+    ["file:///tmp/photo.jpg", "jpeg"],
+    ["file:///tmp/photo.jpeg", "jpeg"],
+    ["file:///tmp/photo.png", "png"],
+    ["file:///tmp/photo.webp", "webp"],
+    ["file:///tmp/photo", "unknown"],
+    ["file:///tmp/photo.unknown", "unknown"],
+  ])("%s → %s", (uri, expected) => {
+    expect(detectImageFormatFromUri(uri)).toBe(expected);
+  });
+
+  it("ignore une querystring après le nom de fichier", () => {
+    expect(detectImageFormatFromUri("https://cdn/photo.gif?token=abc")).toBe(
+      "gif",
+    );
+    expect(detectImageFormatFromUri("https://cdn/photo.heic#frag")).toBe(
+      "heic",
+    );
+  });
+});
+
+describe("compressImage format short-circuit (WHISPR-1197)", () => {
+  beforeEach(() => {
+    mockManipulateAsync.mockReset();
+  });
+
+  it("retourne l'URI inchangée pour un GIF, sans appeler manipulateAsync", async () => {
+    const inputUri = "file:///tmp/animated.gif";
+    const result = await compressImage(inputUri);
+    expect(result).toBe(inputUri);
+    expect(mockManipulateAsync).not.toHaveBeenCalled();
+  });
+
+  it("retourne l'URI inchangée pour un HEIC (extension .heic)", async () => {
+    const inputUri = "file:///tmp/IMG_1234.heic";
+    const result = await compressImage(inputUri);
+    expect(result).toBe(inputUri);
+    expect(mockManipulateAsync).not.toHaveBeenCalled();
+  });
+
+  it("retourne l'URI inchangée pour un HEIF (extension .heif)", async () => {
+    const inputUri = "file:///tmp/IMG_1234.heif";
+    const result = await compressImage(inputUri);
+    expect(result).toBe(inputUri);
+    expect(mockManipulateAsync).not.toHaveBeenCalled();
+  });
+
+  it("compresse un JPEG via manipulateAsync (pas de régression)", async () => {
+    mockManipulateAsync
+      .mockResolvedValueOnce({ uri: "file:///tmp/resized.jpg" })
+      .mockResolvedValueOnce({ uri: "file:///tmp/compressed.jpg" });
+    const result = await compressImage("file:///tmp/photo.jpg");
+    expect(mockManipulateAsync).toHaveBeenCalledTimes(2);
+    expect(result).toBe("file:///tmp/compressed.jpg");
+  });
+
+  it("compresse un PNG via manipulateAsync (pas de régression)", async () => {
+    mockManipulateAsync
+      .mockResolvedValueOnce({ uri: "file:///tmp/resized.jpg" })
+      .mockResolvedValueOnce({ uri: "file:///tmp/compressed.jpg" });
+    const result = await compressImage("file:///tmp/photo.png");
+    expect(mockManipulateAsync).toHaveBeenCalledTimes(2);
+    expect(result).toBe("file:///tmp/compressed.jpg");
+  });
+
+  it("compresse une URI sans extension reconnue (fallback compression)", async () => {
+    mockManipulateAsync
+      .mockResolvedValueOnce({ uri: "file:///tmp/resized.jpg" })
+      .mockResolvedValueOnce({ uri: "file:///tmp/compressed.jpg" });
+    const result = await compressImage("file:///tmp/photo");
+    expect(mockManipulateAsync).toHaveBeenCalledTimes(2);
+    expect(result).toBe("file:///tmp/compressed.jpg");
   });
 });

--- a/src/components/Chat/CameraCapture.tsx
+++ b/src/components/Chat/CameraCapture.tsx
@@ -185,10 +185,12 @@ export const CameraCapture: React.FC<CameraCaptureProps> = ({
         withSpring(1, { damping: 10 }),
       );
 
+      // WHISPR-1197 : pas de `quality` pour préserver le format natif de
+      // l'appareil photo (HEIC sur iOS si "Haute efficacité" est actif).
+      // Imposer une qualité re-encoderait systématiquement en JPEG.
       const result = await ImagePicker.launchCameraAsync({
         mediaTypes: ImagePicker.MediaTypeOptions.Images,
         allowsEditing: false,
-        quality: 0.9,
         cameraType:
           cameraType === "front"
             ? ImagePicker.CameraType.front

--- a/src/components/Chat/MessageInput.tsx
+++ b/src/components/Chat/MessageInput.tsx
@@ -290,10 +290,15 @@ export const MessageInput: React.FC<MessageInputProps> = ({
 
       // Launch image picker without forcing a crop: WHISPR-1039 wants the
       // user to send images in their native ratio (portrait/landscape/square).
+      // WHISPR-1197 : on ne passe PAS `quality` ici — sur iOS/Android
+      // expo-image-picker re-encode en JPEG dès que `quality` est défini,
+      // ce qui aplatit les GIFs animés (premier frame seulement) et perd
+      // la compression native HEIC. La taille du fichier est déjà bornée
+      // côté upload par WHISPR-1220, on accepte donc un léger surcoût
+      // réseau pour préserver l'animation et le format Apple.
       const result = await ImagePicker.launchImageLibraryAsync({
         mediaTypes: ImagePicker.MediaTypeOptions.Images,
         allowsEditing: false,
-        quality: 0.8,
       });
 
       if (!result.canceled && result.assets && result.assets[0]) {

--- a/src/utils/imageCompression.ts
+++ b/src/utils/imageCompression.ts
@@ -3,10 +3,47 @@
  * WHISPR-265: Compression automatique des images avant envoi
  * WHISPR-1039: ne plus déformer les images, le côté le plus long est borné
  *              et le ratio d'origine est préservé.
+ * WHISPR-1197: GIF/HEIC sont préservés tels quels (pas de re-encodage JPEG)
+ *              pour conserver l'animation des GIFs et la compression native
+ *              Apple sur les HEIC. Seuls JPEG/PNG/inconnu passent par le
+ *              pipeline `manipulateAsync`.
  */
 
 import * as ImageManipulator from "expo-image-manipulator";
 import { Image } from "react-native";
+
+export type ImageFormat = "gif" | "heic" | "jpeg" | "png" | "webp" | "unknown";
+
+/**
+ * Détecte le format d'une image à partir de son URI/extension.
+ * Pure et exportée pour être testable sans expo-image-manipulator.
+ *
+ * Note : on s'appuie sur l'extension uniquement. Une détection par magic
+ * bytes serait plus robuste mais nécessiterait un read I/O — l'URI vient
+ * de `expo-image-picker` ou `expo-camera` qui préservent l'extension du
+ * fichier source, donc le risque d'erreur est faible et la perf gagnée
+ * sur le chemin chaud (chaque envoi d'image) en vaut le coût.
+ */
+export function detectImageFormatFromUri(uri: string): ImageFormat {
+  const path = uri.split("?")[0]?.split("#")[0] ?? uri;
+  const ext = path.split(".").pop()?.toLowerCase() ?? "";
+  switch (ext) {
+    case "gif":
+      return "gif";
+    case "heic":
+    case "heif":
+      return "heic";
+    case "jpg":
+    case "jpeg":
+      return "jpeg";
+    case "png":
+      return "png";
+    case "webp":
+      return "webp";
+    default:
+      return "unknown";
+  }
+}
 
 export interface CompressionOptions {
   maxWidth?: number;
@@ -67,6 +104,21 @@ export async function compressImage(
   options: CompressionOptions = {},
 ): Promise<string> {
   try {
+    const format = detectImageFormatFromUri(uri);
+
+    // WHISPR-1197 : GIF et HEIC sont retournés inchangés.
+    // - GIF : `manipulateAsync` ne préserve pas l'animation (extrait juste
+    //   le premier frame), donc tout re-encodage casse le contenu attendu.
+    // - HEIC : la pipeline serveur (media-service `magic-bytes.validator`
+    //   + `THUMBNAIL_ALLOWED_MIME` + media.service.ts) accepte
+    //   `image/heic`, et la modération côté client (`image-to-tensor.ts`)
+    //   convertit en JPEG en interne avant inférence — donc préserver le
+    //   format natif coûte zéro en aval et gagne ~50 % de bande passante
+    //   sur les photos iOS prises en High Efficiency.
+    if (format === "gif" || format === "heic") {
+      return uri;
+    }
+
     const {
       maxWidth = DEFAULT_MAX_WIDTH,
       maxHeight = DEFAULT_MAX_HEIGHT,


### PR DESCRIPTION
- compressImage détecte désormais le format via l'URI (detectImageFormatFromUri) et court-circuite GIF + HEIC pour retourner l'URI inchangée. JPEG/PNG/inconnu passent toujours par manipulateAsync (pas de régression).
- MessageInput.handlePickImage : suppression de quality:0.8 pour ne pas forcer expo-image-picker à re-encoder en JPEG (GIFs animés
  + photos HEIC iOS sont désormais conservés).
- CameraCapture.handleTakePhoto : même retrait de quality:0.9, on préserve le HEIC natif iOS si l'utilisateur a "Haute efficacité" activé. La capture vidéo n'est pas touchée.

Pipeline aval déjà compatible :
- media-service magic-bytes.validator + THUMBNAIL_ALLOWED_MIME acceptent image/gif et image/heic.
- WHISPR-1220 borne déjà la taille fichier côté client, donc on accepte un léger surcoût réseau en échange de la préservation format.
- gateChatImageBeforeSend → image-to-tensor convertit en interne vers JPEG avant inférence TFJS, donc la modération reste format-agnostique.

Tests : detectImageFormatFromUri (11 cas + querystring), short- circuit GIF/HEIC/HEIF (3 cas), JPEG/PNG/unknown vont bien dans manipulateAsync (3 cas). Pas de régression sur buildResizeAction.