### PR TITLE
[WHISPR-1227] fix(avatar): prevent flicker on unrelated re-renders in conversation list

### DIFF
--- a/src/components/Chat/Avatar.tsx
+++ b/src/components/Chat/Avatar.tsx
@@ -187,9 +187,6 @@ export const Avatar: React.FC<AvatarProps> = ({
   isOnline = false,
 }) => {
   const [imageError, setImageError] = React.useState(false);
-  const [resolvedUri, setResolvedUri] = React.useState<string | undefined>(
-    undefined,
-  );
   const triedAuthResolveRef = React.useRef(false);
 
   const effectiveCandidate = React.useMemo(() => {
@@ -247,6 +244,18 @@ export const Avatar: React.FC<AvatarProps> = ({
     return { uri: undefined, mediaId: undefined };
   }, [uri]);
 
+  // Stable key: gating reset on `uri` directly drops a resolved dataUrl on
+  // unrelated re-renders (e.g. Zustand subscriptions in ConversationItem),
+  // producing flicker.
+  const avatarKey = effectiveCandidate.mediaId ?? effectiveCandidate.uri;
+
+  const [resolvedUri, setResolvedUri] = React.useState<string | undefined>(
+    () => {
+      const id = effectiveCandidate.mediaId;
+      return id ? resolvedCache.get(id) : undefined;
+    },
+  );
+
   const effectiveUri = resolvedUri ?? effectiveCandidate.uri;
 
   const initials =
@@ -257,12 +266,16 @@ export const Avatar: React.FC<AvatarProps> = ({
       .toUpperCase()
       .slice(0, 2) || "?";
 
-  // Reset error state when URI changes
-  React.useEffect(() => {
+  const lastAvatarKeyRef = React.useRef(avatarKey);
+  if (lastAvatarKeyRef.current !== avatarKey) {
+    lastAvatarKeyRef.current = avatarKey;
+    const cached = effectiveCandidate.mediaId
+      ? resolvedCache.get(effectiveCandidate.mediaId)
+      : undefined;
+    setResolvedUri(cached);
     setImageError(false);
-    setResolvedUri(undefined);
     triedAuthResolveRef.current = false;
-  }, [uri]);
+  }
 
   // Pre-resolve through `?stream=1` when we know the mediaId, so <Image>
   // never hits `/blob` directly (which returns a JSON envelope it can't


### PR DESCRIPTION
## Summary
- Avatars de la liste des conversations chargeaient une fois sur deux : un re-render de `ConversationItem` causé par une souscription Zustand non liée (présence, lastMessage, unreadCount) déclenchait le `useEffect` qui réinitialisait `resolvedUri` à `undefined`, annulant le travail de résolution déjà effectué.
- Le reset de `resolvedUri`/`imageError` se base désormais sur une clé stable (`mediaId` ou `effectiveCandidate.uri` normalisée) plutôt que sur la prop brute `uri`, qui peut changer de référence sans pointer vers un média différent.
- `resolvedUri` est hydraté synchroniquement depuis le `resolvedCache` module-level quand le `mediaId` est déjà connu, ce qui évite le flash vers le placeholder initiales sur la première frame après changement de clé.

## Test plan
- [x] Unit tests green (`npm test` — 759/759)
- [x] Lint clean (`npm run lint:fix` — 0 errors)
- [x] Type-check clean (pre-push hook `tsc --noEmit`)
- [ ] Tested on iOS simulator — scroll dans la liste des conversations + retour depuis l'écran de chat, vérifier l'absence de flicker
- [ ] Tested on Android emulator
- [ ] Vérifier que les autres usages de `<Avatar />` (ChatHeader, profils, contacts, modals) ne sont pas régressés

Closes WHISPR-1227