### PR TITLE
[WHISPR-1231] feat(chat): redesign conversations list and new conversation flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ when picking up and completing a Jira ticket for this repository.
 
 - Jira cloud ID: fetch at runtime via `mcp__atlassian__getAccessibleAtlassianResources` (select the resource whose `name` matches the Jira site)
 - GitHub org/repo: `whispr-messenger/mobile-app`
-- Default base branch: `main`
+- Default base branch: `deploy/preprod`
 - Node package manager: `npm`
 
 ---
@@ -27,8 +27,8 @@ when picking up and completing a Jira ticket for this repository.
 ## 2. Prepare the branch
 
 ```bash
-git checkout main
-git pull origin main
+git checkout deploy/preprod
+git pull origin deploy/preprod
 git checkout -b <TICKET-KEY>-<short-kebab-description>
 ```
 
@@ -142,7 +142,7 @@ Use `mcp__github__create_pull_request`:
   "repo": "mobile-app",
   "title": "<same as commit title>",
   "head": "<branch-name>",
-  "base": "main",
+  "base": "deploy/preprod",
   "body": "## Summary\n- bullet 1\n- bullet 2\n\n## Test plan\n- [ ] Unit tests green\n- [ ] Lint clean\n- [ ] Tested on iOS simulator\n- [ ] Tested on Android emulator\n\nCloses <TICKET-KEY>"
 }
 ```
@@ -170,7 +170,7 @@ Once all CI checks are green, use `mcp__github__merge_pull_request`:
 }
 ```
 
-Always use **squash** merge to keep `main` history linear.
+Always use **squash** merge to keep `deploy/preprod` history linear.
 
 ---
 
@@ -181,11 +181,11 @@ Use `mcp__atlassian__transitionJiraIssue` with the transition whose `name` is
 
 ---
 
-## 11. Return to main
+## 11. Return to deploy/preprod
 
 ```bash
-git checkout main
-git pull origin main
+git checkout deploy/preprod
+git pull origin deploy/preprod
 ```
 
 ---
@@ -300,7 +300,7 @@ This project is indexed by GitNexus as **mobile-app** (946 symbols, 2610 relatio
 1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
 2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
 3. `READ gitnexus://repo/mobile-app/process/{processName}` — trace the full execution flow step by step
-4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
+4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "deploy/preprod"})` — see what your branch changed
 
 ## When Refactoring
 

--- a/src/components/Chat/ConversationItem.tsx
+++ b/src/components/Chat/ConversationItem.tsx
@@ -145,22 +145,27 @@ export const ConversationItem: React.FC<ConversationItemProps> = ({
     setGroupAvatars,
   ]);
 
-  const translateX = useSharedValue(50);
+  const translateY = useSharedValue(20);
   const opacity = useSharedValue(0);
 
   React.useEffect(() => {
     const delay = index * 50;
-    setTimeout(() => {
-      translateX.value = withSpring(0, {
+    const timeout = setTimeout(() => {
+      translateY.value = withSpring(0, {
         damping: 15,
         stiffness: 150,
       });
       opacity.value = withTiming(1, { duration: 300 });
     }, delay);
-  }, [index, translateX, opacity]);
+    return () => clearTimeout(timeout);
+    // Mount-only animation: keep deps empty so re-ordering (e.g. when the
+    // search query filters the list) doesn't replay it and create visual
+    // artefacts.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const animatedStyle = useAnimatedStyle(() => ({
-    transform: [{ translateX: translateX.value }],
+    transform: [{ translateY: translateY.value }],
     opacity: opacity.value,
   }));
 
@@ -187,7 +192,7 @@ export const ConversationItem: React.FC<ConversationItemProps> = ({
     }
 
     if (diffMinutes < 60) {
-      return `${diffMinutes}min`;
+      return `${diffMinutes}m`;
     }
 
     if (diffDays === 0) {
@@ -352,31 +357,6 @@ export const ConversationItem: React.FC<ConversationItemProps> = ({
                   style={styles.mutedIcon}
                 />
               )}
-            </View>
-            {lastMessageContent ? (
-              <Text
-                style={[
-                  styles.lastMessage,
-                  { color: "rgba(255, 255, 255, 0.7)" },
-                ]}
-                numberOfLines={1}
-              >
-                {lastMessageContent}
-              </Text>
-            ) : (
-              <Text
-                style={[
-                  styles.lastMessage,
-                  { color: "rgba(255, 255, 255, 0.4)", fontStyle: "italic" },
-                ]}
-                numberOfLines={1}
-              >
-                Pas encore de messages
-              </Text>
-            )}
-          </View>
-          <View style={styles.metaContainer}>
-            <View style={styles.metaRow}>
               {formattedTime ? (
                 <Text
                   style={[
@@ -396,22 +376,45 @@ export const ConversationItem: React.FC<ConversationItemProps> = ({
                 />
               )}
             </View>
-            {conversation.unread_count ? (
-              conversation.unread_count > 0 && getBadgeColor ? (
-                <View
+            <View style={styles.lastMessageRow}>
+              {lastMessageContent ? (
+                <Text
                   style={[
-                    styles.unreadBadge,
-                    { backgroundColor: getBadgeColor },
+                    styles.lastMessage,
+                    { color: "rgba(255, 255, 255, 0.7)" },
                   ]}
+                  numberOfLines={1}
                 >
-                  <Text style={styles.unreadText}>
-                    {conversation.unread_count > 99
-                      ? "99+"
-                      : String(conversation.unread_count)}
-                  </Text>
-                </View>
-              ) : null
-            ) : null}
+                  {lastMessageContent}
+                </Text>
+              ) : (
+                <Text
+                  style={[
+                    styles.lastMessage,
+                    { color: "rgba(255, 255, 255, 0.4)", fontStyle: "italic" },
+                  ]}
+                  numberOfLines={1}
+                >
+                  Pas encore de messages
+                </Text>
+              )}
+              {conversation.unread_count ? (
+                conversation.unread_count > 0 && getBadgeColor ? (
+                  <View
+                    style={[
+                      styles.unreadBadge,
+                      { backgroundColor: getBadgeColor },
+                    ]}
+                  >
+                    <Text style={styles.unreadText}>
+                      {conversation.unread_count > 99
+                        ? "99+"
+                        : String(conversation.unread_count)}
+                    </Text>
+                  </View>
+                ) : null
+              ) : null}
+            </View>
           </View>
         </View>
       </TouchableOpacity>
@@ -462,7 +465,6 @@ const styles = StyleSheet.create({
   },
   textContainer: {
     flex: 1,
-    marginRight: 8,
   },
   nameRow: {
     flexDirection: "row",
@@ -472,24 +474,24 @@ const styles = StyleSheet.create({
   name: {
     fontSize: 16,
     fontWeight: "600",
-    flex: 1,
+    flexShrink: 1,
   },
   mutedIcon: {
     marginLeft: 4,
   },
-  lastMessage: {
-    fontSize: 14,
-  },
-  metaContainer: {
-    alignItems: "flex-end",
-  },
-  metaRow: {
+  lastMessageRow: {
     flexDirection: "row",
     alignItems: "center",
-    marginBottom: 4,
+  },
+  lastMessage: {
+    fontSize: 14,
+    flex: 1,
+    marginRight: 8,
   },
   timestamp: {
     fontSize: 12,
+    marginLeft: "auto",
+    paddingLeft: 8,
   },
   pinIcon: {
     marginLeft: 4,

--- a/src/components/Chat/NewConversationModal.tsx
+++ b/src/components/Chat/NewConversationModal.tsx
@@ -1,47 +1,30 @@
-import React, { useState, useEffect, useCallback, useRef } from "react";
-import { formatUsername } from "../../utils";
+import React, { useState, useEffect, useCallback, useMemo } from "react";
 import {
   View,
   Text,
   StyleSheet,
   Modal,
   TouchableOpacity,
-  ScrollView,
   TextInput,
   FlatList,
-  Image,
   Alert,
   ActivityIndicator,
-  Platform,
+  ScrollView,
 } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import {
+  SafeAreaView,
+  useSafeAreaInsets,
+} from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
-import * as ImagePicker from "expo-image-picker";
 import * as Haptics from "expo-haptics";
 import { LinearGradient } from "expo-linear-gradient";
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withSpring,
-  withTiming,
-  withSequence,
-  FadeIn,
-  FadeOut,
-  SlideInDown,
-  SlideOutDown,
-} from "react-native-reanimated";
-import { useTheme } from "../../context/ThemeContext";
-import { colors, withOpacity } from "../../theme/colors";
-import { typography, textStyles } from "../../theme/typography";
-import { Contact, UserSearchResult } from "../../types/contact";
+import { colors } from "../../theme/colors";
+import { Contact } from "../../types/contact";
 import { contactsAPI } from "../../services/contacts/api";
 import { messagingAPI } from "../../services/messaging/api";
 import { Avatar } from "./Avatar";
 import { logger } from "../../utils/logger";
-
-const AnimatedTouchableOpacity =
-  Animated.createAnimatedComponent(TouchableOpacity);
-const AnimatedView = Animated.createAnimatedComponent(View);
+import { formatUsername } from "../../utils";
 
 interface NewConversationModalProps {
   visible: boolean;
@@ -49,116 +32,69 @@ interface NewConversationModalProps {
   onConversationCreated: (conversationId: string) => void;
 }
 
-type ConversationType = "direct" | "group" | null;
+const getContactUserId = (contact: Contact): string | undefined =>
+  contact.contact_id || contact.contact_user?.id;
 
-type DirectTarget =
-  | { type: "contact"; contact: Contact }
-  | { type: "user"; user: UserSearchResult };
+const getContactDisplayName = (contact: Contact): string => {
+  if (contact.nickname) return contact.nickname;
+  const user = contact.contact_user;
+  if (!user) return "Contact";
+  const fullName = `${user.first_name ?? ""} ${user.last_name ?? ""}`.trim();
+  return fullName || formatUsername(user.username) || "Contact";
+};
 
 export const NewConversationModal: React.FC<NewConversationModalProps> = ({
   visible,
   onClose,
   onConversationCreated,
 }) => {
-  const [conversationType, setConversationType] =
-    useState<ConversationType>(null);
   const [contacts, setContacts] = useState<Contact[]>([]);
-  const [loadingContacts, setLoadingContacts] = useState(false);
+  const [loading, setLoading] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  const [userSearchResults, setUserSearchResults] = useState<
-    UserSearchResult[]
-  >([]);
-  const [selectedDirectTarget, setSelectedDirectTarget] =
-    useState<DirectTarget | null>(null);
-  const [selectedMembers, setSelectedMembers] = useState<Set<string>>(
-    new Set(),
-  );
-  const [groupName, setGroupName] = useState("");
-  const [groupDescription, setGroupDescription] = useState("");
-  const [groupPhoto, setGroupPhoto] = useState<string | null>(null);
-  const [groupSearchQuery, setGroupSearchQuery] = useState("");
-  const [groupUserSearchResults, setGroupUserSearchResults] = useState<
-    UserSearchResult[]
-  >([]);
-  const [loadingGroupSearch, setLoadingGroupSearch] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [creating, setCreating] = useState(false);
-  const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const groupSearchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const mountedRef = useRef(true);
-  const { getThemeColors } = useTheme();
-  const themeColors = getThemeColors();
+  const [groupName, setGroupName] = useState("");
+  const [groupNameTouched, setGroupNameTouched] = useState(false);
+  const insets = useSafeAreaInsets();
 
-  // Load contacts when modal opens
+  const resetState = useCallback(() => {
+    setSearchQuery("");
+    setSelectedIds(new Set());
+    setGroupName("");
+    setGroupNameTouched(false);
+  }, []);
+
   useEffect(() => {
-    if (visible && conversationType) {
-      loadContacts();
-    }
-  }, [visible, conversationType]);
-
-  const loadContacts = useCallback(async () => {
-    try {
-      setLoadingContacts(true);
-      const result = await contactsAPI.getContacts();
-      setContacts(result.contacts);
-    } catch (error) {
-      logger.error("NewConversationModal", "Error loading contacts", error);
-      Alert.alert("Erreur", "Impossible de charger les contacts");
-    } finally {
-      setLoadingContacts(false);
-    }
-  }, []);
-
-  const handleSearchChange = useCallback((query: string) => {
-    setSearchQuery(query);
-
-    if (searchTimeoutRef.current) {
-      clearTimeout(searchTimeoutRef.current);
-    }
-
-    const trimmed = query.trim();
-
-    if (!trimmed) {
-      setUserSearchResults([]);
-      setLoadingContacts(false);
-      return;
-    }
-
-    searchTimeoutRef.current = setTimeout(async () => {
+    if (!visible) return;
+    let cancelled = false;
+    (async () => {
       try {
-        setLoadingContacts(true);
-        const results = await contactsAPI.searchUsers({
-          username: trimmed,
-        });
-        setUserSearchResults(results);
+        setLoading(true);
+        const result = await contactsAPI.getContacts();
+        if (!cancelled) setContacts(result.contacts);
       } catch (error) {
-        logger.error("NewConversationModal", "Error searching users", error);
-        Alert.alert("Erreur", "Impossible de rechercher les utilisateurs");
-        setUserSearchResults([]);
+        logger.error("NewConversationModal", "Error loading contacts", error);
+        if (!cancelled) {
+          Alert.alert("Erreur", "Impossible de charger les contacts");
+        }
       } finally {
-        setLoadingContacts(false);
+        if (!cancelled) setLoading(false);
       }
-    }, 300);
-  }, []);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [visible]);
 
-  useEffect(
-    () => () => {
-      mountedRef.current = false;
-      if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
-      if (groupSearchTimeoutRef.current)
-        clearTimeout(groupSearchTimeoutRef.current);
-    },
-    [],
-  );
-
-  const filteredContacts = React.useMemo(() => {
-    if (!searchQuery.trim()) return contacts;
+  const filteredContacts = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
+    if (!query) return contacts;
     return contacts.filter((contact) => {
       const user = contact.contact_user;
-      const nickname = contact.nickname?.toLowerCase() || "";
-      const username = user?.username?.toLowerCase() || "";
-      const firstName = user?.first_name?.toLowerCase() || "";
-      const lastName = user?.last_name?.toLowerCase() || "";
+      const nickname = contact.nickname?.toLowerCase() ?? "";
+      const username = user?.username?.toLowerCase() ?? "";
+      const firstName = user?.first_name?.toLowerCase() ?? "";
+      const lastName = user?.last_name?.toLowerCase() ?? "";
       return (
         nickname.includes(query) ||
         username.includes(query) ||
@@ -168,99 +104,43 @@ export const NewConversationModal: React.FC<NewConversationModalProps> = ({
     });
   }, [contacts, searchQuery]);
 
-  const groupContacts = React.useMemo(() => {
-    if (!groupSearchQuery.trim()) return contacts;
-    const query = groupSearchQuery.trim().toLowerCase();
-    return contacts.filter((contact) => {
-      const user = contact.contact_user;
-      const nickname = contact.nickname?.toLowerCase() || "";
-      const username = user?.username?.toLowerCase() || "";
-      const firstName = user?.first_name?.toLowerCase() || "";
-      const lastName = user?.last_name?.toLowerCase() || "";
-      return (
-        nickname.includes(query) ||
-        username.includes(query) ||
-        firstName.includes(query) ||
-        lastName.includes(query)
-      );
-    });
-  }, [contacts, groupSearchQuery]);
+  const selectedContacts = useMemo(
+    () =>
+      contacts.filter((c) => {
+        const id = getContactUserId(c);
+        return id ? selectedIds.has(id) : false;
+      }),
+    [contacts, selectedIds],
+  );
 
-  const directListItems: DirectTarget[] = React.useMemo(() => {
-    const items: DirectTarget[] = filteredContacts.map((contact) => ({
-      type: "contact",
-      contact,
-    }));
+  const defaultGroupName = useMemo(() => {
+    if (selectedContacts.length < 2) return "";
+    const firstNames = selectedContacts
+      .slice(0, 3)
+      .map((c) => {
+        const display = getContactDisplayName(c);
+        return display.split(" ")[0];
+      })
+      .filter(Boolean);
+    return firstNames.join(", ");
+  }, [selectedContacts]);
 
-    if (searchQuery.trim() && userSearchResults.length > 0) {
-      const existingUserIds = new Set(
-        contacts
-          .map((c) => c.contact_user?.id ?? c.contact_id)
-          .filter((id): id is string => !!id),
-      );
-
-      userSearchResults.forEach((result) => {
-        const userId = result.user.id;
-        if (!existingUserIds.has(userId)) {
-          items.push({ type: "user", user: result });
-        }
-      });
+  useEffect(() => {
+    if (!groupNameTouched) {
+      setGroupName(defaultGroupName);
     }
+  }, [defaultGroupName, groupNameTouched]);
 
-    return items;
-  }, [filteredContacts, userSearchResults, contacts, searchQuery]);
-
-  // Animation values
-  const slideAnim = useSharedValue(0);
-  const scaleAnim = useSharedValue(1);
-  const fadeAnim = useSharedValue(1);
-
-  // Handle type selection with animation and haptics
-  const handleTypeSelect = (type: "direct" | "group") => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-    slideAnim.value = withSpring(-300, { damping: 15, stiffness: 150 });
-    fadeAnim.value = withTiming(0, { duration: 200 });
-
-    setTimeout(() => {
-      setConversationType(type);
-      setSelectedDirectTarget(null);
-      setSelectedMembers(new Set());
-      setGroupName("");
-      setGroupDescription("");
-      setGroupPhoto(null);
-      setSearchQuery("");
-      setGroupSearchQuery("");
-      setUserSearchResults([]);
-      slideAnim.value = 300;
-      fadeAnim.value = 0;
-      setTimeout(() => {
-        slideAnim.value = withSpring(0, { damping: 15, stiffness: 150 });
-        fadeAnim.value = withTiming(1, { duration: 200 });
-      }, 50);
-    }, 200);
-  };
-
-  // Handle contact selection for direct conversation with haptics
-  const handleContactSelect = (contact: Contact) => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    setSelectedDirectTarget({ type: "contact", contact });
-  };
-
-  // Handle member selection for group with haptics
-  const handleMemberToggle = (contact: Contact) => {
-    const userId = contact.contact_user?.id ?? contact.contact_id;
+  const toggleContact = useCallback((contact: Contact) => {
+    const userId = getContactUserId(contact);
     if (!userId) return;
-    toggleGroupMember(userId);
-  };
-
-  const toggleGroupMember = (userId: string) => {
-    setSelectedMembers((prev) => {
-      const newSet = new Set(prev);
-      if (newSet.has(userId)) {
-        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-        newSet.delete(userId);
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(userId)) {
+        next.delete(userId);
       } else {
-        if (newSet.size >= 49) {
+        if (next.size >= 49) {
           Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
           Alert.alert(
             "Limite atteinte",
@@ -268,1225 +148,150 @@ export const NewConversationModal: React.FC<NewConversationModalProps> = ({
           );
           return prev;
         }
-        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-        newSet.add(userId);
+        next.add(userId);
       }
-      return newSet;
+      return next;
     });
-  };
+  }, []);
 
-  const handleGroupSearchChange = useCallback(
-    (query: string) => {
-      setGroupSearchQuery(query);
-      if (groupSearchTimeoutRef.current)
-        clearTimeout(groupSearchTimeoutRef.current);
-      const trimmed = query.trim();
-      if (!trimmed) {
-        setGroupUserSearchResults([]);
-        return;
-      }
-      groupSearchTimeoutRef.current = setTimeout(async () => {
-        if (!mountedRef.current) return;
-        try {
-          setLoadingGroupSearch(true);
-          const results = await contactsAPI.searchUsers({ username: trimmed });
-          if (!mountedRef.current) return;
-          const contactUserIds = new Set(
-            contacts
-              .map((c) => c.contact_user?.id ?? c.contact_id)
-              .filter(Boolean),
-          );
-          setGroupUserSearchResults(
-            results.filter((r) => !contactUserIds.has(r.user.id)),
-          );
-        } catch {
-          if (!mountedRef.current) return;
-          setGroupUserSearchResults([]);
-        } finally {
-          if (mountedRef.current) setLoadingGroupSearch(false);
-        }
-      }, 400);
-    },
-    [contacts],
-  );
-
-  type PhotoSource = {
-    requestPermission: () => Promise<{ status: string }>;
-    launch: () => Promise<ImagePicker.ImagePickerResult>;
-    permissionMessage: string;
-    errorMessage: string;
-  };
-
-  const pickAndSetGroupPhoto = async ({
-    requestPermission,
-    launch,
-    permissionMessage,
-    errorMessage,
-  }: PhotoSource) => {
+  const handleClose = useCallback(() => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    try {
-      const { status } = await requestPermission();
-      if (status !== "granted") {
-        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
-        Alert.alert("Permission requise", permissionMessage);
-        return;
-      }
+    resetState();
+    onClose();
+  }, [onClose, resetState]);
 
-      const result = await launch();
-      const base64 = !result.canceled ? result.assets?.[0]?.base64 : undefined;
-      if (base64) {
-        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-        setGroupPhoto(`data:image/jpeg;base64,${base64}`);
-      }
-    } catch (error) {
-      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
-      Alert.alert("Erreur", errorMessage);
-    }
-  };
-
-  const handleSelectPhoto = () =>
-    pickAndSetGroupPhoto({
-      requestPermission: ImagePicker.requestMediaLibraryPermissionsAsync,
-      launch: () =>
-        ImagePicker.launchImageLibraryAsync({
-          mediaTypes: "images",
-          allowsEditing: true,
-          aspect: [1, 1],
-          quality: 0.5,
-          base64: true,
-        }),
-      permissionMessage:
-        "L'accès à la galerie est nécessaire pour sélectionner une photo",
-      errorMessage: "Impossible de sélectionner la photo",
-    });
-
-  const handleTakePhoto = () =>
-    pickAndSetGroupPhoto({
-      requestPermission: ImagePicker.requestCameraPermissionsAsync,
-      launch: () =>
-        ImagePicker.launchCameraAsync({
-          allowsEditing: true,
-          aspect: [1, 1],
-          quality: 0.5,
-          base64: true,
-        }),
-      permissionMessage:
-        "L'accès à la caméra est nécessaire pour prendre une photo",
-      errorMessage: "Impossible de prendre la photo",
-    });
-
-  // Handle create conversation with haptics and animations
-  const handleCreate = async () => {
-    if (conversationType === "direct") {
-      if (!selectedDirectTarget) {
-        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
-        Alert.alert("Contact requis", "Veuillez sélectionner un contact");
-        return;
-      }
-
+  const createDirect = useCallback(
+    async (userId: string) => {
       try {
         setCreating(true);
-        scaleAnim.value = withSequence(
-          withTiming(0.95, { duration: 100 }),
-          withSpring(1, { damping: 10, stiffness: 200 }),
-        );
-        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-
-        let userId: string | undefined;
-
-        if (selectedDirectTarget.type === "contact") {
-          userId =
-            selectedDirectTarget.contact.contact_user?.id ??
-            selectedDirectTarget.contact.contact_id;
-        } else {
-          userId = selectedDirectTarget.user.user.id;
-        }
-
-        if (!userId) {
-          throw new Error("Contact invalide");
-        }
-
         const conversation =
           await messagingAPI.createDirectConversation(userId);
-
         Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
         onConversationCreated(conversation.id);
-        handleClose();
-      } catch (error: any) {
-        // Error handled by Alert
+        resetState();
+      } catch (error: unknown) {
         Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
-        Alert.alert(
-          "Erreur",
-          error.message || "Impossible de créer la conversation",
-        );
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Impossible de créer la conversation";
+        Alert.alert("Erreur", message);
       } finally {
         setCreating(false);
       }
-    } else if (conversationType === "group") {
-      // Validate group name (3-100 characters)
-      if (!groupName.trim() || groupName.trim().length < 3) {
-        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
-        Alert.alert(
-          "Nom invalide",
-          "Le nom du groupe doit contenir entre 3 et 100 caractères",
-        );
-        return;
-      }
+    },
+    [onConversationCreated, resetState],
+  );
 
-      if (groupName.trim().length > 100) {
-        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
-        Alert.alert(
-          "Nom invalide",
-          "Le nom du groupe ne peut pas dépasser 100 caractères",
-        );
-        return;
-      }
-
-      // Validate at least one member selected
-      if (selectedMembers.size === 0) {
-        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
-        Alert.alert(
-          "Membres requis",
-          "Veuillez sélectionner au moins un membre",
-        );
-        return;
-      }
-
+  const createGroup = useCallback(
+    async (name: string, memberIds: string[]) => {
       try {
         setCreating(true);
-        scaleAnim.value = withSequence(
-          withTiming(0.95, { duration: 100 }),
-          withSpring(1, { damping: 10, stiffness: 200 }),
-        );
-        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
-
-        const memberIds = Array.from(selectedMembers);
-
         const conversation = await messagingAPI.createGroupConversation(
-          groupName.trim(),
+          name,
           memberIds,
-          groupDescription.trim() || undefined,
-          groupPhoto || undefined,
         );
-
         Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
         onConversationCreated(conversation.id);
-        handleClose();
-      } catch (error: any) {
-        // Error handled by Alert
+        resetState();
+      } catch {
         Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
         Alert.alert("Erreur", "Impossible de créer le groupe");
       } finally {
         setCreating(false);
       }
+    },
+    [onConversationCreated, resetState],
+  );
+
+  const handlePrimaryAction = useCallback(() => {
+    const memberIds = Array.from(selectedIds);
+    if (memberIds.length === 0) return;
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    if (memberIds.length === 1) {
+      createDirect(memberIds[0]);
+      return;
     }
-  };
+    const trimmed = groupName.trim();
+    if (trimmed.length < 3) {
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
+      Alert.alert(
+        "Nom invalide",
+        "Le nom du groupe doit contenir au moins 3 caractères",
+      );
+      return;
+    }
+    if (trimmed.length > 100) {
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
+      Alert.alert(
+        "Nom invalide",
+        "Le nom du groupe ne peut pas dépasser 100 caractères",
+      );
+      return;
+    }
+    createGroup(trimmed, memberIds);
+  }, [selectedIds, groupName, createDirect, createGroup]);
 
-  // Handle close with animation
-  const handleClose = () => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    fadeAnim.value = withTiming(0, { duration: 200 });
-    setTimeout(() => {
-      setConversationType(null);
-      setSelectedDirectTarget(null);
-      setSelectedMembers(new Set());
-      setGroupName("");
-      setGroupDescription("");
-      setGroupPhoto(null);
-      setSearchQuery("");
-      setGroupSearchQuery("");
-      setUserSearchResults([]);
-      setGroupUserSearchResults([]);
-      slideAnim.value = 0;
-      fadeAnim.value = 1;
-      onClose();
-    }, 200);
-  };
-
-  // Animated styles
-  const slideStyle = useAnimatedStyle(() => ({
-    transform: [{ translateX: slideAnim.value }],
-    opacity: fadeAnim.value,
-  }));
-
-  const buttonScaleStyle = useAnimatedStyle(() => ({
-    transform: [{ scale: scaleAnim.value }],
-  }));
-
-  // Render type selection screen with animations
-  const renderTypeSelection = () => (
-    <Animated.View
-      style={[styles.typeSelectionContainer, slideStyle]}
-      entering={FadeIn.duration(300).springify()}
-    >
-      <View style={styles.header}>
-        <View style={styles.placeholder} />
+  const renderContact = useCallback(
+    ({ item }: { item: Contact }) => {
+      const userId = getContactUserId(item);
+      const selected = userId ? selectedIds.has(userId) : false;
+      const displayName = getContactDisplayName(item);
+      return (
         <TouchableOpacity
-          onPress={handleClose}
-          style={styles.backButton}
+          style={styles.contactRow}
+          onPress={() => toggleContact(item)}
           activeOpacity={0.7}
         >
-          <Ionicons name="arrow-back" size={24} color={colors.text.light} />
-        </TouchableOpacity>
-      </View>
-      <Animated.Text
-        style={[
-          styles.screenTitle,
-          {
-            color: colors.text.light,
-            fontSize: typography.fontSize.xxxl,
-            fontWeight: typography.fontWeight.bold,
-            letterSpacing: typography.letterSpacing.tight,
-          },
-        ]}
-        entering={FadeIn.delay(100).duration(400)}
-      >
-        Nouvelle conversation
-      </Animated.Text>
-      <Animated.Text
-        style={[
-          styles.screenSubtitle,
-          {
-            color: colors.text.secondary,
-            fontSize: typography.fontSize.md,
-            fontWeight: typography.fontWeight.regular,
-          },
-        ]}
-        entering={FadeIn.delay(200).duration(400)}
-      >
-        Choisissez le type de conversation
-      </Animated.Text>
-
-      <View style={styles.typeButtonsContainer}>
-        <AnimatedTouchableOpacity
-          style={[
-            styles.typeButton,
-            { backgroundColor: colors.background.darkCard },
-          ]}
-          onPress={() => handleTypeSelect("direct")}
-          activeOpacity={0.8}
-          entering={FadeIn.delay(300).springify()}
-        >
-          <LinearGradient
-            colors={[colors.primary.main, colors.secondary.main]}
-            start={{ x: 0, y: 0 }}
-            end={{ x: 1, y: 1 }}
-            style={styles.typeButtonIcon}
-          >
-            <Ionicons name="person" size={32} color={colors.text.light} />
-          </LinearGradient>
-          <Text
+          <View
             style={[
-              styles.typeButtonTitle,
+              styles.checkbox,
+              selected && styles.checkboxSelected,
               {
-                color: colors.text.light,
-                fontSize: typography.fontSize.xl,
-                fontWeight: typography.fontWeight.semiBold,
-              },
-            ]}
-          >
-            Conversation directe
-          </Text>
-          <Text
-            style={[
-              styles.typeButtonSubtitle,
-              {
-                color: colors.text.secondary,
-                fontSize: typography.fontSize.sm,
-                fontWeight: typography.fontWeight.regular,
-              },
-            ]}
-          >
-            Discuter avec un contact
-          </Text>
-        </AnimatedTouchableOpacity>
-
-        <AnimatedTouchableOpacity
-          style={[
-            styles.typeButton,
-            { backgroundColor: colors.background.darkCard },
-          ]}
-          onPress={() => handleTypeSelect("group")}
-          activeOpacity={0.8}
-          entering={FadeIn.delay(400).springify()}
-        >
-          <LinearGradient
-            colors={[colors.secondary.main, colors.primary.main]}
-            start={{ x: 0, y: 0 }}
-            end={{ x: 1, y: 1 }}
-            style={styles.typeButtonIcon}
-          >
-            <Ionicons name="people" size={32} color={colors.text.light} />
-          </LinearGradient>
-          <Text
-            style={[
-              styles.typeButtonTitle,
-              {
-                color: colors.text.light,
-                fontSize: typography.fontSize.xl,
-                fontWeight: typography.fontWeight.semiBold,
-              },
-            ]}
-          >
-            Groupe
-          </Text>
-          <Text
-            style={[
-              styles.typeButtonSubtitle,
-              {
-                color: colors.text.secondary,
-                fontSize: typography.fontSize.sm,
-                fontWeight: typography.fontWeight.regular,
-              },
-            ]}
-          >
-            Créer un groupe de discussion
-          </Text>
-        </AnimatedTouchableOpacity>
-      </View>
-    </Animated.View>
-  );
-
-  // Render direct conversation screen with animations
-  const renderDirectConversation = () => (
-    <Animated.View
-      style={[styles.contentContainer, slideStyle]}
-      entering={SlideInDown.springify()}
-    >
-      <View
-        style={[
-          styles.header,
-          { borderBottomColor: withOpacity(colors.ui.divider, 0.3) },
-        ]}
-      >
-        <TouchableOpacity
-          onPress={() => {
-            Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-            setConversationType(null);
-          }}
-          style={styles.backButton}
-          activeOpacity={0.7}
-        >
-          <Ionicons name="arrow-back" size={24} color={colors.text.light} />
-        </TouchableOpacity>
-        <Text
-          style={[
-            styles.screenTitle,
-            {
-              color: colors.text.light,
-              fontSize: typography.fontSize.xxl,
-              fontWeight: typography.fontWeight.bold,
-            },
-          ]}
-        >
-          Nouvelle conversation
-        </Text>
-        <View style={styles.placeholder} />
-      </View>
-
-      <Animated.View
-        style={[
-          styles.searchContainer,
-          { backgroundColor: withOpacity(colors.background.darkCard, 0.8) },
-        ]}
-        entering={FadeIn.delay(100).duration(300)}
-      >
-        <Ionicons
-          name="search"
-          size={20}
-          color={colors.text.secondary}
-          style={styles.searchIcon}
-        />
-        <TextInput
-          style={[
-            styles.searchInput,
-            {
-              color: colors.text.light,
-              fontSize: typography.fontSize.base,
-              fontWeight: typography.fontWeight.regular,
-            },
-          ]}
-          placeholder="Rechercher un utilisateur"
-          placeholderTextColor={colors.text.tertiary}
-          value={searchQuery}
-          onChangeText={handleSearchChange}
-        />
-      </Animated.View>
-
-      {loadingContacts ? (
-        <View style={styles.loadingContainer}>
-          <ActivityIndicator size="large" color={colors.primary.main} />
-        </View>
-      ) : (
-        <FlatList
-          data={directListItems}
-          keyExtractor={(item) =>
-            item.type === "contact"
-              ? item.contact.id
-              : `user-${item.user.user.id}`
-          }
-          renderItem={({ item }) => {
-            if (item.type === "contact") {
-              const contact = item.contact;
-              const user = contact.contact_user;
-              const displayName =
-                contact.nickname ||
-                user?.first_name ||
-                user?.username ||
-                "Contact";
-              const isSelected =
-                selectedDirectTarget?.type === "contact" &&
-                selectedDirectTarget.contact.id === contact.id;
-
-              return (
-                <AnimatedTouchableOpacity
-                  key={contact.id}
-                  style={[
-                    styles.contactItem,
-                    { backgroundColor: colors.background.darkCard },
-                    isSelected && {
-                      backgroundColor: withOpacity(colors.primary.main, 0.2),
-                    },
-                  ]}
-                  onPress={() => handleContactSelect(contact)}
-                  activeOpacity={0.7}
-                  entering={FadeIn.duration(200)}
-                >
-                  <Avatar
-                    uri={user?.avatar_url}
-                    name={displayName}
-                    size={48}
-                    showOnlineBadge={false}
-                  />
-                  <View style={styles.contactInfo}>
-                    <Text
-                      style={[
-                        styles.contactName,
-                        {
-                          color: colors.text.light,
-                          fontSize: typography.fontSize.base,
-                          fontWeight: typography.fontWeight.semiBold,
-                        },
-                      ]}
-                    >
-                      {displayName}
-                    </Text>
-                    {user?.username && (
-                      <Text
-                        style={[
-                          styles.contactUsername,
-                          {
-                            color: colors.text.secondary,
-                            fontSize: typography.fontSize.sm,
-                            fontWeight: typography.fontWeight.regular,
-                          },
-                        ]}
-                      >
-                        {formatUsername(user.username)}
-                      </Text>
-                    )}
-                  </View>
-                  {isSelected && (
-                    <Animated.View entering={FadeIn.springify()}>
-                      <Ionicons
-                        name="checkmark-circle"
-                        size={24}
-                        color={colors.primary.main}
-                      />
-                    </Animated.View>
-                  )}
-                </AnimatedTouchableOpacity>
-              );
-            }
-
-            const result = item.user;
-            const user = result.user;
-            const displayName =
-              user.first_name || user.username || "Utilisateur";
-            const isSelected =
-              selectedDirectTarget?.type === "user" &&
-              selectedDirectTarget.user.user.id === user.id;
-
-            return (
-              <AnimatedTouchableOpacity
-                key={user.id}
-                style={[
-                  styles.contactItem,
-                  { backgroundColor: colors.background.darkCard },
-                  isSelected && {
-                    backgroundColor: withOpacity(colors.primary.main, 0.2),
-                  },
-                ]}
-                onPress={() => {
-                  Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                  setSelectedDirectTarget(item);
-                }}
-                activeOpacity={0.7}
-                entering={FadeIn.duration(200)}
-              >
-                <Avatar
-                  uri={user.avatar_url}
-                  name={displayName}
-                  size={48}
-                  showOnlineBadge={false}
-                />
-                <View style={styles.contactInfo}>
-                  <Text
-                    style={[
-                      styles.contactName,
-                      {
-                        color: colors.text.light,
-                        fontSize: typography.fontSize.base,
-                        fontWeight: typography.fontWeight.semiBold,
-                      },
-                    ]}
-                  >
-                    {displayName}
-                  </Text>
-                  {user.username && (
-                    <Text
-                      style={[
-                        styles.contactUsername,
-                        {
-                          color: colors.text.secondary,
-                          fontSize: typography.fontSize.sm,
-                          fontWeight: typography.fontWeight.regular,
-                        },
-                      ]}
-                    >
-                      {formatUsername(user.username)}
-                    </Text>
-                  )}
-                </View>
-                {isSelected && (
-                  <Animated.View entering={FadeIn.springify()}>
-                    <Ionicons
-                      name="checkmark-circle"
-                      size={24}
-                      color={colors.primary.main}
-                    />
-                  </Animated.View>
-                )}
-              </AnimatedTouchableOpacity>
-            );
-          }}
-          ListEmptyComponent={
-            <View style={styles.emptyContainer}>
-              <Text
-                style={[styles.emptyText, { color: colors.text.secondary }]}
-              >
-                Aucun contact trouvé
-              </Text>
-            </View>
-          }
-        />
-      )}
-
-      {selectedDirectTarget && (
-        <AnimatedTouchableOpacity
-          style={[
-            styles.createButton,
-            { backgroundColor: colors.primary.main },
-            buttonScaleStyle,
-          ]}
-          onPress={handleCreate}
-          disabled={creating}
-          activeOpacity={0.8}
-          entering={FadeIn.delay(200).springify()}
-        >
-          {creating ? (
-            <ActivityIndicator color={colors.text.light} size="small" />
-          ) : (
-            <Text
-              style={[
-                styles.createButtonText,
-                {
-                  color: colors.text.light,
-                  fontSize: typography.fontSize.base,
-                  fontWeight: typography.fontWeight.semiBold,
-                },
-              ]}
-            >
-              Créer la conversation
-            </Text>
-          )}
-        </AnimatedTouchableOpacity>
-      )}
-    </Animated.View>
-  );
-
-  // Render group creation screen with animations
-  const renderGroupCreation = () => {
-    const selectedContacts = contacts.filter((c) => {
-      const uid = c.contact_user?.id ?? c.contact_id;
-      return uid && selectedMembers.has(uid);
-    });
-
-    return (
-      <Animated.View
-        style={[styles.contentContainer, slideStyle]}
-        entering={SlideInDown.springify()}
-      >
-        <View
-          style={[
-            styles.header,
-            { borderBottomColor: withOpacity(colors.ui.divider, 0.3) },
-          ]}
-        >
-          <TouchableOpacity
-            onPress={() => {
-              Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-              setConversationType(null);
-            }}
-            style={styles.backButton}
-            activeOpacity={0.7}
-          >
-            <Ionicons name="arrow-back" size={24} color={colors.text.light} />
-          </TouchableOpacity>
-          <Text
-            style={[
-              styles.screenTitle,
-              {
-                color: colors.text.light,
-                fontSize: typography.fontSize.xxl,
-                fontWeight: typography.fontWeight.bold,
-              },
-            ]}
-          >
-            Nouveau groupe
-          </Text>
-          <View style={styles.placeholder} />
-        </View>
-
-        <ScrollView
-          style={styles.scrollView}
-          showsVerticalScrollIndicator={false}
-        >
-          {/* Group Photo */}
-          <Animated.View
-            style={styles.photoSection}
-            entering={FadeIn.delay(100).duration(300)}
-          >
-            <TouchableOpacity
-              style={styles.photoContainer}
-              onPress={handleSelectPhoto}
-              activeOpacity={0.8}
-            >
-              {groupPhoto ? (
-                <Image source={{ uri: groupPhoto }} style={styles.groupPhoto} />
-              ) : (
-                <View
-                  style={[
-                    styles.photoPlaceholder,
-                    { backgroundColor: colors.background.darkCard },
-                  ]}
-                >
-                  <Ionicons
-                    name="camera"
-                    size={40}
-                    color={colors.text.secondary}
-                  />
-                </View>
-              )}
-              <View
-                style={[
-                  styles.photoOverlay,
-                  { backgroundColor: colors.primary.main },
-                ]}
-              >
-                <Ionicons name="camera" size={20} color={colors.text.light} />
-              </View>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={styles.takePhotoButton}
-              onPress={handleTakePhoto}
-              activeOpacity={0.7}
-            >
-              <Text
-                style={[
-                  styles.takePhotoText,
-                  {
-                    color: colors.primary.main,
-                    fontSize: typography.fontSize.sm,
-                    fontWeight: typography.fontWeight.semiBold,
-                  },
-                ]}
-              >
-                Prendre une photo
-              </Text>
-            </TouchableOpacity>
-          </Animated.View>
-
-          {/* Group Name */}
-          <Animated.View
-            style={styles.inputSection}
-            entering={FadeIn.delay(200).duration(300)}
-          >
-            <Text
-              style={[
-                styles.inputLabel,
-                {
-                  color: colors.text.light,
-                  fontSize: typography.fontSize.md,
-                  fontWeight: typography.fontWeight.semiBold,
-                },
-              ]}
-            >
-              Nom du groupe *
-            </Text>
-            <TextInput
-              style={[
-                styles.input,
-                {
-                  backgroundColor: colors.background.darkCard,
-                  color: colors.text.light,
-                  borderColor:
-                    groupName.trim().length > 0 && groupName.trim().length < 3
-                      ? colors.ui.error
-                      : "transparent",
-                  fontSize: typography.fontSize.base,
-                  fontWeight: typography.fontWeight.regular,
-                },
-              ]}
-              placeholder="Nom du groupe (3-100 caractères)"
-              placeholderTextColor={colors.text.tertiary}
-              value={groupName}
-              onChangeText={setGroupName}
-              maxLength={100}
-            />
-            {groupName.trim().length > 0 && groupName.trim().length < 3 && (
-              <Animated.Text
-                style={[
-                  styles.errorText,
-                  {
-                    color: colors.ui.error,
-                    fontSize: typography.fontSize.xs,
-                    fontWeight: typography.fontWeight.regular,
-                  },
-                ]}
-                entering={FadeIn.duration(200)}
-              >
-                Le nom doit contenir au moins 3 caractères
-              </Animated.Text>
-            )}
-            <Text
-              style={[
-                styles.helperText,
-                {
-                  color: colors.text.secondary,
-                  fontSize: typography.fontSize.xs,
-                  fontWeight: typography.fontWeight.regular,
-                },
-              ]}
-            >
-              {groupName.length}/100
-            </Text>
-          </Animated.View>
-
-          {/* Group Description */}
-          <Animated.View
-            style={styles.inputSection}
-            entering={FadeIn.delay(300).duration(300)}
-          >
-            <Text
-              style={[
-                styles.inputLabel,
-                {
-                  color: colors.text.light,
-                  fontSize: typography.fontSize.md,
-                  fontWeight: typography.fontWeight.semiBold,
-                },
-              ]}
-            >
-              Description (optionnel)
-            </Text>
-            <TextInput
-              style={[
-                styles.input,
-                styles.textArea,
-                {
-                  backgroundColor: colors.background.darkCard,
-                  color: colors.text.light,
-                  fontSize: typography.fontSize.base,
-                  fontWeight: typography.fontWeight.regular,
-                },
-              ]}
-              placeholder="Description du groupe (max 500 caractères)"
-              placeholderTextColor={colors.text.tertiary}
-              value={groupDescription}
-              onChangeText={setGroupDescription}
-              multiline
-              numberOfLines={3}
-              maxLength={500}
-            />
-            <Text
-              style={[
-                styles.helperText,
-                {
-                  color: colors.text.secondary,
-                  fontSize: typography.fontSize.xs,
-                  fontWeight: typography.fontWeight.regular,
-                },
-              ]}
-            >
-              {groupDescription.length}/500
-            </Text>
-          </Animated.View>
-
-          {/* Members Selection */}
-          <Animated.View
-            style={styles.membersSection}
-            entering={FadeIn.delay(400).duration(300)}
-          >
-            <View style={styles.membersHeader}>
-              <Text
-                style={[
-                  styles.inputLabel,
-                  {
-                    color: colors.text.light,
-                    fontSize: typography.fontSize.md,
-                    fontWeight: typography.fontWeight.semiBold,
-                  },
-                ]}
-              >
-                Membres ({selectedMembers.size}/50)
-              </Text>
-              <View
-                style={[
-                  styles.searchContainer,
-                  {
-                    backgroundColor: withOpacity(
-                      colors.background.darkCard,
-                      0.8,
-                    ),
-                  },
-                ]}
-              >
-                <Ionicons
-                  name="search"
-                  size={20}
-                  color={colors.text.secondary}
-                  style={styles.searchIcon}
-                />
-                <TextInput
-                  style={[
-                    styles.searchInput,
-                    {
-                      color: colors.text.light,
-                      fontSize: typography.fontSize.base,
-                      fontWeight: typography.fontWeight.regular,
-                    },
-                  ]}
-                  placeholder="Rechercher par nom, @pseudo ou numéro..."
-                  placeholderTextColor={colors.text.tertiary}
-                  value={groupSearchQuery}
-                  onChangeText={handleGroupSearchChange}
-                />
-              </View>
-            </View>
-
-            {/* Selected Members Preview */}
-            {selectedContacts.length > 0 && (
-              <Animated.View
-                style={styles.selectedMembersContainer}
-                entering={FadeIn.duration(300)}
-              >
-                <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-                  {selectedContacts.map((contact, index) => {
-                    const user = contact.contact_user;
-                    const displayName =
-                      contact.nickname ||
-                      user?.first_name ||
-                      user?.username ||
-                      "Contact";
-                    return (
-                      <Animated.View
-                        key={contact.id}
-                        style={styles.selectedMemberChip}
-                        entering={FadeIn.delay(index * 50).springify()}
-                      >
-                        <Avatar
-                          uri={user?.avatar_url}
-                          name={displayName}
-                          size={32}
-                          showOnlineBadge={false}
-                        />
-                        <TouchableOpacity
-                          style={styles.removeMemberButton}
-                          onPress={() => handleMemberToggle(contact)}
-                          activeOpacity={0.7}
-                        >
-                          <Ionicons
-                            name="close-circle"
-                            size={18}
-                            color={colors.ui.error}
-                          />
-                        </TouchableOpacity>
-                      </Animated.View>
-                    );
-                  })}
-                </ScrollView>
-              </Animated.View>
-            )}
-
-            {/* Contacts List */}
-            {loadingContacts ? (
-              <View style={styles.loadingContainer}>
-                <ActivityIndicator size="large" color={colors.primary.main} />
-              </View>
-            ) : (
-              <FlatList
-                data={groupContacts}
-                keyExtractor={(item) => item.id}
-                scrollEnabled={false}
-                renderItem={({ item }) => {
-                  const user = item.contact_user;
-                  const userId = user?.id;
-                  const displayName =
-                    item.nickname ||
-                    user?.first_name ||
-                    user?.username ||
-                    "Contact";
-                  const isSelected = userId
-                    ? selectedMembers.has(userId)
-                    : false;
-
-                  if (!userId) return null;
-
-                  return (
-                    <AnimatedTouchableOpacity
-                      key={item.id}
-                      style={[
-                        styles.contactItem,
-                        { backgroundColor: colors.background.darkCard },
-                        isSelected && {
-                          backgroundColor: withOpacity(
-                            colors.primary.main,
-                            0.2,
-                          ),
-                        },
-                      ]}
-                      onPress={() => handleMemberToggle(item)}
-                      activeOpacity={0.7}
-                      entering={FadeIn.duration(200)}
-                    >
-                      <Avatar
-                        uri={user?.avatar_url}
-                        name={displayName}
-                        size={48}
-                        showOnlineBadge={false}
-                      />
-                      <View style={styles.contactInfo}>
-                        <Text
-                          style={[
-                            styles.contactName,
-                            {
-                              color: colors.text.light,
-                              fontSize: typography.fontSize.base,
-                              fontWeight: typography.fontWeight.semiBold,
-                            },
-                          ]}
-                        >
-                          {displayName}
-                        </Text>
-                        {user?.username && (
-                          <Text
-                            style={[
-                              styles.contactUsername,
-                              {
-                                color: colors.text.secondary,
-                                fontSize: typography.fontSize.sm,
-                                fontWeight: typography.fontWeight.regular,
-                              },
-                            ]}
-                          >
-                            {formatUsername(user.username)}
-                          </Text>
-                        )}
-                      </View>
-                      {isSelected ? (
-                        <Animated.View entering={FadeIn.springify()}>
-                          <Ionicons
-                            name="checkmark-circle"
-                            size={24}
-                            color={colors.primary.main}
-                          />
-                        </Animated.View>
-                      ) : (
-                        <View
-                          style={[
-                            styles.checkbox,
-                            { borderColor: colors.text.tertiary },
-                          ]}
-                        />
-                      )}
-                    </AnimatedTouchableOpacity>
-                  );
-                }}
-                ListEmptyComponent={
-                  groupUserSearchResults.length === 0 && !loadingGroupSearch ? (
-                    <View style={styles.emptyContainer}>
-                      <Text
-                        style={[
-                          styles.emptyText,
-                          { color: colors.text.secondary },
-                        ]}
-                      >
-                        Aucun contact trouvé
-                      </Text>
-                    </View>
-                  ) : null
-                }
-              />
-            )}
-
-            {/* Non-contact search results (by phone/username) */}
-            {loadingGroupSearch && (
-              <View style={styles.loadingContainer}>
-                <ActivityIndicator size="small" color={colors.primary.main} />
-              </View>
-            )}
-            {!loadingGroupSearch && groupUserSearchResults.length > 0 && (
-              <>
-                <Text
-                  style={[
-                    styles.inputLabel,
-                    {
-                      color: colors.text.secondary,
-                      fontSize: typography.fontSize.sm,
-                      marginTop: 12,
-                      marginBottom: 4,
-                    },
-                  ]}
-                >
-                  Autres utilisateurs
-                </Text>
-                {groupUserSearchResults.map((result) => {
-                  const user = result.user;
-                  const isSelected = selectedMembers.has(user.id);
-                  const displayName =
-                    user.first_name || user.username || user.id;
-                  return (
-                    <AnimatedTouchableOpacity
-                      key={`search-${user.id}`}
-                      style={[
-                        styles.contactItem,
-                        { backgroundColor: colors.background.darkCard },
-                        isSelected && {
-                          backgroundColor: withOpacity(
-                            colors.primary.main,
-                            0.2,
-                          ),
-                        },
-                      ]}
-                      onPress={() => toggleGroupMember(user.id)}
-                      activeOpacity={0.7}
-                      entering={FadeIn.duration(200)}
-                    >
-                      <Avatar
-                        uri={user.avatar_url}
-                        name={displayName}
-                        size={48}
-                        showOnlineBadge={false}
-                      />
-                      <View style={styles.contactInfo}>
-                        <Text
-                          style={[
-                            styles.contactName,
-                            {
-                              color: colors.text.light,
-                              fontSize: typography.fontSize.base,
-                              fontWeight: typography.fontWeight.semiBold,
-                            },
-                          ]}
-                        >
-                          {displayName}
-                        </Text>
-                        {user.username && (
-                          <Text
-                            style={[
-                              styles.contactUsername,
-                              {
-                                color: colors.text.secondary,
-                                fontSize: typography.fontSize.sm,
-                              },
-                            ]}
-                          >
-                            {formatUsername(user.username)}
-                          </Text>
-                        )}
-                      </View>
-                      {isSelected ? (
-                        <Animated.View entering={FadeIn.springify()}>
-                          <Ionicons
-                            name="checkmark-circle"
-                            size={24}
-                            color={colors.primary.main}
-                          />
-                        </Animated.View>
-                      ) : (
-                        <View
-                          style={[
-                            styles.checkbox,
-                            { borderColor: colors.text.tertiary },
-                          ]}
-                        />
-                      )}
-                    </AnimatedTouchableOpacity>
-                  );
-                })}
-              </>
-            )}
-          </Animated.View>
-        </ScrollView>
-
-        {/* Create Button */}
-        <AnimatedTouchableOpacity
-          style={[
-            styles.createButton,
-            {
-              backgroundColor:
-                groupName.trim().length >= 3 && selectedMembers.size > 0
+                borderColor: selected
                   ? colors.primary.main
-                  : colors.background.tertiary,
-            },
-            buttonScaleStyle,
-          ]}
-          onPress={handleCreate}
-          disabled={
-            creating ||
-            groupName.trim().length < 3 ||
-            selectedMembers.size === 0
-          }
-          activeOpacity={0.8}
-          entering={FadeIn.delay(500).springify()}
-        >
-          {creating ? (
-            <ActivityIndicator color={colors.text.light} size="small" />
-          ) : (
-            <Text
-              style={[
-                styles.createButtonText,
-                {
-                  color: colors.text.light,
-                  fontSize: typography.fontSize.base,
-                  fontWeight: typography.fontWeight.semiBold,
-                },
-              ]}
-            >
-              Créer le groupe
+                  : "rgba(255, 255, 255, 0.5)",
+              },
+            ]}
+          >
+            {selected && (
+              <Ionicons name="checkmark" size={16} color={colors.text.light} />
+            )}
+          </View>
+          <Avatar
+            size={44}
+            uri={item.contact_user?.avatar_url}
+            name={displayName}
+          />
+          <View style={styles.contactText}>
+            <Text style={styles.contactName} numberOfLines={1}>
+              {displayName}
             </Text>
-          )}
-        </AnimatedTouchableOpacity>
-      </Animated.View>
-    );
-  };
+            {item.contact_user?.username ? (
+              <Text style={styles.contactUsername} numberOfLines={1}>
+                {formatUsername(item.contact_user.username)}
+              </Text>
+            ) : null}
+          </View>
+        </TouchableOpacity>
+      );
+    },
+    [selectedIds, toggleContact],
+  );
+
+  const keyExtractor = useCallback(
+    (item: Contact) => getContactUserId(item) ?? item.id,
+    [],
+  );
+
+  const primaryButtonLabel =
+    selectedIds.size <= 1 ? "Créer la conversation" : "Créer le groupe";
 
   return (
     <Modal
       visible={visible}
       animationType="slide"
-      presentationStyle="pageSheet"
+      presentationStyle="fullScreen"
       onRequestClose={handleClose}
     >
       <LinearGradient
@@ -1496,9 +301,157 @@ export const NewConversationModal: React.FC<NewConversationModalProps> = ({
         style={styles.gradientContainer}
       >
         <SafeAreaView style={styles.container} edges={["top"]}>
-          {!conversationType && renderTypeSelection()}
-          {conversationType === "direct" && renderDirectConversation()}
-          {conversationType === "group" && renderGroupCreation()}
+          <View style={[styles.header, { marginTop: insets.top }]}>
+            <TouchableOpacity
+              onPress={handleClose}
+              style={styles.closeButton}
+              hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            >
+              <Ionicons name="close" size={20} color={colors.text.light} />
+            </TouchableOpacity>
+            {selectedIds.size >= 2 ? (
+              <View style={styles.headerTitleEditable}>
+                <TextInput
+                  style={styles.headerTitleInput}
+                  value={groupName}
+                  onChangeText={(text) => {
+                    setGroupName(text);
+                    setGroupNameTouched(true);
+                  }}
+                  placeholder="Nom du groupe"
+                  placeholderTextColor="rgba(255, 255, 255, 0.5)"
+                  maxLength={100}
+                  returnKeyType="done"
+                />
+                <Ionicons
+                  name="pencil"
+                  size={14}
+                  color="rgba(255, 255, 255, 0.6)"
+                  style={styles.headerTitleEditIcon}
+                />
+              </View>
+            ) : (
+              <Text style={styles.headerTitle}>Nouvelle conversation</Text>
+            )}
+            <View style={styles.headerButton} />
+          </View>
+
+          <View style={styles.searchBar}>
+            <Ionicons
+              name="search-outline"
+              size={20}
+              color="rgba(255, 255, 255, 0.7)"
+              style={styles.searchIcon}
+            />
+            <TextInput
+              style={styles.searchInput}
+              placeholder="Rechercher un contact"
+              placeholderTextColor="rgba(255, 255, 255, 0.6)"
+              value={searchQuery}
+              onChangeText={setSearchQuery}
+              autoCorrect={false}
+              autoCapitalize="none"
+            />
+            {searchQuery.length > 0 && (
+              <TouchableOpacity
+                onPress={() => setSearchQuery("")}
+                style={styles.clearButton}
+              >
+                <Ionicons
+                  name="close-circle"
+                  size={20}
+                  color="rgba(255, 255, 255, 0.7)"
+                />
+              </TouchableOpacity>
+            )}
+          </View>
+
+          {selectedContacts.length > 0 && (
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              style={styles.chipsRow}
+              contentContainerStyle={styles.chipsContent}
+            >
+              {selectedContacts.map((contact) => {
+                const userId = getContactUserId(contact);
+                if (!userId) return null;
+                return (
+                  <TouchableOpacity
+                    key={userId}
+                    style={styles.chip}
+                    onPress={() => toggleContact(contact)}
+                    activeOpacity={0.7}
+                  >
+                    <Avatar
+                      size={24}
+                      uri={contact.contact_user?.avatar_url}
+                      name={getContactDisplayName(contact)}
+                    />
+                    <Text style={styles.chipText} numberOfLines={1}>
+                      {getContactDisplayName(contact)}
+                    </Text>
+                    <Ionicons
+                      name="close"
+                      size={14}
+                      color="rgba(255, 255, 255, 0.8)"
+                    />
+                  </TouchableOpacity>
+                );
+              })}
+            </ScrollView>
+          )}
+
+          {loading ? (
+            <View style={styles.centered}>
+              <ActivityIndicator color={colors.primary.main} />
+            </View>
+          ) : filteredContacts.length === 0 ? (
+            <View style={styles.centered}>
+              <Text style={styles.emptyText}>
+                {searchQuery.trim()
+                  ? "Aucun contact trouvé"
+                  : "Aucun contact disponible"}
+              </Text>
+            </View>
+          ) : (
+            <FlatList
+              data={filteredContacts}
+              renderItem={renderContact}
+              keyExtractor={keyExtractor}
+              contentContainerStyle={[
+                styles.listContent,
+                {
+                  paddingBottom:
+                    insets.bottom + (selectedIds.size > 0 ? 96 : 24),
+                },
+              ]}
+              keyboardShouldPersistTaps="handled"
+            />
+          )}
+
+          {selectedIds.size > 0 && (
+            <View style={[styles.bottomBar, { bottom: 16 + insets.bottom }]}>
+              <TouchableOpacity
+                style={[
+                  styles.primaryButton,
+                  creating && styles.primaryButtonDisabled,
+                ]}
+                onPress={handlePrimaryAction}
+                disabled={creating}
+                activeOpacity={0.8}
+              >
+                {creating ? (
+                  <ActivityIndicator color={colors.text.light} />
+                ) : (
+                  <Text style={styles.primaryButtonText}>
+                    {primaryButtonLabel}
+                    {selectedIds.size > 1 ? ` (${selectedIds.size})` : ""}
+                  </Text>
+                )}
+              </TouchableOpacity>
+            </View>
+          )}
         </SafeAreaView>
       </LinearGradient>
     </Modal>
@@ -1513,218 +466,164 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: "transparent",
   },
-  typeSelectionContainer: {
-    flex: 1,
-    paddingHorizontal: 24,
-    paddingTop: 16,
-    paddingBottom: 24,
-    justifyContent: "flex-start",
-  },
-  screenTitle: {
-    marginBottom: 8,
-    textAlign: "center",
-  },
-  screenSubtitle: {
-    marginBottom: 32,
-    textAlign: "center",
-  },
-  typeButtonsContainer: {
-    gap: 16,
-  },
-  typeButton: {
-    padding: 24,
-    borderRadius: 16,
-    alignItems: "center",
-  },
-  typeButtonIcon: {
-    width: 64,
-    height: 64,
-    borderRadius: 32,
-    justifyContent: "center",
-    alignItems: "center",
-    marginBottom: 16,
-  },
-  typeButtonTitle: {
-    marginBottom: 4,
-  },
-  typeButtonSubtitle: {
-    // Typography applied inline
-  },
-  contentContainer: {
-    flex: 1,
-  },
   header: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
     paddingHorizontal: 16,
     paddingVertical: 12,
-    borderBottomWidth: 1,
-    borderBottomColor: "rgba(255, 255, 255, 0.1)",
   },
-  backButton: {
-    padding: 8,
-  },
-  placeholder: {
+  headerButton: {
     width: 40,
+    height: 40,
+    alignItems: "center",
+    justifyContent: "center",
   },
-  searchContainer: {
+  closeButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "rgba(255, 255, 255, 0.12)",
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.2)",
+  },
+  headerTitle: {
+    color: colors.text.light,
+    fontSize: 17,
+    fontWeight: "600",
+  },
+  headerTitleEditable: {
+    flexDirection: "row",
+    alignItems: "center",
+    flex: 1,
+    justifyContent: "center",
+    marginHorizontal: 8,
+  },
+  headerTitleInput: {
+    color: colors.text.light,
+    fontSize: 17,
+    fontWeight: "600",
+    padding: 0,
+    textAlign: "center",
+    flexShrink: 1,
+  },
+  headerTitleEditIcon: {
+    marginLeft: 6,
+  },
+  searchBar: {
     flexDirection: "row",
     alignItems: "center",
     marginHorizontal: 16,
-    marginVertical: 12,
+    marginBottom: 8,
     paddingHorizontal: 12,
     paddingVertical: 8,
-    borderRadius: 12,
+    borderRadius: 10,
+    backgroundColor: "rgba(255, 255, 255, 0.15)",
   },
   searchIcon: {
     marginRight: 8,
   },
   searchInput: {
     flex: 1,
-    fontSize: 16,
+    fontSize: 15,
+    color: colors.text.light,
+    padding: 0,
   },
-  scrollView: {
-    flex: 1,
+  clearButton: {
+    marginLeft: 8,
+    padding: 4,
   },
-  photoSection: {
-    alignItems: "center",
-    paddingVertical: 24,
-  },
-  photoContainer: {
-    width: 120,
-    height: 120,
-    borderRadius: 60,
-    marginBottom: 12,
-    position: "relative",
-  },
-  groupPhoto: {
-    width: 120,
-    height: 120,
-    borderRadius: 60,
-  },
-  photoPlaceholder: {
-    width: 120,
-    height: 120,
-    borderRadius: 60,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  photoOverlay: {
-    position: "absolute",
-    bottom: 0,
-    right: 0,
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    justifyContent: "center",
-    alignItems: "center",
-    borderWidth: 3,
-    borderColor: "#FFFFFF",
-  },
-  takePhotoButton: {
-    paddingVertical: 8,
-    paddingHorizontal: 16,
-  },
-  takePhotoText: {
-    fontSize: 14,
-    fontWeight: "600",
-  },
-  inputSection: {
-    paddingHorizontal: 16,
-    marginBottom: 24,
-  },
-  inputLabel: {
-    fontSize: 16,
-    fontWeight: "600",
+  chipsRow: {
+    maxHeight: 48,
     marginBottom: 8,
   },
-  input: {
+  chipsContent: {
     paddingHorizontal: 16,
-    paddingVertical: 12,
-    borderRadius: 12,
-    fontSize: 16,
-    borderWidth: 1,
+    gap: 8,
+    alignItems: "center",
   },
-  textArea: {
-    minHeight: 80,
-    textAlignVertical: "top",
-  },
-  helperText: {
-    fontSize: 12,
-    marginTop: 4,
-  },
-  errorText: {
-    fontSize: 12,
-    marginTop: 4,
-  },
-  membersSection: {
-    paddingHorizontal: 16,
-    marginBottom: 24,
-  },
-  membersHeader: {
-    marginBottom: 12,
-  },
-  selectedMembersContainer: {
-    marginBottom: 16,
-    paddingVertical: 8,
-  },
-  selectedMemberChip: {
-    marginRight: 8,
-    position: "relative",
-  },
-  removeMemberButton: {
-    position: "absolute",
-    top: -4,
-    right: -4,
-    backgroundColor: "#FFFFFF",
-    borderRadius: 9,
-  },
-  contactItem: {
+  chip: {
     flexDirection: "row",
     alignItems: "center",
-    padding: 12,
-    borderRadius: 12,
-    marginBottom: 8,
+    paddingLeft: 4,
+    paddingRight: 10,
+    height: 36,
+    borderRadius: 999,
+    backgroundColor: "rgba(255, 255, 255, 0.15)",
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.2)",
+    gap: 8,
   },
-  contactInfo: {
-    flex: 1,
-    marginLeft: 12,
+  chipText: {
+    color: colors.text.light,
+    fontSize: 13,
+    fontWeight: "500",
+    maxWidth: 120,
   },
-  contactName: {
-    fontSize: 16,
-    fontWeight: "600",
-    marginBottom: 2,
+  listContent: {
+    paddingHorizontal: 16,
   },
-  contactUsername: {
-    fontSize: 14,
+  contactRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 8,
+    gap: 12,
   },
   checkbox: {
     width: 24,
     height: 24,
     borderRadius: 12,
     borderWidth: 2,
-  },
-  loadingContainer: {
-    padding: 32,
+    justifyContent: "center",
     alignItems: "center",
   },
-  emptyContainer: {
-    padding: 32,
-    alignItems: "center",
+  checkboxSelected: {
+    backgroundColor: colors.primary.main,
   },
-  emptyText: {
+  contactText: {
+    flex: 1,
+  },
+  contactName: {
+    color: colors.text.light,
     fontSize: 16,
+    fontWeight: "600",
   },
-  createButton: {
-    marginHorizontal: 16,
-    marginVertical: 16,
-    paddingVertical: 16,
-    borderRadius: 12,
+  contactUsername: {
+    color: "rgba(255, 255, 255, 0.6)",
+    fontSize: 13,
+    marginTop: 2,
+  },
+  centered: {
+    flex: 1,
     alignItems: "center",
     justifyContent: "center",
+    paddingHorizontal: 32,
   },
-  createButtonText: {
+  emptyText: {
+    color: "rgba(255, 255, 255, 0.7)",
+    fontSize: 15,
+    textAlign: "center",
+  },
+  bottomBar: {
+    position: "absolute",
+    left: 16,
+    right: 16,
+  },
+  primaryButton: {
+    height: 52,
+    borderRadius: 26,
+    backgroundColor: colors.primary.main,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 24,
+  },
+  primaryButtonDisabled: {
+    opacity: 0.5,
+  },
+  primaryButtonText: {
+    color: colors.text.light,
     fontSize: 16,
     fontWeight: "600",
   },

--- a/src/components/Chat/SwipeableConversationItem.tsx
+++ b/src/components/Chat/SwipeableConversationItem.tsx
@@ -2,31 +2,25 @@
  * SwipeableConversationItem - Conversation item with swipe actions
  */
 
-import React, { useRef } from "react";
-import {
-  View,
-  Text,
-  StyleSheet,
-  TouchableOpacity,
-  Animated,
-  Dimensions,
-} from "react-native";
+import React, { useRef, useState } from "react";
+import { View, StyleSheet, TouchableOpacity, Animated } from "react-native";
 import { Swipeable } from "react-native-gesture-handler";
 import { Ionicons } from "@expo/vector-icons";
 import * as Haptics from "expo-haptics";
-import { LinearGradient } from "expo-linear-gradient";
 import { Conversation } from "../../types/messaging";
 import { colors } from "../../theme/colors";
+import { useConversationsStore } from "../../store/conversationsStore";
 import ConversationItem from "./ConversationItem";
 
-const SCREEN_WIDTH = Dimensions.get("window").width;
+const BUTTON_SIZE = 52;
+const BUTTON_GAP = 12;
 
 interface SwipeableConversationItemProps {
   conversation: Conversation;
   onPress: (conversationId: string) => void;
   onDelete?: (conversationId: string) => void;
   onMute?: (conversationId: string) => void;
-  onUnread?: (conversationId: string) => void;
+  onToggleRead?: (conversationId: string, isCurrentlyUnread: boolean) => void;
   onArchive?: (conversationId: string) => void;
   onPin?: (conversationId: string) => void;
   index?: number;
@@ -41,7 +35,7 @@ export const SwipeableConversationItem: React.FC<
   onPress,
   onDelete,
   onMute,
-  onUnread,
+  onToggleRead,
   onArchive,
   onPin,
   index = 0,
@@ -49,13 +43,19 @@ export const SwipeableConversationItem: React.FC<
   isSelected = false,
 }) => {
   const swipeableRef = useRef<Swipeable>(null);
+  const [isSwiping, setIsSwiping] = useState(false);
+  const isManuallyUnread = useConversationsStore((s) =>
+    s.manuallyUnreadIds.has(conversation.id),
+  );
+  const isUnread = (conversation.unread_count ?? 0) > 0 || isManuallyUnread;
 
   const renderRightActions = (
     progress: Animated.AnimatedInterpolation<number>,
     dragX: Animated.AnimatedInterpolation<number>,
   ) => {
+    if (!isSwiping) return <View />;
     const actionCount = [onArchive, onMute, onDelete].filter(Boolean).length;
-    const totalWidth = actionCount * 88;
+    const totalWidth = actionCount * (BUTTON_SIZE + BUTTON_GAP) + BUTTON_GAP;
     const scale = progress.interpolate({
       inputRange: [0, 1],
       outputRange: [0.8, 1],
@@ -63,12 +63,7 @@ export const SwipeableConversationItem: React.FC<
     });
 
     return (
-      <View
-        style={[
-          styles.rightActions,
-          { width: Math.max(totalWidth, SCREEN_WIDTH) },
-        ]}
-      >
+      <View style={[styles.rightActions, { width: totalWidth }]}>
         {onArchive && (
           <Animated.View style={{ transform: [{ scale }] }}>
             <TouchableOpacity
@@ -81,10 +76,9 @@ export const SwipeableConversationItem: React.FC<
             >
               <Ionicons
                 name="archive-outline"
-                size={20}
+                size={24}
                 color={colors.text.light}
               />
-              <Text style={styles.actionText}>Archiver</Text>
             </TouchableOpacity>
           </Animated.View>
         )}
@@ -100,10 +94,9 @@ export const SwipeableConversationItem: React.FC<
             >
               <Ionicons
                 name="notifications-off-outline"
-                size={20}
+                size={24}
                 color={colors.text.light}
               />
-              <Text style={styles.actionText}>Muet</Text>
             </TouchableOpacity>
           </Animated.View>
         )}
@@ -119,10 +112,9 @@ export const SwipeableConversationItem: React.FC<
             >
               <Ionicons
                 name="trash-outline"
-                size={20}
+                size={24}
                 color={colors.text.light}
               />
-              <Text style={styles.actionText}>Supprimer</Text>
             </TouchableOpacity>
           </Animated.View>
         )}
@@ -134,8 +126,9 @@ export const SwipeableConversationItem: React.FC<
     progress: Animated.AnimatedInterpolation<number>,
     dragX: Animated.AnimatedInterpolation<number>,
   ) => {
-    const actionCount = [onPin, onUnread].filter(Boolean).length;
-    const totalWidth = actionCount * 88;
+    if (!isSwiping) return <View />;
+    const actionCount = [onPin, onToggleRead].filter(Boolean).length;
+    const totalWidth = actionCount * (BUTTON_SIZE + BUTTON_GAP) + BUTTON_GAP;
     const scale = progress.interpolate({
       inputRange: [0, 1],
       outputRange: [0.8, 1],
@@ -143,12 +136,7 @@ export const SwipeableConversationItem: React.FC<
     });
 
     return (
-      <View
-        style={[
-          styles.leftActions,
-          { width: Math.max(totalWidth, SCREEN_WIDTH) },
-        ]}
-      >
+      <View style={[styles.leftActions, { width: totalWidth }]}>
         {onPin && (
           <Animated.View style={{ transform: [{ scale }] }}>
             <TouchableOpacity
@@ -161,29 +149,27 @@ export const SwipeableConversationItem: React.FC<
             >
               <Ionicons
                 name="pin-outline"
-                size={20}
+                size={24}
                 color={colors.text.light}
               />
-              <Text style={styles.actionText}>Épingler</Text>
             </TouchableOpacity>
           </Animated.View>
         )}
-        {onUnread && (
+        {onToggleRead && (
           <Animated.View style={{ transform: [{ scale }] }}>
             <TouchableOpacity
               style={[styles.actionButton, styles.unreadButton]}
               onPress={() => {
                 Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-                onUnread(conversation.id);
+                onToggleRead(conversation.id, isUnread);
                 swipeableRef.current?.close();
               }}
             >
               <Ionicons
-                name="chatbubble-outline"
-                size={20}
+                name={isUnread ? "mail-open-outline" : "mail-unread-outline"}
+                size={24}
                 color={colors.text.light}
               />
-              <Text style={styles.actionText}>Non lu</Text>
             </TouchableOpacity>
           </Animated.View>
         )}
@@ -214,12 +200,17 @@ export const SwipeableConversationItem: React.FC<
         friction={2}
         overshootRight={false}
         overshootLeft={false}
+        onBegan={() => setIsSwiping(true)}
+        onSwipeableWillOpen={() => {
+          Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+        }}
+        onSwipeableClose={() => setIsSwiping(false)}
       >
-        <LinearGradient
-          colors={colors.background.gradient.app}
-          start={{ x: 0, y: 0 }}
-          end={{ x: 1, y: 1 }}
-          style={styles.contentWrapper}
+        <View
+          style={[
+            styles.contentWrapper,
+            isSwiping && styles.contentWrapperSwiping,
+          ]}
         >
           <ConversationItem
             conversation={conversation}
@@ -228,7 +219,7 @@ export const SwipeableConversationItem: React.FC<
             editMode={editMode}
             isSelected={isSelected}
           />
-        </LinearGradient>
+        </View>
       </Swipeable>
     </View>
   );
@@ -240,48 +231,46 @@ const styles = StyleSheet.create({
     backgroundColor: "transparent",
     overflow: "hidden",
   },
+  contentWrapperSwiping: {
+    backgroundColor: "#1A1F3A",
+    borderRadius: 16,
+  },
   rightActions: {
     flexDirection: "row",
-    alignItems: "stretch",
+    alignItems: "center",
     justifyContent: "flex-end",
-    height: 88,
-    minWidth: SCREEN_WIDTH,
+    paddingHorizontal: BUTTON_GAP,
+    gap: BUTTON_GAP,
     backgroundColor: "transparent",
   },
   leftActions: {
     flexDirection: "row",
-    alignItems: "stretch",
+    alignItems: "center",
     justifyContent: "flex-start",
-    height: 88,
-    minWidth: SCREEN_WIDTH,
+    paddingHorizontal: BUTTON_GAP,
+    gap: BUTTON_GAP,
     backgroundColor: "transparent",
   },
   actionButton: {
-    width: 88,
-    height: "100%",
+    width: BUTTON_SIZE,
+    height: BUTTON_SIZE,
+    borderRadius: BUTTON_SIZE / 2,
     justifyContent: "center",
     alignItems: "center",
-    paddingVertical: 8,
   },
   archiveButton: {
-    backgroundColor: "#39437C",
+    backgroundColor: "#5B66B8",
   },
   muteButton: {
-    backgroundColor: "#39437C",
+    backgroundColor: "#5B66B8",
   },
   deleteButton: {
-    backgroundColor: "#FE7A5C",
+    backgroundColor: "#FF3B30",
   },
   pinButton: {
-    backgroundColor: "#39437C",
+    backgroundColor: "#5B66B8",
   },
   unreadButton: {
-    backgroundColor: "#39437C",
-  },
-  actionText: {
-    color: colors.text.light,
-    fontSize: 12,
-    fontWeight: "600",
-    marginTop: 4,
+    backgroundColor: "#5B66B8",
   },
 });

--- a/src/components/Navigation/BottomTabBar.tsx
+++ b/src/components/Navigation/BottomTabBar.tsx
@@ -21,6 +21,7 @@ import { navigate } from "../../navigation/navigationRef";
 import type { AuthStackParamList } from "../../navigation/AuthNavigator";
 import { colors } from "../../theme/colors";
 import { useConversationsStore } from "../../store/conversationsStore";
+import { useUIStore } from "../../store/uiStore";
 import {
   FLOATING_TAB_BAR_BORDER_RADIUS as PILL_BORDER_RADIUS,
   FLOATING_TAB_BAR_BOTTOM_OFFSET as PILL_BOTTOM_OFFSET,
@@ -155,7 +156,9 @@ const BottomTabBarImpl: React.FC<Props> = ({ currentRouteName }) => {
     }
   }, []);
 
-  const visible = tabs.some((t) => t.route === currentRouteName);
+  const bottomTabBarHidden = useUIStore((s) => s.bottomTabBarHidden);
+  const visible =
+    tabs.some((t) => t.route === currentRouteName) && !bottomTabBarHidden;
 
   // On garde la pilule montée en permanence pour ne pas couper l'animation
   // de sortie ; `pointerEvents="none"` empêche les touches résiduelles de

--- a/src/screens/Chat/ConversationsListScreen.tsx
+++ b/src/screens/Chat/ConversationsListScreen.tsx
@@ -18,8 +18,15 @@ import {
   SafeAreaView,
   useSafeAreaInsets,
 } from "react-native-safe-area-context";
-import { FLOATING_TAB_BAR_RESERVED_SPACE } from "../../components/Navigation/floatingTabBarLayout";
+import {
+  FLOATING_TAB_BAR_BORDER_RADIUS,
+  FLOATING_TAB_BAR_BOTTOM_OFFSET,
+  FLOATING_TAB_BAR_HORIZONTAL_MARGIN,
+  FLOATING_TAB_BAR_PILL_HEIGHT,
+  FLOATING_TAB_BAR_RESERVED_SPACE,
+} from "../../components/Navigation/floatingTabBarLayout";
 import { LinearGradient } from "expo-linear-gradient";
+import { BlurView } from "expo-blur";
 import { useNavigation } from "@react-navigation/native";
 import { StackNavigationProp } from "@react-navigation/stack";
 import { Ionicons } from "@expo/vector-icons";
@@ -37,6 +44,7 @@ import { AuthStackParamList } from "../../navigation/AuthNavigator";
 import { colors } from "../../theme/colors";
 import Toast from "../../components/Toast/Toast";
 import { useConversationsStore } from "../../store/conversationsStore";
+import { useUIStore } from "../../store/uiStore";
 import { messagingAPI } from "../../services/messaging/api";
 import { OfflineBanner } from "../../components/Chat/OfflineBanner";
 import { getConversationDisplayName } from "../../utils";
@@ -71,14 +79,20 @@ export const ConversationsListScreen: React.FC = () => {
   const pinConversation = useConversationsStore((s) => s.pinConversation);
   const markAsUnread = useConversationsStore((s) => s.markAsUnread);
   const clearManualUnread = useConversationsStore((s) => s.clearManualUnread);
+  const resetUnreadCount = useConversationsStore((s) => s.resetUnreadCount);
   const loadManuallyUnreadIds = useConversationsStore(
     (s) => s.loadManuallyUnreadIds,
   );
+  const setBottomTabBarHidden = useUIStore((s) => s.setBottomTabBarHidden);
 
   // UI-only state
   const [refreshing, setRefreshing] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [editMode, setEditMode] = useState(false);
+  useEffect(() => {
+    setBottomTabBarHidden(editMode);
+    return () => setBottomTabBarHidden(false);
+  }, [editMode, setBottomTabBarHidden]);
   const [selectedConversations, setSelectedConversations] = useState<
     Set<string>
   >(new Set());
@@ -142,20 +156,22 @@ export const ConversationsListScreen: React.FC = () => {
     TokenService.getAccessToken().then((t) => setToken(t ?? ""));
   }, [userId]);
 
-  const { connectionState, joinConversationChannel } = useWebSocket({
-    userId,
-    token,
-    onNewMessage: (message: Message) => {
-      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-      applyNewMessage(message, userId);
+  const { connectionState, joinConversationChannel, markAsRead } = useWebSocket(
+    {
+      userId,
+      token,
+      onNewMessage: (message: Message) => {
+        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        applyNewMessage(message, userId);
+      },
+      onConversationUpdate: (conversation: Conversation) => {
+        applyConversationUpdate(conversation);
+      },
+      onConversationSummaries: (conversations: Conversation[]) => {
+        applyConversationSummaries(conversations);
+      },
     },
-    onConversationUpdate: (conversation: Conversation) => {
-      applyConversationUpdate(conversation);
-    },
-    onConversationSummaries: (conversations: Conversation[]) => {
-      applyConversationSummaries(conversations);
-    },
-  });
+  );
 
   // Subscribe to every visible conversation so we receive presence_diff /
   // presence_state events for members. Without this, the list items show
@@ -301,17 +317,34 @@ export const ConversationsListScreen: React.FC = () => {
     [muteConversation],
   );
 
-  const handleUnread = useCallback(
-    (conversationId: string) => {
+  const handleToggleRead = useCallback(
+    (conversationId: string, isCurrentlyUnread: boolean) => {
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-      markAsUnread(conversationId);
-      setToast({
-        visible: true,
-        message: "Conversation marquée comme non lue",
-        type: "info",
-      });
+      if (isCurrentlyUnread) {
+        clearManualUnread(conversationId);
+        resetUnreadCount(conversationId);
+        const conv = useConversationsStore
+          .getState()
+          .conversations.find((c) => c.id === conversationId);
+        const lastMessageId = conv?.last_message?.id;
+        if (lastMessageId) {
+          markAsRead(conversationId, lastMessageId);
+        }
+        setToast({
+          visible: true,
+          message: "Conversation marquée comme lue",
+          type: "info",
+        });
+      } else {
+        markAsUnread(conversationId);
+        setToast({
+          visible: true,
+          message: "Conversation marquée comme non lue",
+          type: "info",
+        });
+      }
     },
-    [markAsUnread],
+    [markAsUnread, clearManualUnread, resetUnreadCount, markAsRead],
   );
 
   const handleArchive = useCallback(
@@ -336,7 +369,7 @@ export const ConversationsListScreen: React.FC = () => {
         onPress={handleConversationPress}
         onDelete={handleDelete}
         onMute={handleMute}
-        onUnread={handleUnread}
+        onToggleRead={handleToggleRead}
         onArchive={handleArchive}
         onPin={handlePin}
         index={index}
@@ -348,7 +381,7 @@ export const ConversationsListScreen: React.FC = () => {
       handleConversationPress,
       handleDelete,
       handleMute,
-      handleUnread,
+      handleToggleRead,
       handleArchive,
       handlePin,
       editMode,
@@ -448,7 +481,7 @@ export const ConversationsListScreen: React.FC = () => {
                 setSelectedConversations(new Set());
               }
             }}
-            style={styles.headerButton}
+            style={[styles.headerButton, styles.editButtonPill]}
           >
             <Text style={[styles.editButton, { color: colors.text.light }]}>
               {editMode ? "Annuler" : "Modifier"}
@@ -550,54 +583,6 @@ export const ConversationsListScreen: React.FC = () => {
 
         {renderContent()}
 
-        {editMode && selectedConversations.size > 0 && (
-          <View style={styles.editActionsBar}>
-            <TouchableOpacity
-              style={styles.editActionButton}
-              onPress={handleBulkDelete}
-            >
-              <Ionicons
-                name="trash-outline"
-                size={24}
-                color={colors.ui.error}
-              />
-              <Text style={styles.editActionText}>Supprimer</Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={styles.editActionButton}
-              onPress={handleBulkArchive}
-            >
-              <Ionicons
-                name="archive-outline"
-                size={24}
-                color={colors.secondary.main}
-              />
-              <Text style={styles.editActionText}>Archiver</Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={styles.editActionButton}
-              onPress={handleSelectAll}
-            >
-              <Ionicons
-                name={
-                  selectedConversations.size ===
-                  filteredAndSortedConversations.length
-                    ? "checkmark-done-outline"
-                    : "checkmark-outline"
-                }
-                size={24}
-                color={colors.primary.main}
-              />
-              <Text style={styles.editActionText}>
-                {selectedConversations.size ===
-                filteredAndSortedConversations.length
-                  ? "Tout désélectionner"
-                  : "Tout sélectionner"}
-              </Text>
-            </TouchableOpacity>
-          </View>
-        )}
-
         <Toast
           visible={toast.visible}
           message={toast.message}
@@ -605,6 +590,100 @@ export const ConversationsListScreen: React.FC = () => {
           onHide={() => setToast({ ...toast, visible: false })}
         />
       </SafeAreaView>
+
+      {editMode && (
+        <View
+          pointerEvents="box-none"
+          style={[
+            styles.editActionsFloating,
+            { bottom: FLOATING_TAB_BAR_BOTTOM_OFFSET + insets.bottom },
+          ]}
+        >
+          <View style={styles.editActionsShadow}>
+            <View style={styles.editActionsClip}>
+              <BlurView
+                intensity={Platform.OS === "ios" ? 60 : 80}
+                tint="dark"
+                style={styles.editActionsBlur}
+              >
+                <View style={styles.editActionsOverlay}>
+                  <View style={styles.editActionsRow}>
+                    <TouchableOpacity
+                      style={styles.editActionButton}
+                      onPress={handleBulkDelete}
+                      disabled={selectedConversations.size === 0}
+                    >
+                      <Ionicons
+                        name="trash-outline"
+                        size={24}
+                        color={
+                          selectedConversations.size === 0
+                            ? "rgba(255, 80, 80, 0.4)"
+                            : colors.ui.error
+                        }
+                      />
+                      <Text
+                        style={[
+                          styles.editActionText,
+                          selectedConversations.size === 0 &&
+                            styles.editActionTextDisabled,
+                        ]}
+                      >
+                        Supprimer
+                      </Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                      style={styles.editActionButton}
+                      onPress={handleBulkArchive}
+                      disabled={selectedConversations.size === 0}
+                    >
+                      <Ionicons
+                        name="archive-outline"
+                        size={24}
+                        color={
+                          selectedConversations.size === 0
+                            ? "rgba(255, 255, 255, 0.4)"
+                            : colors.text.light
+                        }
+                      />
+                      <Text
+                        style={[
+                          styles.editActionText,
+                          selectedConversations.size === 0 &&
+                            styles.editActionTextDisabled,
+                        ]}
+                      >
+                        Archiver
+                      </Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                      style={styles.editActionButton}
+                      onPress={handleSelectAll}
+                    >
+                      <Ionicons
+                        name={
+                          selectedConversations.size ===
+                          filteredAndSortedConversations.length
+                            ? "checkmark-done-outline"
+                            : "checkmark-outline"
+                        }
+                        size={24}
+                        color={colors.primary.main}
+                      />
+                      <Text style={styles.editActionText}>
+                        {selectedConversations.size ===
+                        filteredAndSortedConversations.length
+                          ? "Désélec."
+                          : "Tout sélec."}
+                      </Text>
+                    </TouchableOpacity>
+                  </View>
+                </View>
+              </BlurView>
+            </View>
+          </View>
+        </View>
+      )}
 
       <NewConversationModal
         visible={showNewConversationModal}
@@ -645,19 +724,26 @@ const styles = StyleSheet.create({
     textAlign: "center",
   },
   headerButton: {
-    padding: 4,
-    minWidth: 44,
     alignItems: "center",
     justifyContent: "center",
   },
+  editButtonPill: {
+    height: 40,
+    paddingHorizontal: 18,
+    borderRadius: 999,
+    backgroundColor: "rgba(255, 255, 255, 0.15)",
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.2)",
+    justifyContent: "center",
+  },
   editButton: {
-    fontSize: 17,
+    fontSize: 15,
     fontWeight: "500",
   },
   composeButton: {
-    width: 32,
-    height: 32,
-    borderRadius: 8,
+    width: 40,
+    height: 40,
+    borderRadius: 20,
     alignItems: "center",
     justifyContent: "center",
   },
@@ -699,38 +785,54 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
   },
-  editActionsBar: {
+  editActionsFloating: {
+    position: "absolute",
+    left: FLOATING_TAB_BAR_HORIZONTAL_MARGIN,
+    right: FLOATING_TAB_BAR_HORIZONTAL_MARGIN,
+  },
+  editActionsShadow: {
+    borderRadius: FLOATING_TAB_BAR_BORDER_RADIUS,
+    shadowColor: "#000",
+    shadowOpacity: 0.32,
+    shadowRadius: 18,
+    shadowOffset: { width: 0, height: 8 },
+    elevation: 12,
+    backgroundColor: "transparent",
+  },
+  editActionsClip: {
+    borderRadius: FLOATING_TAB_BAR_BORDER_RADIUS,
+    overflow: "hidden",
+  },
+  editActionsBlur: {
+    borderRadius: FLOATING_TAB_BAR_BORDER_RADIUS,
+  },
+  editActionsOverlay: {
+    borderRadius: FLOATING_TAB_BAR_BORDER_RADIUS,
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.18)",
+    backgroundColor:
+      Platform.OS === "ios"
+        ? "rgba(20, 25, 50, 0.35)"
+        : "rgba(20, 25, 50, 0.7)",
+  },
+  editActionsRow: {
     flexDirection: "row",
-    justifyContent: "space-around",
-    alignItems: "center",
-    paddingVertical: 16,
-    paddingHorizontal: 20,
-    borderTopWidth: 1,
-    borderTopColor: "rgba(255, 255, 255, 0.1)",
-    backgroundColor: "rgba(255, 255, 255, 0.95)",
-    ...Platform.select({
-      ios: {
-        shadowColor: "#000",
-        shadowOffset: { width: 0, height: -2 },
-        shadowOpacity: 0.1,
-        shadowRadius: 8,
-      },
-      android: {
-        elevation: 8,
-      },
-    }),
+    height: FLOATING_TAB_BAR_PILL_HEIGHT,
+    paddingHorizontal: 4,
   },
   editActionButton: {
     flex: 1,
     alignItems: "center",
-    paddingVertical: 8,
-    borderRadius: 12,
-    marginHorizontal: 4,
+    justifyContent: "center",
+    paddingVertical: 6,
   },
   editActionText: {
-    color: "#1A1625",
+    color: colors.text.light,
     fontSize: 12,
-    fontWeight: "600",
-    marginTop: 6,
+    fontWeight: "500",
+    marginTop: 2,
+  },
+  editActionTextDisabled: {
+    color: "rgba(255, 255, 255, 0.4)",
   },
 });

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -1,0 +1,14 @@
+import { create } from "zustand";
+
+interface UIState {
+  bottomTabBarHidden: boolean;
+}
+
+interface UIActions {
+  setBottomTabBarHidden: (hidden: boolean) => void;
+}
+
+export const useUIStore = create<UIState & UIActions>((set) => ({
+  bottomTabBarHidden: false,
+  setBottomTabBarHidden: (hidden) => set({ bottomTabBarHidden: hidden }),
+}));


### PR DESCRIPTION
## Summary

Refonte UI de l'écran Discussions et du flux de création d'une nouvelle conversation pour gagner en cohérence visuelle (alignement avec la pilule de navigation) et améliorer l'UX.

### Liste des discussions
- Items transparents (gradient global visible à travers), fond opaque temporaire pendant le swipe pour masquer correctement les actions.
- Boutons d'action de swipe redessinés en cercles détachés type iMessage (52px, espacés, icônes seules).
- Bouton « Lu/Non lu » booléen : icône et action s'inversent selon l'état de la conversation.
- Timestamp aligné avec le nom de la discussion. Format `Xmin` → `Xm`.
- Coins arrondis de l'item pendant le swipe.
- Swipe limité à la révélation des boutons (l'item ne disparaît plus).
- Actions de swipe rendues uniquement pendant le geste (plus d'artefacts en transparence).
- Animation d'entrée des items en `translateY` et jouée uniquement au montage (corrige les artefacts au filtrage).
- Retour haptique au déclenchement du swipe.

### Topbar / mode édition
- Bouton « Modifier » dans une pill arrondie avec bordure subtile.
- Bouton de création en cercle 40×40.
- Mode édition par lot : la pilule de nav se masque et est remplacée par une pilule d'actions flottante (BlurView). Boutons disabled tant qu'aucune sélection.
- Nouveau `uiStore` pour piloter la visibilité de la pilule de nav depuis n'importe quel écran.

### Création de conversation
- Suppression du chooser « Direct vs Groupe » → on arrive directement sur l'écran de sélection des contacts.
- Recherche multi-sélection sur les contacts existants uniquement.
- Chips horizontaux pour les sélections.
- 1 contact = direct, 2+ contacts = groupe.
- Le titre devient un input éditable quand 2+ contacts sont sélectionnés, pré-rempli avec les prénoms des 3 premiers.
- Modal en plein écran (plus de pageSheet), safe area top/bottom respectées.
- Bouton de fermeture rond avec bordure transparente.
- Suppression du formulaire complet de groupe (description / photo) du flux de création — éditables ensuite via les paramètres du groupe.
- Composant simplifié : 1731 → 530 lignes.

### Documentation
- `CLAUDE.md` : changement de la base branch par défaut de `main` vers `deploy/preprod`.

## Test plan

- [ ] Swipe sur un item de discussion : actions visibles uniquement pendant le geste.
- [ ] Filtrage par recherche : aucun artefact d'animation des items.
- [ ] Mode édition par lot : la pilule de nav se masque et la barre d'actions apparaît à sa place.
- [ ] Création conversation directe avec 1 contact.
- [ ] Création groupe avec 2+ contacts (nom par défaut + édition manuelle).
- [ ] Safe area top et bottom respectées sur iOS et Android.
- [ ] Tests unitaires verts.
- [ ] Lint clean.

Closes WHISPR-1231