### PR TITLE
fix(contacts): defensive JSON parsing for user search endpoints

### DIFF
--- a/contactsApi.test.ts
+++ b/contactsApi.test.ts
@@ -277,6 +277,57 @@ describe("contactsAPI.searchUsers", () => {
     expect(phoneCall).toBeDefined();
   });
 
+  it("does not crash when /search/username and /search/phone return an empty body (WHISPR-1234)", async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ body: [] })); // getContacts
+    mockFetch.mockResolvedValueOnce(mockResponse({ body: [] })); // getBlockedUsers
+    // Backend currently returns 200 + empty body when no match — must not throw.
+    mockFetch.mockResolvedValueOnce(mockResponse({ textBody: "" })); // username
+    mockFetch.mockResolvedValueOnce(mockResponse({ body: [] })); // name
+    mockFetch.mockResolvedValueOnce(mockResponse({ textBody: "" })); // phone
+
+    await expect(
+      contactsAPI.searchUsers({ username: "+33600000000" }),
+    ).resolves.toEqual([]);
+  });
+
+  it("unwraps the new { user: User } envelope from /search/username (WHISPR-1233)", async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ body: [] })); // getContacts
+    mockFetch.mockResolvedValueOnce(mockResponse({ body: [] })); // getBlockedUsers
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ body: { user: { id: "u-1", username: "ada" } } }),
+    ); // username (new wrapped format)
+    mockFetch.mockResolvedValueOnce(mockResponse({ body: [] })); // name
+
+    const results = await contactsAPI.searchUsers({ username: "ada" });
+    expect(results).toHaveLength(1);
+    expect(results[0].user.id).toBe("u-1");
+  });
+
+  it("treats { user: null } from /search/username as no result (WHISPR-1233)", async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ body: [] })); // getContacts
+    mockFetch.mockResolvedValueOnce(mockResponse({ body: [] })); // getBlockedUsers
+    mockFetch.mockResolvedValueOnce(mockResponse({ body: { user: null } })); // username
+    mockFetch.mockResolvedValueOnce(mockResponse({ body: [] })); // name
+
+    await expect(contactsAPI.searchUsers({ username: "ada" })).resolves.toEqual(
+      [],
+    );
+  });
+
+  it("unwraps the new { user: User } envelope from /search/phone (WHISPR-1233)", async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ body: [] })); // getContacts
+    mockFetch.mockResolvedValueOnce(mockResponse({ body: [] })); // getBlockedUsers
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 404 })); // username
+    mockFetch.mockResolvedValueOnce(mockResponse({ body: [] })); // name
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ body: { user: { id: "u-9", username: "match" } } }),
+    ); // phone (new wrapped format)
+
+    const results = await contactsAPI.searchUsers({ username: "+33600000000" });
+    expect(results).toHaveLength(1);
+    expect(results[0].user.id).toBe("u-9");
+  });
+
   it("flags is_blocked=true on search hits that are in the blocked list (WHISPR-1215)", async () => {
     // getContacts
     mockFetch.mockResolvedValueOnce(mockResponse({ body: [] }));

--- a/src/services/contacts/api.ts
+++ b/src/services/contacts/api.ts
@@ -134,6 +134,19 @@ const fetchUserById = async (userId: string): Promise<User | null> => {
   return promise;
 };
 
+// Some backend search endpoints return `200` with an empty body when no
+// match is found, which makes `response.json()` throw. Read as text first
+// and treat empty/whitespace-only payloads as `null` to avoid noisy errors.
+const parseJsonSafe = async (response: Response): Promise<unknown> => {
+  const text = await response.text().catch(() => "");
+  if (!text.trim()) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+};
+
 const buildSearchResult = (
   u: any,
   contactIds?: Set<string>,
@@ -419,7 +432,10 @@ export const contactsAPI = {
       )
         .then(async (r) => {
           if (!r.ok) return [];
-          const user = await r.json().catch(() => null);
+          const data = (await parseJsonSafe(r)) as any;
+          // WHISPR-1233 — backend wraps the response as `{ user: User | null }`.
+          // Fall back to the raw payload for backwards compatibility.
+          const user = data?.user ?? data;
           if (!user?.id && !user?.userId) return [];
           return [buildSearchResult(user, contactIds, blockedIds)];
         })
@@ -436,7 +452,7 @@ export const contactsAPI = {
       )
         .then(async (r) => {
           if (!r.ok) return [];
-          const data = await r.json().catch(() => []);
+          const data = (await parseJsonSafe(r)) as any;
           const items = Array.isArray(data)
             ? data
             : Array.isArray(data?.results)
@@ -461,12 +477,16 @@ export const contactsAPI = {
         )
           .then(async (r) => {
             if (!r.ok) return [];
-            const data = await r.json().catch(() => null);
+            const data = (await parseJsonSafe(r)) as any;
             if (!data) return [];
-            const items = Array.isArray(data)
-              ? data
-              : data?.id || data?.userId
-                ? [data]
+            // WHISPR-1233 — backend wraps the response as `{ user: User | null }`.
+            // Unwrap it; fall back to the raw payload for backwards compatibility.
+            const payload = data?.user !== undefined ? data.user : data;
+            if (!payload) return [];
+            const items = Array.isArray(payload)
+              ? payload
+              : payload?.id || payload?.userId
+                ? [payload]
                 : [];
             return items
               .filter((u: any) => u?.id || u?.userId)
@@ -520,7 +540,7 @@ export const contactsAPI = {
       });
 
       if (batchResponse.ok) {
-        const data = await batchResponse.json();
+        const data = (await parseJsonSafe(batchResponse)) as any;
         const items = Array.isArray(data)
           ? data
           : Array.isArray(data?.results)
@@ -556,13 +576,18 @@ export const contactsAPI = {
         );
         if (!response.ok) continue;
 
-        const data = await response.json().catch(() => null);
+        const data = (await parseJsonSafe(response)) as any;
         if (!data) continue;
 
-        const items = Array.isArray(data)
-          ? data
-          : data?.id || data?.userId
-            ? [data]
+        // WHISPR-1233 — backend wraps the response as `{ user: User | null }`.
+        // Unwrap it; fall back to the raw payload for backwards compatibility.
+        const payload = data?.user !== undefined ? data.user : data;
+        if (!payload) continue;
+
+        const items = Array.isArray(payload)
+          ? payload
+          : payload?.id || payload?.userId
+            ? [payload]
             : [];
 
         for (const u of items) {


### PR DESCRIPTION
## Summary

- `searchUsers` failed silently because `/search/username` and `/search/phone` return `200 OK` with an **empty body** when no user matches — `response.json()` then threw `Unexpected end of input` and the error was swallowed by `.catch(() => null)`. The result : every search returned `[]`.
- New shared helper `parseJsonSafe` reads the response as text first and treats empty / whitespace-only payloads as `null`. Applied to all 5 call sites (`searchUsers` × 3 + `lookupUsersByPhones` × 2).
- Also unwraps the upcoming `{ user: User | null }` envelope on `/search/username` and `/search/phone` (cf. **WHISPR-1233**) with a `data?.user ?? data` fallback, so the client stays compatible with both the current and the new backend format and no coordinated deploy is required.
- `/search/name` is left unchanged — WHISPR-1233 confirms it keeps returning a plain array.

## Test plan

- [x] Unit tests green — added 4 new cases in `contactsApi.test.ts` :
  - empty body on `/search/username` and `/search/phone` no longer crashes
  - new `{ user: User }` envelope is unwrapped on `/search/username`
  - `{ user: null }` is treated as no result
  - new `{ user: User }` envelope is unwrapped on `/search/phone`
- [x] Lint clean (0 new errors)
- [ ] Tested on iOS simulator
- [ ] Tested on Android emulator

## Links

- Closes WHISPR-1234
- Relates to WHISPR-1233 (backend fix that wraps the response — once merged, the fallback in this PR can eventually be cleaned up)