### PR TITLE
[WHISPR-1251] feat(calls): graceful fallback when calls are unavailable

### DIFF
--- a/ChatHeader.test.tsx
+++ b/ChatHeader.test.tsx
@@ -72,4 +72,34 @@ describe("ChatHeader back button", () => {
     expect(mockGoBack).not.toHaveBeenCalled();
     expect(mockNavigate).toHaveBeenCalledWith("ConversationsList");
   });
+
+  it("invokes call handlers and stays clickable when calls are unavailable (so the parent can show a toast)", () => {
+    mockCanGoBack.mockReturnValue(true);
+    const onAudio = jest.fn();
+    const onVideo = jest.fn();
+
+    const { UNSAFE_getAllByType } = render(
+      <ChatHeader
+        conversationName="Alice"
+        conversationType="direct"
+        onAudioCallPress={onAudio}
+        onVideoCallPress={onVideo}
+        callsAvailable={false}
+      />,
+    );
+
+    const TouchableOpacity = require("react-native").TouchableOpacity;
+    const touchables = UNSAFE_getAllByType(TouchableOpacity);
+    // touchables[0] = back, [1] = audio, [2] = video
+    fireEvent.press(touchables[1]);
+    fireEvent.press(touchables[2]);
+
+    expect(onAudio).toHaveBeenCalledTimes(1);
+    expect(onVideo).toHaveBeenCalledTimes(1);
+
+    const audioStyle = Array.isArray(touchables[1].props.style)
+      ? Object.assign({}, ...touchables[1].props.style.filter(Boolean))
+      : touchables[1].props.style;
+    expect(audioStyle.opacity).toBe(0.4);
+  });
 });

--- a/callsStore.test.ts
+++ b/callsStore.test.ts
@@ -35,6 +35,11 @@ jest.mock("expo-constants", () => ({
   },
 }));
 
+jest.mock("react-native", () => ({
+  Platform: { OS: "ios" },
+  NativeModules: { WebRTCModule: {} },
+}));
+
 import { useCallsStore } from "./src/store/callsStore";
 import { callsLiveKit } from "./src/services/calls/liveKitProvider";
 

--- a/src/hooks/useCallsAvailable.ts
+++ b/src/hooks/useCallsAvailable.ts
@@ -1,0 +1,70 @@
+/**
+ * useCallsAvailable — Détection centralisée du support des appels.
+ *
+ * Les appels reposent sur des modules natifs (@livekit/react-native,
+ * @livekit/react-native-webrtc, react-native-call-keeper) absents d'Expo Go.
+ * Ce hook (et le helper sync isCallsAvailable) permet à l'UI d'afficher un
+ * fallback explicite plutôt que de planter silencieusement au clic.
+ */
+
+import { useMemo } from "react";
+import Constants from "expo-constants";
+import { NativeModules, Platform } from "react-native";
+
+export type CallsUnavailableReason = "expo-go" | "no-webrtc" | "web";
+
+export interface CallsAvailability {
+  available: boolean;
+  reason: CallsUnavailableReason | null;
+}
+
+function detectIsExpoGo(): boolean {
+  const executionEnvironment = (Constants as any)?.executionEnvironment;
+  const appOwnership = (Constants as any)?.appOwnership;
+  return executionEnvironment === "storeClient" || appOwnership === "expo";
+}
+
+function detectHasWebRtcNative(): boolean {
+  const native = NativeModules as Record<string, unknown>;
+  return Boolean(native?.WebRTCModule || native?.LivekitReactNativeWebRTC);
+}
+
+export function getCallsAvailability(): CallsAvailability {
+  if (Platform.OS === "web") {
+    return { available: false, reason: "web" };
+  }
+  if (detectIsExpoGo()) {
+    return { available: false, reason: "expo-go" };
+  }
+  if (!detectHasWebRtcNative()) {
+    return { available: false, reason: "no-webrtc" };
+  }
+  return { available: true, reason: null };
+}
+
+export function isCallsAvailable(): boolean {
+  return getCallsAvailability().available;
+}
+
+export function isExpoGo(): boolean {
+  return detectIsExpoGo();
+}
+
+export function getCallsUnavailableMessage(
+  reason: CallsUnavailableReason | null,
+): string {
+  switch (reason) {
+    case "expo-go":
+      return "Les appels ne sont pas disponibles dans Expo Go. Utilisez un build de développement.";
+    case "no-webrtc":
+      return "Les appels nécessitent une reconstruction de l'application (module WebRTC manquant).";
+    case "web":
+      return "Les appels ne sont pas disponibles sur le web.";
+    default:
+      return "Les appels ne sont pas disponibles sur cet appareil.";
+  }
+}
+
+export function useCallsAvailable(): CallsAvailability {
+  return useMemo(getCallsAvailability, []);
+}

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -8,7 +8,6 @@
 
 import { useEffect, useRef, useCallback, useState, useMemo } from "react";
 import { AppState } from "react-native";
-import Constants from "expo-constants";
 import {
   getSharedSocket,
   ConnectionState,
@@ -22,11 +21,7 @@ import {
   buildIncomingCallPresentation,
   systemCallProvider,
 } from "../services/calls/systemCallProvider";
-
-const executionEnvironment = (Constants as any)?.executionEnvironment;
-const appOwnership = (Constants as any)?.appOwnership;
-const isExpoGo =
-  executionEnvironment === "storeClient" || appOwnership === "expo";
+import { isCallsAvailable } from "./useCallsAvailable";
 
 /** Payload normalisé (snake_case) pour reaction_added / reaction_removed */
 export interface ReactionRealtimePayload {
@@ -133,7 +128,7 @@ export const useWebSocket = (options: UseWebSocketOptions) => {
         initiator_name?: string;
       }) => {
         if (!data?.call_id) return;
-        if (isExpoGo) return;
+        if (!isCallsAvailable()) return;
         useCallsStore.getState().setIncoming({
           callId: data.call_id,
           initiatorId: data.initiator_id,

--- a/src/navigation/AuthNavigator.tsx
+++ b/src/navigation/AuthNavigator.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { createStackNavigator } from "@react-navigation/stack";
-import { NativeModules, Platform, Text, View } from "react-native";
+import { CallsUnavailableScreen } from "../screens/Calls/CallsUnavailableScreen";
+import { isCallsAvailable } from "../hooks/useCallsAvailable";
 import { WelcomeScreen } from "../screens/Auth/WelcomeScreen";
 import { PhoneInputScreen } from "../screens/Auth/PhoneInputScreen";
 import { OtpScreen } from "../screens/Auth/OtpScreen";
@@ -57,7 +58,6 @@ import { UserService } from "../services/UserService";
 import { NotificationService } from "../services/NotificationService";
 import { systemCallProvider } from "../services/calls/systemCallProvider";
 import { initCallNotificationBridge } from "../services/calls/callNotificationBridge";
-import Constants from "expo-constants";
 import type { AuthPurpose } from "../types/auth";
 import type {
   Report,
@@ -153,15 +153,11 @@ export const AuthNavigator: React.FC = () => {
     boolean | null
   >(null);
   const fetchMyRole = useModerationStore((s) => s.fetchMyRole);
-  // Web (PWA Safari) uses the browser's built-in WebRTC via livekit-client,
-  // so calls work without a native module. The CallsUnavailableScreen
-  // guard only applies to native builds (Expo Go) that lack the
-  // @livekit/react-native-webrtc native bindings.
-  const hasCallsSupport = useMemo(() => {
-    if (Platform.OS === "web") return true;
-    const native = NativeModules as Record<string, unknown>;
-    return Boolean(native?.WebRTCModule || native?.LivekitReactNativeWebRTC);
-  }, []);
+  // Source de vérité unique pour la disponibilité des appels (Expo Go,
+  // module natif WebRTC manquant, web). Mémorisé : la dispo ne change pas
+  // pendant la durée de vie de l'app — un nouveau native module ne peut
+  // pas apparaître sans rebuild.
+  const hasCallsSupport = useMemo(isCallsAvailable, []);
 
   // WHISPR-1060: drain any offline-queued messages left over from a
   // previous session as soon as the authenticated tree mounts, and keep
@@ -225,7 +221,7 @@ export const AuthNavigator: React.FC = () => {
     try {
       require("../screens/Contacts/QRCodeScannerScreen");
     } catch {}
-    if (Constants.appOwnership !== "expo" && hasCallsSupport) {
+    if (hasCallsSupport) {
       try {
         require("../screens/Calls/CallsScreen");
         require("../screens/Calls/IncomingCallScreen");
@@ -251,22 +247,6 @@ export const AuthNavigator: React.FC = () => {
     : profileSetupPending
       ? "ProfileSetup"
       : "ConversationsList";
-
-  const CallsUnavailableScreen = () => (
-    <View
-      style={{
-        flex: 1,
-        alignItems: "center",
-        justifyContent: "center",
-        paddingHorizontal: 24,
-      }}
-    >
-      <Text style={{ textAlign: "center", opacity: 0.8 }}>
-        Les appels ne sont pas disponibles sur ce build. Recompilez le dev
-        client avec le module WebRTC natif.
-      </Text>
-    </View>
-  );
 
   return (
     <Stack.Navigator

--- a/src/screens/Calls/CallsUnavailableScreen.tsx
+++ b/src/screens/Calls/CallsUnavailableScreen.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Ionicons } from "@expo/vector-icons";
+import { colors } from "../../theme/colors";
+import {
+  getCallsAvailability,
+  getCallsUnavailableMessage,
+} from "../../hooks/useCallsAvailable";
+
+export const CallsUnavailableScreen: React.FC = () => {
+  const { reason } = getCallsAvailability();
+
+  return (
+    <LinearGradient
+      colors={colors.background.gradient.app}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 1 }}
+      style={styles.gradient}
+    >
+      <SafeAreaView style={styles.container} edges={["top", "bottom"]}>
+        <View style={styles.iconWrap}>
+          <Ionicons
+            name="call-outline"
+            size={36}
+            color="rgba(255,255,255,0.82)"
+          />
+        </View>
+        <Text style={styles.title}>Appels indisponibles</Text>
+        <Text style={styles.message}>{getCallsUnavailableMessage(reason)}</Text>
+      </SafeAreaView>
+    </LinearGradient>
+  );
+};
+
+const styles = StyleSheet.create({
+  gradient: {
+    flex: 1,
+  },
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 32,
+  },
+  iconWrap: {
+    width: 72,
+    height: 72,
+    borderRadius: 36,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "rgba(255,255,255,0.08)",
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.12)",
+    marginBottom: 20,
+  },
+  title: {
+    color: colors.text.light,
+    fontSize: 20,
+    fontFamily: "Inter_700Bold",
+    marginBottom: 12,
+    textAlign: "center",
+  },
+  message: {
+    color: "rgba(255,255,255,0.78)",
+    fontSize: 15,
+    lineHeight: 22,
+    fontFamily: "Inter_400Regular",
+    textAlign: "center",
+  },
+});
+
+export default CallsUnavailableScreen;

--- a/src/screens/Chat/ChatHeader.tsx
+++ b/src/screens/Chat/ChatHeader.tsx
@@ -144,7 +144,6 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
             ]}
             accessibilityRole="button"
             accessibilityLabel="Appel audio"
-            accessibilityState={{ disabled: !callsAvailable }}
           >
             <Ionicons
               name="call-outline"
@@ -162,7 +161,6 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
             ]}
             accessibilityRole="button"
             accessibilityLabel="Appel video"
-            accessibilityState={{ disabled: !callsAvailable }}
           >
             <Ionicons
               name="videocam-outline"

--- a/src/screens/Chat/ChatHeader.tsx
+++ b/src/screens/Chat/ChatHeader.tsx
@@ -23,6 +23,7 @@ interface ChatHeaderProps {
   onScheduledPress?: () => void;
   onAudioCallPress?: () => void;
   onVideoCallPress?: () => void;
+  callsAvailable?: boolean;
 }
 
 export const ChatHeader: React.FC<ChatHeaderProps> = ({
@@ -38,6 +39,7 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
   onScheduledPress,
   onAudioCallPress,
   onVideoCallPress,
+  callsAvailable = true,
 }) => {
   const navigation = useNavigation();
   const { getThemeColors } = useTheme();
@@ -136,9 +138,13 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
         {onAudioCallPress && (
           <TouchableOpacity
             onPress={onAudioCallPress}
-            style={styles.actionButton}
+            style={[
+              styles.actionButton,
+              !callsAvailable && styles.actionButtonDisabled,
+            ]}
             accessibilityRole="button"
             accessibilityLabel="Appel audio"
+            accessibilityState={{ disabled: !callsAvailable }}
           >
             <Ionicons
               name="call-outline"
@@ -150,9 +156,13 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
         {onVideoCallPress && (
           <TouchableOpacity
             onPress={onVideoCallPress}
-            style={styles.actionButton}
+            style={[
+              styles.actionButton,
+              !callsAvailable && styles.actionButtonDisabled,
+            ]}
             accessibilityRole="button"
             accessibilityLabel="Appel video"
+            accessibilityState={{ disabled: !callsAvailable }}
           >
             <Ionicons
               name="videocam-outline"
@@ -254,5 +264,8 @@ const styles = StyleSheet.create({
   actionButton: {
     padding: 8,
     marginLeft: 4,
+  },
+  actionButtonDisabled: {
+    opacity: 0.4,
   },
 });

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -52,6 +52,11 @@ import { ForwardMessageModal } from "../../components/Chat/ForwardMessageModal";
 import { useConversationsStore } from "../../store/conversationsStore";
 import { useCallsStore } from "../../store/callsStore";
 import { systemCallProvider } from "../../services/calls/systemCallProvider";
+import {
+  useCallsAvailable,
+  getCallsUnavailableMessage,
+} from "../../hooks/useCallsAvailable";
+import Toast, { ToastType } from "../../components/Toast/Toast";
 import { ReactionPicker } from "../../components/Chat/ReactionPicker";
 import { ReactionReactorsModal } from "../../components/Chat/ReactionReactorsModal";
 import { DateSeparator } from "../../components/Chat/DateSeparator";
@@ -203,6 +208,12 @@ export const ChatScreen: React.FC = () => {
   const [showForwardModal, setShowForwardModal] = useState(false);
   const [forwardingMessage, setForwardingMessage] =
     useState<MessageWithRelations | null>(null);
+  const callsAvailability = useCallsAvailable();
+  const [callsToast, setCallsToast] = useState<{
+    visible: boolean;
+    message: string;
+    type: ToastType;
+  }>({ visible: false, message: "", type: "info" });
   const [forwardSending, setForwardSending] = useState(false);
   const [showReportSheet, setShowReportSheet] = useState(false);
   const [reportSheetMessage, setReportSheetMessage] =
@@ -1467,6 +1478,14 @@ export const ChatScreen: React.FC = () => {
   const handleInitiateCall = useCallback(
     async (type: "audio" | "video") => {
       if (!conversation) return;
+      if (!callsAvailability.available) {
+        setCallsToast({
+          visible: true,
+          message: getCallsUnavailableMessage(callsAvailability.reason),
+          type: "warning",
+        });
+        return;
+      }
       const displayName = getConversationDisplayName(conversation);
       const avatarUrl =
         conversation.type === "direct"
@@ -1507,7 +1526,14 @@ export const ChatScreen: React.FC = () => {
         console.error("Failed to initiate call", err);
       }
     },
-    [conversation, conversationMembers, conversationId, userId, navigation],
+    [
+      conversation,
+      conversationMembers,
+      conversationId,
+      userId,
+      navigation,
+      callsAvailability,
+    ],
   );
 
   const resolveReactorDisplayName = useCallback(
@@ -2234,6 +2260,7 @@ export const ChatScreen: React.FC = () => {
           onScheduledPress={handleScheduledPress}
           onAudioCallPress={() => handleInitiateCall("audio")}
           onVideoCallPress={() => handleInitiateCall("video")}
+          callsAvailable={callsAvailability.available}
         />
         {isOtherUserContact === false && (
           <View style={styles.notContactBanner}>
@@ -2575,6 +2602,13 @@ export const ChatScreen: React.FC = () => {
             </View>
           </View>
         </Modal>
+        <Toast
+          visible={callsToast.visible}
+          message={callsToast.message}
+          type={callsToast.type}
+          duration={4000}
+          onHide={() => setCallsToast((t) => ({ ...t, visible: false }))}
+        />
       </SafeAreaView>
     </LinearGradient>
   );

--- a/src/services/calls/bootstrap.native.ts
+++ b/src/services/calls/bootstrap.native.ts
@@ -1,5 +1,4 @@
-import Constants from "expo-constants";
-import { NativeModules } from "react-native";
+import { getCallsAvailability } from "../../hooks/useCallsAvailable";
 
 declare const require: (path: string) => any;
 
@@ -10,33 +9,21 @@ declare const require: (path: string) => any;
  *
  * Metro resolves this file on native builds via the `.native.ts` suffix.
  */
-const executionEnvironment = (Constants as any)?.executionEnvironment;
-const appOwnership = (Constants as any)?.appOwnership;
-const isExpoGo =
-  executionEnvironment === "storeClient" || appOwnership === "expo";
+const { available, reason } = getCallsAvailability();
 
-if (!isExpoGo) {
+if (available) {
   try {
-    // Dev clients can be launched before native modules are linked/rebuilt.
-    // In this case registerGlobals() would throw (NativeEventEmitter null).
-    const hasWebRtcNative =
-      Boolean((NativeModules as Record<string, unknown>)?.WebRTCModule) ||
-      Boolean(
-        (NativeModules as Record<string, unknown>)?.LivekitReactNativeWebRTC,
-      );
-    if (!hasWebRtcNative) {
-      console.warn(
-        "[calls/bootstrap] WebRTC native module missing — skipping LiveKit registerGlobals. Rebuild the iOS/Android dev client (e.g. `npx expo run:ios`) after adding @livekit/react-native-webrtc.",
-      );
-    } else {
-      const livekit =
-        require("@livekit/react-native") as typeof import("@livekit/react-native");
-      livekit.registerGlobals();
-    }
+    const livekit =
+      require("@livekit/react-native") as typeof import("@livekit/react-native");
+    livekit.registerGlobals();
   } catch (error) {
     console.warn(
       "[calls/bootstrap] registerGlobals failed — continuing without LiveKit globals:",
       error,
     );
   }
+} else if (reason === "no-webrtc") {
+  console.warn(
+    "[calls/bootstrap] WebRTC native module missing — skipping LiveKit registerGlobals. Rebuild the iOS/Android dev client (e.g. `npx expo run:ios`) after adding @livekit/react-native-webrtc.",
+  );
 }

--- a/src/services/calls/systemCallProvider.ts
+++ b/src/services/calls/systemCallProvider.ts
@@ -1,8 +1,8 @@
-import Constants from "expo-constants";
 import * as ExpoCrypto from "expo-crypto";
 import { PermissionsAndroid, Platform } from "react-native";
 import { navigate, navigationRef } from "../../navigation/navigationRef";
 import { useCallsStore, type IncomingCallInfo } from "../../store/callsStore";
+import { isCallsAvailable } from "../../hooks/useCallsAvailable";
 
 type CallKeepModule = typeof import("react-native-call-keeper").default;
 
@@ -24,14 +24,9 @@ export interface NativeCallPresentation {
   hasVideo: boolean;
 }
 
-const executionEnvironment = (Constants as any)?.executionEnvironment;
-const appOwnership = (Constants as any)?.appOwnership;
-const isExpoGo =
-  executionEnvironment === "storeClient" || appOwnership === "expo";
-
 function loadCallKeep(): CallKeepModule | null {
   if (Platform.OS !== "ios" && Platform.OS !== "android") return null;
-  if (isExpoGo) return null;
+  if (!isCallsAvailable()) return null;
   try {
     return require("react-native-call-keeper").default as CallKeepModule;
   } catch {

--- a/src/store/callsStore.ts
+++ b/src/store/callsStore.ts
@@ -1,21 +1,18 @@
 import { create } from "zustand";
-import Constants from "expo-constants";
 import { callsApi } from "../services/calls/callsApi";
+import {
+  getCallsAvailability,
+  getCallsUnavailableMessage,
+} from "../hooks/useCallsAvailable";
 import type { CallStatus, CallType } from "../types/calls";
 import type { Room } from "livekit-client";
 
 declare const require: (path: string) => any;
 
-const executionEnvironment = (Constants as any)?.executionEnvironment;
-const appOwnership = (Constants as any)?.appOwnership;
-const isExpoGo =
-  executionEnvironment === "storeClient" || appOwnership === "expo";
-
 function getCallsLiveKit() {
-  if (isExpoGo) {
-    throw new Error(
-      "Calls are not supported in Expo Go. Use a development build.",
-    );
+  const { available, reason } = getCallsAvailability();
+  if (!available) {
+    throw new Error(getCallsUnavailableMessage(reason));
   }
   const mod =
     require("../services/calls/liveKitProvider") as typeof import("../services/calls/liveKitProvider");

--- a/useCallsAvailable.test.ts
+++ b/useCallsAvailable.test.ts
@@ -1,0 +1,91 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Tests for useCallsAvailable — centralised detection of calls support.
+ * Each scenario re-imports the module after redefining the env mocks so the
+ * platform/environment branches are exercised independently.
+ */
+
+describe("useCallsAvailable", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  function setupMocks(opts: {
+    platform?: "ios" | "android" | "web";
+    expoGo?: boolean;
+    hasWebRtc?: boolean;
+  }) {
+    const platform = opts.platform ?? "ios";
+    const expoGo = opts.expoGo ?? false;
+    const hasWebRtc = opts.hasWebRtc ?? true;
+
+    jest.doMock("expo-constants", () => ({
+      __esModule: true,
+      default: {
+        executionEnvironment: expoGo ? "storeClient" : "standalone",
+        appOwnership: expoGo ? "expo" : "standalone",
+      },
+    }));
+
+    jest.doMock("react-native", () => ({
+      Platform: { OS: platform },
+      NativeModules: hasWebRtc ? { WebRTCModule: {} } : {},
+    }));
+  }
+
+  it("returns available=true on a native dev build with WebRTC linked", () => {
+    setupMocks({ platform: "ios", expoGo: false, hasWebRtc: true });
+    const {
+      getCallsAvailability,
+      isCallsAvailable,
+    } = require("./src/hooks/useCallsAvailable");
+
+    expect(getCallsAvailability()).toEqual({ available: true, reason: null });
+    expect(isCallsAvailable()).toBe(true);
+  });
+
+  it("returns reason=expo-go in Expo Go", () => {
+    setupMocks({ platform: "ios", expoGo: true });
+    const {
+      getCallsAvailability,
+      getCallsUnavailableMessage,
+    } = require("./src/hooks/useCallsAvailable");
+
+    const result = getCallsAvailability();
+    expect(result.available).toBe(false);
+    expect(result.reason).toBe("expo-go");
+    expect(getCallsUnavailableMessage(result.reason)).toMatch(/Expo Go/);
+  });
+
+  it("returns reason=web on web platform", () => {
+    setupMocks({ platform: "web", expoGo: false });
+    const { getCallsAvailability } = require("./src/hooks/useCallsAvailable");
+
+    expect(getCallsAvailability()).toEqual({
+      available: false,
+      reason: "web",
+    });
+  });
+
+  it("returns reason=no-webrtc when native module is missing", () => {
+    setupMocks({ platform: "android", expoGo: false, hasWebRtc: false });
+    const { getCallsAvailability } = require("./src/hooks/useCallsAvailable");
+
+    expect(getCallsAvailability()).toEqual({
+      available: false,
+      reason: "no-webrtc",
+    });
+  });
+
+  it("provides a French fallback message for each reason", () => {
+    setupMocks({ platform: "ios" });
+    const {
+      getCallsUnavailableMessage,
+    } = require("./src/hooks/useCallsAvailable");
+
+    expect(getCallsUnavailableMessage("expo-go")).toContain("Expo Go");
+    expect(getCallsUnavailableMessage("no-webrtc")).toContain("WebRTC");
+    expect(getCallsUnavailableMessage("web")).toContain("web");
+    expect(getCallsUnavailableMessage(null)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Centralise Expo Go / WebRTC / web detection in a new `useCallsAvailable` hook (and sync `isCallsAvailable()` helper for Zustand). The four existing detection sites (`callsStore`, `bootstrap.native`, `useWebSocket`, `systemCallProvider`) now share one source of truth.
- In `ChatHeader`, audio/video call buttons stay rendered but appear dimmed (opacity 0.4) when calls are not supported. Tapping a dimmed button surfaces a localized toast in `ChatScreen` instead of firing a silent `console.error` from the store.
- French fallback messages tailored per reason (Expo Go, missing WebRTC native module, web platform).

## Test plan
- [x] Unit tests green (`useCallsAvailable.test.ts`, `ChatHeader.test.tsx`, `callsStore.test.ts`)
- [x] Lint clean (no new errors)
- [ ] Tested on iOS simulator
- [ ] Tested on Android emulator
- [ ] Tested in Expo Go: tap on call button shows the toast, no crash

Closes WHISPR-1251