### PR TITLE
fix(web): scroll conversations + photo picker (WHISPR-1254, WHISPR-1255)

### DIFF
--- a/src/screens/Chat/ConversationsListScreen.tsx
+++ b/src/screens/Chat/ConversationsListScreen.tsx
@@ -444,7 +444,10 @@ export const ConversationsListScreen: React.FC = () => {
         initialNumToRender={15}
         windowSize={10}
         getItemLayout={getItemLayout}
-        showsVerticalScrollIndicator={false}
+        // WHISPR-1254 — sur web on garde l'indicateur visible pour qu'il
+        // soit clair que la liste scrolle; sur natif on conserve le look
+        // d'origine.
+        showsVerticalScrollIndicator={Platform.OS === "web"}
         refreshControl={
           <RefreshControl
             refreshing={refreshing}
@@ -703,10 +706,19 @@ export const ConversationsListScreen: React.FC = () => {
 const styles = StyleSheet.create({
   gradientContainer: {
     flex: 1,
+    // WHISPR-1254 — sur react-native-web, flex:1 seul ne propage pas la
+    // hauteur disponible jusqu'aux enfants si l'ancêtre racine (#root) ne
+    // borne pas son propre contenu. height:100% force le wrapper racine à
+    // occuper exactement la hauteur du viewport.
+    ...(Platform.OS === "web" ? { height: "100%" } : {}),
   },
   container: {
     flex: 1,
     backgroundColor: "transparent",
+    // WHISPR-1254 — minHeight:0 est requis par CSS flexbox pour qu'un
+    // enfant scrollable (FlatList) puisse overflow au lieu de pousser le
+    // parent. Sans ça, les conversations dépassent le viewport.
+    ...(Platform.OS === "web" ? { minHeight: 0 } : {}),
   },
   header: {
     flexDirection: "row",
@@ -774,10 +786,12 @@ const styles = StyleSheet.create({
   list: {
     flex: 1,
     backgroundColor: "transparent",
+    // WHISPR-1254 — même raison que .container : permettre l'overflow
+    // vertical natif côté react-native-web.
+    ...(Platform.OS === "web" ? { minHeight: 0 } : {}),
   },
   listContent: {
     paddingVertical: 8,
-    flexGrow: 1,
     backgroundColor: "transparent",
   },
   loadingContainer: {

--- a/src/screens/Profile/MyProfileScreen.tsx
+++ b/src/screens/Profile/MyProfileScreen.tsx
@@ -56,6 +56,49 @@ type NavigationProp = StackNavigationProp<any, "MyProfile">;
 const isMediaNotFound = (message?: string) =>
   typeof message === "string" && /media not found/i.test(message);
 
+/**
+ * WHISPR-1255 — Fallback web pour sélectionner une image.
+ * expo-image-picker SDK 17 supporte mal le user-gesture côté web; on
+ * crée un <input type="file"> détaché qu'on click programmatiquement.
+ * On retourne un blob URL utilisable comme uri par MediaService.
+ */
+const pickImageFromWeb = (
+  opts: { preferCamera?: boolean } = {},
+): Promise<string | null> => {
+  if (typeof document === "undefined") return Promise.resolve(null);
+  return new Promise((resolve) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = "image/*";
+    if (opts.preferCamera) {
+      input.setAttribute("capture", "environment");
+    }
+    input.style.position = "fixed";
+    input.style.left = "-9999px";
+    let settled = false;
+    const settle = (value: string | null) => {
+      if (settled) return;
+      settled = true;
+      input.remove();
+      resolve(value);
+    };
+    input.onchange = () => {
+      const file = input.files && input.files[0];
+      if (!file) return settle(null);
+      settle(URL.createObjectURL(file));
+    };
+    // Si l'utilisateur ferme la dialog sans choisir, focus revient à
+    // window — on libère la promesse pour ne pas leak.
+    const onFocus = () => {
+      window.removeEventListener("focus", onFocus);
+      setTimeout(() => settle(null), 300);
+    };
+    window.addEventListener("focus", onFocus);
+    document.body.appendChild(input);
+    input.click();
+  });
+};
+
 export const MyProfileScreen: React.FC = () => {
   const { userId: currentUserId } = useAuth();
   const navigation = useNavigation<NavigationProp>();
@@ -158,6 +201,21 @@ export const MyProfileScreen: React.FC = () => {
 
   const handleImagePicker = async () => {
     try {
+      // WHISPR-1255 — sur react-native-web, expo-image-picker ne déclenche
+      // pas de file picker (le polyfill web requiert un user-gesture
+      // synchrone qu'on perd à travers la promesse permissions). On
+      // contourne avec un <input type="file"> natif qu'on click depuis
+      // le clic utilisateur courant.
+      if (Platform.OS === "web") {
+        const uri = await pickImageFromWeb();
+        if (uri) {
+          setProfile((prev) => ({ ...prev, profilePicture: uri }));
+          setPendingAvatar({ localUri: uri });
+          setShowImagePicker(false);
+        }
+        return;
+      }
+
       const { status } =
         await ImagePicker.requestMediaLibraryPermissionsAsync();
       if (status !== "granted") {
@@ -189,6 +247,20 @@ export const MyProfileScreen: React.FC = () => {
 
   const handleCameraCapture = async () => {
     try {
+      // WHISPR-1255 — sur web, on retombe sur le même <input type=file>
+      // mais avec capture="environment" pour proposer la caméra quand
+      // disponible (mobile web). Sur desktop le navigateur retombe
+      // automatiquement sur le file picker classique.
+      if (Platform.OS === "web") {
+        const uri = await pickImageFromWeb({ preferCamera: true });
+        if (uri) {
+          setProfile((prev) => ({ ...prev, profilePicture: uri }));
+          setPendingAvatar({ localUri: uri });
+          setShowImagePicker(false);
+        }
+        return;
+      }
+
       const { status } = await ImagePicker.requestCameraPermissionsAsync();
       if (status !== "granted") {
         Alert.alert(


### PR DESCRIPTION
Deux bugs trouves pendant les tests Playwright sur preprod.

WHISPR-1254 - scroll cassé sur ConversationsList web

La FlatList rendait bien toutes les convs mais aucun parent n'etait scrollable, du coup les items en bas du viewport etaient inaccessibles. Cause: `flexGrow: 1` sur le contentContainer forcait le contenu a faire pile la taille du viewport. Fix: virer ce flexGrow + ajouter `height: 100%` sur le gradient + `minHeight: 0` sur les conteneurs (web only). C'est le pattern flexbox classique pour permettre l'overflow.

WHISPR-1255 - photo picker profil ne s'ouvre pas sur web

`expo-image-picker` se cable mal sur le bundle react-native-web (probleme de user-gesture). Du coup tap sur l'avatar = rien. Fix: fallback web avec un `<input type=file>` cree en JS, click programmatique, on recupere le blob via `URL.createObjectURL`. Mobile natif: rien ne change.

Test:
- preprod, 0769828164/123456
- ConversationsList: scroll OK jusqu'au bas
- Edit profile: tap avatar -> file dialog s'ouvre