### PR TITLE
[WHISPR-1257] feat(chat): redesign chat topbar with glassmorphism and unified call menu

### DIFF
--- a/ChatHeader.test.tsx
+++ b/ChatHeader.test.tsx
@@ -23,6 +23,15 @@ jest.mock("@expo/vector-icons", () => ({
   Ionicons: ({ testID }: any) => null,
 }));
 
+jest.mock("expo-blur", () => {
+  const { View } = require("react-native");
+  return {
+    BlurView: ({ children, style }: any) => (
+      <View style={style}>{children}</View>
+    ),
+  };
+});
+
 jest.mock("./src/context/ThemeContext", () => ({
   useTheme: () => ({
     getThemeColors: () => ({
@@ -73,12 +82,41 @@ describe("ChatHeader back button", () => {
     expect(mockNavigate).toHaveBeenCalledWith("ConversationsList");
   });
 
-  it("invokes call handlers and stays clickable when calls are unavailable (so the parent can show a toast)", () => {
+  it("opens a menu offering audio and video when calls are available", () => {
     mockCanGoBack.mockReturnValue(true);
     const onAudio = jest.fn();
     const onVideo = jest.fn();
 
-    const { UNSAFE_getAllByType } = render(
+    const { UNSAFE_getAllByType, queryByLabelText } = render(
+      <ChatHeader
+        conversationName="Alice"
+        conversationType="direct"
+        onAudioCallPress={onAudio}
+        onVideoCallPress={onVideo}
+        callsAvailable
+      />,
+    );
+
+    const TouchableOpacity = require("react-native").TouchableOpacity;
+    // touchables[0] = back, [1] = title area, [2] = call button
+    const callButton = UNSAFE_getAllByType(TouchableOpacity)[2];
+    fireEvent.press(callButton);
+
+    // Tapping the call button should not fire either handler directly —
+    // it should reveal the menu items so the user can pick.
+    expect(onAudio).not.toHaveBeenCalled();
+    expect(onVideo).not.toHaveBeenCalled();
+
+    fireEvent.press(queryByLabelText("Appel audio")!);
+    expect(onAudio).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires the fallback handler directly when calls are unavailable (so the parent can show a toast) without opening the menu", () => {
+    mockCanGoBack.mockReturnValue(true);
+    const onAudio = jest.fn();
+    const onVideo = jest.fn();
+
+    const { UNSAFE_getAllByType, queryByLabelText } = render(
       <ChatHeader
         conversationName="Alice"
         conversationType="direct"
@@ -89,17 +127,18 @@ describe("ChatHeader back button", () => {
     );
 
     const TouchableOpacity = require("react-native").TouchableOpacity;
-    const touchables = UNSAFE_getAllByType(TouchableOpacity);
-    // touchables[0] = back, [1] = audio, [2] = video
-    fireEvent.press(touchables[1]);
-    fireEvent.press(touchables[2]);
+    const callButton = UNSAFE_getAllByType(TouchableOpacity)[2];
+    fireEvent.press(callButton);
 
-    expect(onAudio).toHaveBeenCalledTimes(1);
+    // The button stays clickable but bypasses the menu and triggers the
+    // video handler so the parent can surface the unavailable-toast.
     expect(onVideo).toHaveBeenCalledTimes(1);
+    expect(onAudio).not.toHaveBeenCalled();
+    expect(queryByLabelText("Appel audio")).toBeNull();
 
-    const audioStyle = Array.isArray(touchables[1].props.style)
-      ? Object.assign({}, ...touchables[1].props.style.filter(Boolean))
-      : touchables[1].props.style;
-    expect(audioStyle.opacity).toBe(0.4);
+    const callStyle = Array.isArray(callButton.props.style)
+      ? Object.assign({}, ...callButton.props.style.filter(Boolean))
+      : callButton.props.style;
+    expect(callStyle.opacity).toBe(0.4);
   });
 });

--- a/ChatScreen.test.tsx
+++ b/ChatScreen.test.tsx
@@ -87,9 +87,18 @@ jest.mock("./src/services/MediaService", () => ({
 jest.mock("./src/services/SchedulingService", () => ({
   SchedulingService: { createScheduledMessage: jest.fn() },
 }));
-jest.mock("./src/store/conversationsStore", () => ({
-  useConversationsStore: (selector: any) => selector({ conversations: [] }),
-}));
+jest.mock("./src/store/conversationsStore", () => {
+  const state = {
+    conversations: [],
+    resetUnreadCount: jest.fn(),
+    applyConversationUpdate: jest.fn(),
+    setGroupAvatars: jest.fn(),
+    groupAvatars: {},
+  };
+  const useConversationsStore: any = (selector: any) => selector(state);
+  useConversationsStore.getState = () => state;
+  return { useConversationsStore };
+});
 jest.mock("./src/store/presenceStore", () => ({
   usePresenceStore: (selector: any) =>
     selector({ onlineUserIds: new Set(), lastSeenAt: {} }),

--- a/src/components/Chat/SwipeableConversationItem.tsx
+++ b/src/components/Chat/SwipeableConversationItem.tsx
@@ -49,6 +49,15 @@ export const SwipeableConversationItem: React.FC<
   );
   const isUnread = (conversation.unread_count ?? 0) > 0 || isManuallyUnread;
 
+  const handlePress = (conversationId: string) => {
+    if (isSwiping) {
+      swipeableRef.current?.close();
+      setIsSwiping(false);
+      return;
+    }
+    onPress(conversationId);
+  };
+
   const renderRightActions = (
     progress: Animated.AnimatedInterpolation<number>,
     dragX: Animated.AnimatedInterpolation<number>,
@@ -200,7 +209,7 @@ export const SwipeableConversationItem: React.FC<
         friction={2}
         overshootRight={false}
         overshootLeft={false}
-        onBegan={() => setIsSwiping(true)}
+        onSwipeableOpenStartDrag={() => setIsSwiping(true)}
         onSwipeableWillOpen={() => {
           Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
         }}
@@ -214,7 +223,7 @@ export const SwipeableConversationItem: React.FC<
         >
           <ConversationItem
             conversation={conversation}
-            onPress={onPress}
+            onPress={handlePress}
             index={index}
             editMode={editMode}
             isSelected={isSelected}

--- a/src/navigation/AuthNavigator.tsx
+++ b/src/navigation/AuthNavigator.tsx
@@ -90,7 +90,7 @@ export type AuthStackParamList = {
   TwoFactorVerify: { secret: string };
   TwoFactorBackupCodes: { codes: string[] };
   ConversationsList: undefined;
-  Chat: { conversationId: string };
+  Chat: { conversationId: string; openSearch?: boolean };
   Contacts: undefined;
   MyQRCode: undefined;
   QRCodeScanner: undefined;

--- a/src/screens/Chat/ChatHeader.tsx
+++ b/src/screens/Chat/ChatHeader.tsx
@@ -3,7 +3,16 @@
  */
 
 import React, { useState } from "react";
-import { View, Text, StyleSheet, TouchableOpacity, Modal } from "react-native";
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  Modal,
+  Platform,
+} from "react-native";
+import { BlurView } from "expo-blur";
 import { useNavigation } from "@react-navigation/native";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "../../context/ThemeContext";
@@ -18,13 +27,20 @@ interface ChatHeaderProps {
   conversationType: "direct" | "group";
   onlineMemberCount?: number;
   groupAvatars?: Array<{ uri?: string; name: string }>;
-  onSearchPress?: () => void;
-  onInfoPress?: () => void;
-  onScheduledPress?: () => void;
+  typingNames?: string[];
+  onTitlePress?: () => void;
   onAudioCallPress?: () => void;
   onVideoCallPress?: () => void;
   callsAvailable?: boolean;
 }
+
+const formatTypingLabel = (names: string[]): string => {
+  if (names.length === 0) return "";
+  if (names.length === 1) return `${names[0]} est en train d'écrire…`;
+  if (names.length === 2)
+    return `${names[0]} et ${names[1]} sont en train d'écrire…`;
+  return `${names[0]} et ${names.length - 1} autres sont en train d'écrire…`;
+};
 
 export const ChatHeader: React.FC<ChatHeaderProps> = ({
   conversationName,
@@ -34,9 +50,8 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
   conversationType,
   onlineMemberCount = 0,
   groupAvatars,
-  onSearchPress,
-  onInfoPress,
-  onScheduledPress,
+  typingNames,
+  onTitlePress,
   onAudioCallPress,
   onVideoCallPress,
   callsAvailable = true,
@@ -48,8 +63,59 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
   const groupAvatarNodes =
     conversationType === "group" ? (groupAvatars || []).slice(0, 2) : [];
 
+  const isTyping = (typingNames?.length ?? 0) > 0;
+  const [callMenuOpen, setCallMenuOpen] = useState(false);
+  const hasCallActions = !!(onAudioCallPress || onVideoCallPress);
+
+  const handleCallButtonPress = () => {
+    if (!hasCallActions) return;
+    // When calls are unavailable we still want the parent to surface the
+    // toast — fire one of the handlers directly instead of opening a menu
+    // that would offer two unusable choices.
+    if (!callsAvailable) {
+      (onVideoCallPress ?? onAudioCallPress)?.();
+      return;
+    }
+    setCallMenuOpen(true);
+  };
+
+  const renderAvatar = () =>
+    conversationType === "group" ? (
+      avatarUrl ? (
+        <Avatar size={36} uri={avatarUrl} name={conversationName} />
+      ) : groupAvatarNodes.length > 0 ? (
+        <View style={styles.groupAvatarStack}>
+          {groupAvatarNodes.map((a, idx) => (
+            <View
+              key={`${a.uri ?? a.name}-${idx}`}
+              style={[
+                styles.groupAvatarItem,
+                idx === 1 ? styles.groupAvatarItemTop : null,
+              ]}
+            >
+              <Avatar size={24} uri={a.uri} name={a.name} />
+            </View>
+          ))}
+        </View>
+      ) : (
+        <Avatar size={36} name={conversationName} />
+      )
+    ) : (
+      <Avatar
+        size={36}
+        uri={avatarUrl}
+        name={conversationName}
+        showOnlineBadge
+        isOnline={isOnline}
+      />
+    );
+
   return (
-    <View style={[styles.container, { backgroundColor: "transparent" }]}>
+    <BlurView
+      intensity={Platform.OS === "ios" ? 60 : 80}
+      tint="dark"
+      style={styles.container}
+    >
       <TouchableOpacity
         onPress={() => {
           if (navigation.canGoBack()) {
@@ -63,104 +129,75 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
         accessibilityLabel="Retour"
       >
         <Ionicons
-          name="arrow-back"
-          size={24}
+          name="chevron-back"
+          size={26}
           color={themeColors.text.primary}
         />
       </TouchableOpacity>
-      {conversationType === "group" ? (
-        avatarUrl ? (
-          <Avatar size={32} uri={avatarUrl} name={conversationName} />
-        ) : groupAvatarNodes.length > 0 ? (
-          <View style={styles.groupAvatarStack}>
-            {groupAvatarNodes.map((a, idx) => (
-              <View
-                key={`${a.uri ?? a.name}-${idx}`}
-                style={[
-                  styles.groupAvatarItem,
-                  idx === 1 ? styles.groupAvatarItemTop : null,
-                ]}
-              >
-                <Avatar size={22} uri={a.uri} name={a.name} />
-              </View>
-            ))}
-          </View>
-        ) : (
-          <Avatar size={32} name={conversationName} />
-        )
-      ) : (
-        <Avatar
-          size={32}
-          uri={avatarUrl}
-          name={conversationName}
-          showOnlineBadge
-          isOnline={isOnline}
-        />
-      )}
-      <View style={styles.info}>
-        <Text
-          style={[styles.name, { color: themeColors.text.primary }]}
-          numberOfLines={1}
-        >
-          {conversationName}
-        </Text>
-        {conversationType === "direct" && (
+      <TouchableOpacity
+        style={styles.titleArea}
+        onPress={onTitlePress}
+        activeOpacity={onTitlePress ? 0.6 : 1}
+        disabled={!onTitlePress}
+        accessibilityRole="button"
+        accessibilityLabel={`Détails de ${conversationName}`}
+      >
+        {renderAvatar()}
+        <View style={styles.info}>
           <Text
-            style={[
-              styles.status,
-              {
-                color: isOnline
-                  ? colors.status.online
-                  : themeColors.text.secondary,
-              },
-            ]}
+            style={[styles.name, { color: themeColors.text.primary }]}
             numberOfLines={1}
           >
-            {isOnline
-              ? "En ligne"
-              : lastSeenAt
-                ? `Vu \u00e0 ${new Date(lastSeenAt).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" })}`
-                : "Hors ligne"}
+            {conversationName}
           </Text>
-        )}
-        {conversationType === "group" && onlineMemberCount > 0 && (
-          <Text
-            style={[styles.status, { color: colors.status.online }]}
-            numberOfLines={1}
-          >
-            {onlineMemberCount === 1
-              ? "1 membre en ligne"
-              : `${onlineMemberCount} membres en ligne`}
-          </Text>
-        )}
-      </View>
+          {isTyping ? (
+            <Text
+              style={[styles.status, { color: colors.status.online }]}
+              numberOfLines={1}
+            >
+              {formatTypingLabel(typingNames!)}
+            </Text>
+          ) : conversationType === "direct" && (isOnline || lastSeenAt) ? (
+            // The avatar's coloured dot already conveys online/offline state,
+            // so we only render text when it adds information beyond the dot:
+            // "En ligne" (qualitative reinforcement) or a "Vu à HH:MM" timestamp.
+            <Text
+              style={[
+                styles.status,
+                {
+                  color: isOnline
+                    ? colors.status.online
+                    : themeColors.text.secondary,
+                },
+              ]}
+              numberOfLines={1}
+            >
+              {isOnline
+                ? "En ligne"
+                : `Vu à ${new Date(lastSeenAt!).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" })}`}
+            </Text>
+          ) : onlineMemberCount > 0 ? (
+            <Text
+              style={[styles.status, { color: colors.status.online }]}
+              numberOfLines={1}
+            >
+              {onlineMemberCount === 1
+                ? "1 membre en ligne"
+                : `${onlineMemberCount} membres en ligne`}
+            </Text>
+          ) : null}
+        </View>
+      </TouchableOpacity>
       <View style={styles.actions}>
-        {onAudioCallPress && (
+        {hasCallActions && (
           <TouchableOpacity
-            onPress={onAudioCallPress}
+            onPress={handleCallButtonPress}
             style={[
               styles.actionButton,
               !callsAvailable && styles.actionButtonDisabled,
             ]}
             accessibilityRole="button"
-            accessibilityLabel="Appel audio"
-          >
-            <Ionicons
-              name="call-outline"
-              size={22}
-              color={themeColors.text.primary}
-            />
-          </TouchableOpacity>
-        )}
-        {onVideoCallPress && (
-          <TouchableOpacity
-            onPress={onVideoCallPress}
-            style={[
-              styles.actionButton,
-              !callsAvailable && styles.actionButtonDisabled,
-            ]}
-            accessibilityRole="button"
-            accessibilityLabel="Appel video"
+            accessibilityLabel="Lancer un appel"
           >
             <Ionicons
               name="videocam-outline"
@@ -169,50 +206,79 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
             />
           </TouchableOpacity>
         )}
-        {onScheduledPress && (
-          <TouchableOpacity
-            onPress={onScheduledPress}
-            style={styles.actionButton}
-            accessibilityRole="button"
-            accessibilityLabel="Messages programmés"
-          >
-            <Ionicons
-              name="timer-outline"
-              size={22}
-              color={themeColors.text.primary}
-            />
-          </TouchableOpacity>
-        )}
-        {onSearchPress && (
-          <TouchableOpacity
-            onPress={onSearchPress}
-            style={styles.actionButton}
-            accessibilityRole="button"
-            accessibilityLabel="Rechercher dans la conversation"
-          >
-            <Ionicons
-              name="search"
-              size={22}
-              color={themeColors.text.primary}
-            />
-          </TouchableOpacity>
-        )}
-        <TouchableOpacity
-          onPress={() => {
-            onInfoPress?.();
-          }}
-          style={styles.actionButton}
-          accessibilityRole="button"
-          accessibilityLabel="Détails de la conversation"
-        >
-          <Ionicons
-            name="information-circle-outline"
-            size={22}
-            color={themeColors.text.primary}
-          />
-        </TouchableOpacity>
       </View>
-    </View>
+      <Modal
+        visible={callMenuOpen}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setCallMenuOpen(false)}
+      >
+        <TouchableWithoutFeedback onPress={() => setCallMenuOpen(false)}>
+          <View style={styles.callMenuBackdrop}>
+            <TouchableWithoutFeedback>
+              <BlurView
+                intensity={Platform.OS === "ios" ? 60 : 80}
+                tint="dark"
+                style={styles.callMenu}
+              >
+                {onAudioCallPress && (
+                  <TouchableOpacity
+                    style={styles.callMenuItem}
+                    onPress={() => {
+                      setCallMenuOpen(false);
+                      onAudioCallPress();
+                    }}
+                    accessibilityRole="button"
+                    accessibilityLabel="Appel audio"
+                  >
+                    <Ionicons
+                      name="call-outline"
+                      size={20}
+                      color={themeColors.text.primary}
+                      style={styles.callMenuIcon}
+                    />
+                    <Text
+                      style={[
+                        styles.callMenuLabel,
+                        { color: themeColors.text.primary },
+                      ]}
+                    >
+                      Appel audio
+                    </Text>
+                  </TouchableOpacity>
+                )}
+                {onVideoCallPress && (
+                  <TouchableOpacity
+                    style={styles.callMenuItem}
+                    onPress={() => {
+                      setCallMenuOpen(false);
+                      onVideoCallPress();
+                    }}
+                    accessibilityRole="button"
+                    accessibilityLabel="Appel vidéo"
+                  >
+                    <Ionicons
+                      name="videocam-outline"
+                      size={20}
+                      color={themeColors.text.primary}
+                      style={styles.callMenuIcon}
+                    />
+                    <Text
+                      style={[
+                        styles.callMenuLabel,
+                        { color: themeColors.text.primary },
+                      ]}
+                    >
+                      Appel vidéo
+                    </Text>
+                  </TouchableOpacity>
+                )}
+              </BlurView>
+            </TouchableWithoutFeedback>
+          </View>
+        </TouchableWithoutFeedback>
+      </Modal>
+    </BlurView>
   );
 };
 
@@ -220,18 +286,30 @@ const styles = StyleSheet.create({
   container: {
     flexDirection: "row",
     alignItems: "center",
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    borderBottomWidth: 1,
-    borderBottomColor: "rgba(255, 255, 255, 0.1)",
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "rgba(255, 255, 255, 0.18)",
+    backgroundColor:
+      Platform.OS === "ios"
+        ? "rgba(20, 25, 50, 0.35)"
+        : "rgba(20, 25, 50, 0.7)",
   },
   backButton: {
-    marginRight: 12,
+    paddingHorizontal: 4,
+    paddingVertical: 4,
+    marginRight: 4,
+  },
+  titleArea: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 4,
+    paddingRight: 8,
   },
   groupAvatarStack: {
-    width: 32,
-    height: 32,
-    marginRight: 0,
+    width: 36,
+    height: 36,
   },
   groupAvatarItem: {
     position: "absolute",
@@ -240,7 +318,7 @@ const styles = StyleSheet.create({
   },
   groupAvatarItemTop: {
     left: 12,
-    top: 10,
+    top: 12,
   },
   info: {
     flex: 1,
@@ -257,13 +335,46 @@ const styles = StyleSheet.create({
   actions: {
     flexDirection: "row",
     alignItems: "center",
-    marginLeft: 8,
   },
   actionButton: {
     padding: 8,
-    marginLeft: 4,
+    marginLeft: 2,
   },
   actionButtonDisabled: {
     opacity: 0.4,
+  },
+  callMenuBackdrop: {
+    flex: 1,
+    alignItems: "flex-end",
+    // Push the menu just below where the topbar typically ends. The
+    // topbar height varies with the safe-area inset, so we use a value
+    // that works on phones with and without a notch — the user can still
+    // tap anywhere outside to dismiss.
+    paddingTop: Platform.OS === "ios" ? 96 : 64,
+    paddingRight: 8,
+  },
+  callMenu: {
+    minWidth: 180,
+    borderRadius: 12,
+    overflow: "hidden",
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.18)",
+    backgroundColor:
+      Platform.OS === "ios"
+        ? "rgba(20, 25, 50, 0.55)"
+        : "rgba(20, 25, 50, 0.85)",
+  },
+  callMenuItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+  },
+  callMenuIcon: {
+    marginRight: 12,
+  },
+  callMenuLabel: {
+    fontSize: 15,
+    fontWeight: "500",
   },
 });

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -164,7 +164,16 @@ export const ChatScreen: React.FC = () => {
   const route = useRoute<ChatScreenRouteProp>();
   const navigation = useNavigation<ChatScreenNavigationProp>();
   const { conversationId } = route.params;
-  const [conversation, setConversation] = useState<Conversation | null>(null);
+  // Hydrate from the conversations store so the header (name + avatar)
+  // shows immediately while getConversation() is still in flight. The
+  // store entry has already been enriched with display_name and avatar_url
+  // by enrichSingleConversation() for direct chats.
+  const [conversation, setConversation] = useState<Conversation | null>(() => {
+    const cached = useConversationsStore
+      .getState()
+      .conversations.find((c) => c.id === conversationId);
+    return cached ?? null;
+  });
   const [messages, setMessages] = useState<MessageWithRelations[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -577,19 +586,26 @@ export const ChatScreen: React.FC = () => {
     try {
       const conv = await messagingAPI.getConversation(conversationId);
 
-      // Resolve display name for direct conversations
-      // The detail endpoint returns members array, not member_user_ids
+      // Resolve display name and avatar for direct conversations.
+      // The detail endpoint returns members array, not member_user_ids,
+      // and does not populate avatar_url for direct chats — we enrich it
+      // from the other user's profile to feed the header avatar.
       const memberIds =
         conv.member_user_ids ||
         conv.members?.map((m: { user_id: string }) => m.user_id);
-      if (conv.type === "direct" && !conv.display_name && memberIds) {
+      if (
+        conv.type === "direct" &&
+        (!conv.display_name || !conv.avatar_url) &&
+        memberIds
+      ) {
         conv.member_user_ids = memberIds;
         const otherUserId = memberIds.find((id: string) => id !== userId);
         if (otherUserId) {
           try {
             const userInfo = await messagingAPI.getUserInfo(otherUserId);
             if (userInfo) {
-              conv.display_name = userInfo.display_name;
+              conv.display_name = conv.display_name || userInfo.display_name;
+              conv.avatar_url = conv.avatar_url || userInfo.avatar_url;
             }
           } catch {}
         }
@@ -623,6 +639,16 @@ export const ChatScreen: React.FC = () => {
       markAsRead(conversationId, lastMsg.id);
     }
   }, [conversationId, messages.length, userId, markAsRead]);
+
+  // Consume the openSearch route param (set by GroupDetails or other screens
+  // that want to drop the user directly into the search UI). Clear it after
+  // use so it doesn't re-trigger on subsequent re-renders or focus events.
+  useEffect(() => {
+    if (route.params?.openSearch) {
+      setShowSearch(true);
+      navigation.setParams({ openSearch: undefined });
+    }
+  }, [route.params?.openSearch, navigation]);
 
   useEffect(() => {
     // Load data
@@ -2255,9 +2281,10 @@ export const ChatScreen: React.FC = () => {
           isOnline={isOtherOnline}
           lastSeenAt={otherLastSeenAt}
           onlineMemberCount={onlineMemberCount}
-          onSearchPress={() => setShowSearch(true)}
-          onInfoPress={handleInfoPress}
-          onScheduledPress={handleScheduledPress}
+          typingNames={typingUsers
+            .map((id) => typingUsersNames[id])
+            .filter(Boolean)}
+          onTitlePress={handleInfoPress}
           onAudioCallPress={() => handleInitiateCall("audio")}
           onVideoCallPress={() => handleInitiateCall("video")}
           callsAvailable={callsAvailability.available}
@@ -2597,6 +2624,59 @@ export const ChatScreen: React.FC = () => {
                       {messages.length} message{messages.length > 1 ? "s" : ""}
                     </Text>
                   </View>
+                  <View style={styles.infoSectionActions}>
+                    <Text style={styles.infoLabel}>ACTIONS</Text>
+                    <TouchableOpacity
+                      style={styles.infoActionRow}
+                      onPress={() => {
+                        setShowInfoModal(false);
+                        setShowSearch(true);
+                      }}
+                      activeOpacity={0.7}
+                      accessibilityRole="button"
+                      accessibilityLabel="Rechercher dans la conversation"
+                    >
+                      <Ionicons
+                        name="search"
+                        size={20}
+                        color={colors.text.light}
+                        style={styles.infoActionIcon}
+                      />
+                      <Text style={styles.infoActionLabel}>
+                        Rechercher des messages
+                      </Text>
+                      <Ionicons
+                        name="chevron-forward"
+                        size={20}
+                        color={withOpacity(colors.text.light, 0.4)}
+                      />
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                      style={styles.infoActionRow}
+                      onPress={() => {
+                        setShowInfoModal(false);
+                        handleScheduledPress();
+                      }}
+                      activeOpacity={0.7}
+                      accessibilityRole="button"
+                      accessibilityLabel="Messages programmés"
+                    >
+                      <Ionicons
+                        name="timer-outline"
+                        size={20}
+                        color={colors.text.light}
+                        style={styles.infoActionIcon}
+                      />
+                      <Text style={styles.infoActionLabel}>
+                        Messages programmés
+                      </Text>
+                      <Ionicons
+                        name="chevron-forward"
+                        size={20}
+                        color={withOpacity(colors.text.light, 0.4)}
+                      />
+                    </TouchableOpacity>
+                  </View>
                 </ScrollView>
               </LinearGradient>
             </View>
@@ -2773,5 +2853,26 @@ const styles = StyleSheet.create({
     fontWeight: "600",
     color: colors.text.light,
     letterSpacing: 0.2,
+  },
+  infoSectionActions: {
+    marginBottom: 24,
+  },
+  infoActionRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 14,
+    paddingHorizontal: 12,
+    backgroundColor: withOpacity(colors.text.light, 0.06),
+    borderRadius: 12,
+    marginBottom: 8,
+  },
+  infoActionIcon: {
+    marginRight: 14,
+  },
+  infoActionLabel: {
+    flex: 1,
+    fontSize: 15,
+    color: colors.text.light,
+    fontWeight: "500",
   },
 });

--- a/src/screens/Groups/GroupDetailsScreen.tsx
+++ b/src/screens/Groups/GroupDetailsScreen.tsx
@@ -1439,6 +1439,75 @@ export const GroupDetailsScreen: React.FC = () => {
           <AnimatedTouchableOpacity
             style={styles.actionButton}
             onPress={() => {
+              Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+              navigation.navigate("Chat", {
+                conversationId: conversationKey,
+                openSearch: true,
+              });
+            }}
+            activeOpacity={0.7}
+            entering={FadeInDown.delay(100).duration(300)}
+          >
+            <View style={styles.actionButtonContent}>
+              <View style={styles.actionIconContainer}>
+                <LinearGradient
+                  colors={[colors.primary.main, colors.primary.dark]}
+                  style={styles.actionIconGradient}
+                >
+                  <Ionicons name="search" size={20} color={colors.text.light} />
+                </LinearGradient>
+              </View>
+              <Text
+                style={[styles.actionButtonText, { color: colors.text.light }]}
+              >
+                Rechercher des messages
+              </Text>
+            </View>
+            <Ionicons
+              name="chevron-forward"
+              size={20}
+              color={withOpacity(colors.text.light, 0.4)}
+            />
+          </AnimatedTouchableOpacity>
+          <AnimatedTouchableOpacity
+            style={styles.actionButton}
+            onPress={() => {
+              Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+              navigation.navigate("ScheduledMessages", {
+                conversationId: conversationKey,
+              });
+            }}
+            activeOpacity={0.7}
+            entering={FadeInDown.delay(150).duration(300)}
+          >
+            <View style={styles.actionButtonContent}>
+              <View style={styles.actionIconContainer}>
+                <LinearGradient
+                  colors={[colors.primary.main, colors.primary.dark]}
+                  style={styles.actionIconGradient}
+                >
+                  <Ionicons
+                    name="timer-outline"
+                    size={20}
+                    color={colors.text.light}
+                  />
+                </LinearGradient>
+              </View>
+              <Text
+                style={[styles.actionButtonText, { color: colors.text.light }]}
+              >
+                Messages programmés
+              </Text>
+            </View>
+            <Ionicons
+              name="chevron-forward"
+              size={20}
+              color={withOpacity(colors.text.light, 0.4)}
+            />
+          </AnimatedTouchableOpacity>
+          <AnimatedTouchableOpacity
+            style={styles.actionButton}
+            onPress={() => {
               Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
               setShowLeaveModal(true);
             }}


### PR DESCRIPTION
## Summary

- Fix the missing avatar in direct conversation topbars by enriching `avatar_url` from `getUserInfo` (the conversation detail endpoint does not populate it for directs) and hydrate `ChatScreen` from the conversations store so the header shows immediately.
- Apply the same glassmorphism treatment as the Settings redesign: `BlurView` (60 iOS / 80 Android) with a translucent navy overlay and a subtle white border. Avatar bumped to 36, back icon switched to `chevron-back`, and avatar + name now act as a single tap-target that opens the conversation details.
- Drop the redundant "Hors ligne" status (the avatar dot already conveys that), keep "En ligne" / "Vu à HH:MM", and surface a typing indicator in the topbar when applicable.
- Move Search and Scheduled Messages out of the topbar into the conversation details (modal for directs, `GroupDetailsScreen` for groups). Groups reach the search via a new `openSearch` route param that `ChatScreen` consumes once and clears.
- Collapse the audio + video buttons into a single `videocam-outline` button that opens a small popover. When calls are unavailable, the button bypasses the menu and triggers the existing toast directly.

## Test plan

- [ ] Unit tests green (`npm test`)
- [ ] Lint clean (`npm run lint:fix`)
- [ ] Direct conversation: avatar appears in the topbar; tapping avatar/name opens the details modal; "Hors ligne" no longer shows; typing indicator surfaces when the other user types.
- [ ] Group conversation: avatar (single or stacked) renders; tapping the title opens `GroupDetailsScreen`.
- [ ] Call button opens a popover with audio + vidéo; tapping outside dismisses; tapping a choice triggers the corresponding handler.
- [ ] Calls unavailable: button is dimmed (opacity 0.4), bypasses the menu, surfaces the toast.
- [ ] Search and Scheduled Messages reachable from the direct modal and from `GroupDetailsScreen`; group's "Rechercher" navigates back to Chat with the search bar opened.
- [ ] Tested on iOS simulator
- [ ] Tested on Android emulator

Closes WHISPR-1257