### PR TITLE
[WHISPR-1259] feat(chat): redesign message bubbles with iMessage-style tail and glass surface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@livekit/react-native": "^2.10.1",
         "@livekit/react-native-webrtc": "^144.0.0",
         "@react-native-async-storage/async-storage": "^2.2.0",
+        "@react-native-masked-view/masked-view": "^0.3.2",
         "@react-navigation/native": "^7.1.17",
         "@react-navigation/stack": "^7.4.8",
         "@tensorflow/tfjs": "^4.22.0",
@@ -3208,6 +3209,16 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
+    "node_modules/@react-native-masked-view/masked-view": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@react-native-masked-view/masked-view/-/masked-view-0.3.2.tgz",
+      "integrity": "sha512-XwuQoW7/GEgWRMovOQtX3A4PrXhyaZm0lVUiY8qJDvdngjLms9Cpdck6SmGAUNqQwcj2EadHC1HwL0bEyoa/SQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16",
+        "react-native": ">=0.57"
       }
     },
     "node_modules/@react-native/assets-registry": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@livekit/react-native": "^2.10.1",
     "@livekit/react-native-webrtc": "^144.0.0",
     "@react-native-async-storage/async-storage": "^2.2.0",
+    "@react-native-masked-view/masked-view": "^0.3.2",
     "@react-navigation/native": "^7.1.17",
     "@react-navigation/stack": "^7.4.8",
     "@tensorflow/tfjs": "^4.22.0",

--- a/src/components/Chat/BubbleSilhouette.tsx
+++ b/src/components/Chat/BubbleSilhouette.tsx
@@ -8,22 +8,14 @@
  * bubbles that need a hairline border.
  */
 
-import React from "react";
+import React, { memo, useMemo } from "react";
 import Svg, { Path } from "react-native-svg";
 
 const RADIUS = 18;
-// Hand-tuned iMessage-style drop tail. Reference (w=150, h=45, r=18):
-//   M18 0 H127 q24 0 25 22 V27 Q150 45 136 45
-//   q-5 1 -2 8 Q136.5 56 133 55 129 53 126 49 124 45 116 45
-//   H16 Q0 45 -2 25 L-2 20 Q0 0 18 0 Z
-// The tail is anchored to the bottom-RIGHT corner (w, h) — its shape is
-// invariant under vertical/horizontal growth. Only the straight side edges
-// (between the corner curves) stretch when the bubble grows.
-// The tail no longer extends horizontally past the bubble (the bottom-right
-// corner flows inward into the tail), so TAIL_W is 0. Kept as a named
-// constant in case future tweaks add a horizontal overshoot back.
+// The tail is anchored to the bottom-right corner — its shape is invariant
+// under bubble growth; only the straight side edges stretch.
 const TAIL_W = 0;
-const TAIL_H = 11; // downward extent past the bubble's bottom (tip at h + 11)
+const TAIL_H = 11;
 
 interface BubbleSilhouetteProps {
   width: number;
@@ -164,7 +156,7 @@ function buildPath(
   return side === "right" ? rightPath : mirrorPathHorizontally(rightPath, w);
 }
 
-export const BubbleSilhouette: React.FC<BubbleSilhouetteProps> = ({
+const BubbleSilhouetteImpl: React.FC<BubbleSilhouetteProps> = ({
   width,
   height,
   side,
@@ -173,16 +165,16 @@ export const BubbleSilhouette: React.FC<BubbleSilhouetteProps> = ({
   strokeWidth = 1,
   fill = "#000",
 }) => {
+  const path = useMemo(
+    () => buildPath(width, height, side, withTail),
+    [width, height, side, withTail],
+  );
   if (width <= 0 || height <= 0) return null;
-  // The tail extends OUTSIDE the bubble's logical width/height — the SVG
-  // viewBox must be enlarged to include it (downward and slightly sideways),
-  // otherwise the tail would be clipped by the SVG's bounds.
   const tailExtentX = withTail ? TAIL_W : 0;
   const tailExtentY = withTail ? TAIL_H + 1 : 0;
   const totalHeight = height + tailExtentY;
   const totalWidth = width + tailExtentX;
   const offsetX = side === "left" ? tailExtentX : 0;
-  const path = buildPath(width, height, side, withTail);
   return (
     <Svg
       width={totalWidth}
@@ -198,6 +190,8 @@ export const BubbleSilhouette: React.FC<BubbleSilhouetteProps> = ({
     </Svg>
   );
 };
+
+export const BubbleSilhouette = memo(BubbleSilhouetteImpl);
 
 export const BUBBLE_TAIL_WIDTH = TAIL_W;
 export const BUBBLE_TAIL_HEIGHT = TAIL_H;

--- a/src/components/Chat/BubbleSilhouette.tsx
+++ b/src/components/Chat/BubbleSilhouette.tsx
@@ -1,0 +1,203 @@
+/**
+ * BubbleSilhouette — single SVG path describing a chat bubble with an
+ * integrated tail at the bottom corner. Used as a mask so the underlying
+ * surface (gradient, BlurView) is rendered as one seamless shape, eliminating
+ * the visible seam that appears when a separate tail is stacked on the bubble.
+ *
+ * Optionally also renders a stroked outline of the same path for received
+ * bubbles that need a hairline border.
+ */
+
+import React from "react";
+import Svg, { Path } from "react-native-svg";
+
+const RADIUS = 18;
+// Hand-tuned iMessage-style drop tail. Reference (w=150, h=45, r=18):
+//   M18 0 H127 q24 0 25 22 V27 Q150 45 136 45
+//   q-5 1 -2 8 Q136.5 56 133 55 129 53 126 49 124 45 116 45
+//   H16 Q0 45 -2 25 L-2 20 Q0 0 18 0 Z
+// The tail is anchored to the bottom-RIGHT corner (w, h) — its shape is
+// invariant under vertical/horizontal growth. Only the straight side edges
+// (between the corner curves) stretch when the bubble grows.
+// The tail no longer extends horizontally past the bubble (the bottom-right
+// corner flows inward into the tail), so TAIL_W is 0. Kept as a named
+// constant in case future tweaks add a horizontal overshoot back.
+const TAIL_W = 0;
+const TAIL_H = 11; // downward extent past the bubble's bottom (tip at h + 11)
+
+interface BubbleSilhouetteProps {
+  width: number;
+  height: number;
+  side: "left" | "right";
+  /** When false, draws a simple rounded rectangle without a tail. Used for
+   * non-terminal messages in a burst from the same sender (iMessage groups
+   * consecutive bubbles, only the last one carries a tail). */
+  withTail?: boolean;
+  /** When set, renders a stroked outline (no fill) instead of a filled
+   * silhouette — used for the hairline border layer over received bubbles. */
+  stroke?: string;
+  strokeWidth?: number;
+  /** Solid fill colour for the mask layer. Mask elements only need their
+   * alpha channel; any opaque colour works. */
+  fill?: string;
+}
+
+function buildRoundedRectPath(w: number, h: number, r: number): string {
+  return [
+    `M${r} 0`,
+    `L${w - r} 0`,
+    `Q${w} 0 ${w} ${r}`,
+    `V${h - r}`,
+    `Q${w} ${h} ${w - r} ${h}`,
+    `L${r} ${h}`,
+    `Q0 ${h} 0 ${h - r}`,
+    `V${r}`,
+    `Q0 0 ${r} 0`,
+    "Z",
+  ].join(" ");
+}
+
+function buildRightPath(w: number, h: number, r: number): string {
+  // Reference geometry (offsets relative to the bottom-right corner (w, h)):
+  //
+  //   Three of the four corners are uniform quarter circles of radius r.
+  //   Only the bottom-right corner is reshaped to flow into the tail.
+  //
+  //   Top-left:     L(0, r)  → Q(0, 0) → (r, 0)
+  //   Top-right:    L(w, r)  → Q(w, 0) → (w - r, 0)
+  //   Bottom-left:  L(0, h - r) → Q(0, h) → (r, h)
+  //   Bottom-right: tail (custom)
+  //
+  // Only the straight side edges (r → h - r) stretch with bubble size.
+  return [
+    `M${r} 0`,
+    `L${w - r} 0`,
+    `Q${w} 0 ${w} ${r}`,
+    `V${h - r}`,
+    // Bottom-right tucked corner that flows into the tail.
+    `Q${w} ${h} ${w - 14} ${h}`,
+    `q-5 1 -2 8`,
+    `Q${w - 13.5} ${h + TAIL_H} ${w - 17} ${h + 10}`,
+    `T${w - 24} ${h + 4}`,
+    `T${w - 34} ${h}`,
+    `H${r}`,
+    `Q0 ${h} 0 ${h - r}`,
+    `V${r}`,
+    `Q0 0 ${r} 0`,
+    "Z",
+  ].join(" ");
+}
+
+/**
+ * Mirror an SVG path along the vertical axis x = w/2 (so x → w - x). Works on
+ * absolute commands (M, L, H, V, Q, C, T, S, Z) AND relative ones (m, l, h,
+ * v, q, c, t, s) — relative dx values flip sign, dy values stay.
+ */
+function mirrorPathHorizontally(path: string, w: number): string {
+  const tokens = path.match(/[a-zA-Z]|-?\d*\.?\d+/g);
+  if (!tokens) return path;
+  const out: string[] = [];
+  let i = 0;
+  while (i < tokens.length) {
+    const cmd = tokens[i];
+    if (!/[a-zA-Z]/.test(cmd)) {
+      i += 1;
+      continue;
+    }
+    const isRelative = cmd === cmd.toLowerCase();
+    const upper = cmd.toUpperCase();
+    // Number of params per command.
+    const arity: Record<string, number> = {
+      M: 2,
+      L: 2,
+      T: 2,
+      H: 1,
+      V: 1,
+      Q: 4,
+      C: 6,
+      S: 4,
+      Z: 0,
+    };
+    const n = arity[upper] ?? 0;
+    out.push(cmd);
+    if (n === 0) {
+      i += 1;
+      continue;
+    }
+    const params = tokens.slice(i + 1, i + 1 + n).map(Number);
+    i += 1 + n;
+    if (upper === "H") {
+      out.push(String(isRelative ? -params[0] : w - params[0]));
+    } else if (upper === "V") {
+      out.push(String(params[0]));
+    } else {
+      // Pairs: (x, y), (x, y), ...
+      for (let k = 0; k < params.length; k += 2) {
+        const x = params[k];
+        const y = params[k + 1];
+        out.push(String(isRelative ? -x : w - x));
+        out.push(String(y));
+      }
+    }
+  }
+  return out.join(" ");
+}
+
+function buildPath(
+  w: number,
+  h: number,
+  side: "left" | "right",
+  withTail: boolean,
+): string {
+  // Adaptive corner radius:
+  //  - On single-line bubbles (h ≤ 2*RADIUS) the radius equals h/2 so the
+  //    shape becomes a true pill — the side arcs meet in the middle with no
+  //    visible vertical edge.
+  //  - On taller bubbles the radius caps at RADIUS so the corners stay
+  //    moderate and the shape reads as a rounded box, not an over-rounded
+  //    candy.
+  const r = Math.min(h / 2, w / 2, RADIUS);
+  if (!withTail) {
+    return buildRoundedRectPath(w, h, r);
+  }
+  const rightPath = buildRightPath(w, h, r);
+  return side === "right" ? rightPath : mirrorPathHorizontally(rightPath, w);
+}
+
+export const BubbleSilhouette: React.FC<BubbleSilhouetteProps> = ({
+  width,
+  height,
+  side,
+  withTail = true,
+  stroke,
+  strokeWidth = 1,
+  fill = "#000",
+}) => {
+  if (width <= 0 || height <= 0) return null;
+  // The tail extends OUTSIDE the bubble's logical width/height — the SVG
+  // viewBox must be enlarged to include it (downward and slightly sideways),
+  // otherwise the tail would be clipped by the SVG's bounds.
+  const tailExtentX = withTail ? TAIL_W : 0;
+  const tailExtentY = withTail ? TAIL_H + 1 : 0;
+  const totalHeight = height + tailExtentY;
+  const totalWidth = width + tailExtentX;
+  const offsetX = side === "left" ? tailExtentX : 0;
+  const path = buildPath(width, height, side, withTail);
+  return (
+    <Svg
+      width={totalWidth}
+      height={totalHeight}
+      viewBox={`${-offsetX} 0 ${totalWidth} ${totalHeight}`}
+    >
+      <Path
+        d={path}
+        fill={stroke ? "none" : fill}
+        stroke={stroke}
+        strokeWidth={stroke ? strokeWidth : 0}
+      />
+    </Svg>
+  );
+};
+
+export const BUBBLE_TAIL_WIDTH = TAIL_W;
+export const BUBBLE_TAIL_HEIGHT = TAIL_H;

--- a/src/components/Chat/MaskedBubbleSurface.tsx
+++ b/src/components/Chat/MaskedBubbleSurface.tsx
@@ -1,0 +1,164 @@
+/**
+ * MaskedBubbleSurface — renders the painted background of a chat bubble
+ * (gradient for sent, BlurView + tint for received) clipped to a single
+ * silhouette that includes the tail. The text/media content is rendered as
+ * children on top, naturally laying out and measuring the surface.
+ *
+ * Why this exists: stacking a separate tail SVG on top of a translucent
+ * BlurView (or differently-clipped LinearGradient) leaves a visible seam at
+ * the join. By masking ONE continuous surface, the seam disappears.
+ */
+
+import React, { useState, useCallback } from "react";
+import { View, StyleSheet, LayoutChangeEvent } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import { BlurView } from "expo-blur";
+import MaskedView from "@react-native-masked-view/masked-view";
+import {
+  BubbleSilhouette,
+  BUBBLE_TAIL_WIDTH,
+  BUBBLE_TAIL_HEIGHT,
+} from "./BubbleSilhouette";
+
+type Variant = "sent" | "received" | "failed";
+
+interface MaskedBubbleSurfaceProps {
+  variant: Variant;
+  side: "left" | "right";
+  /** When false, the tail is omitted (consecutive messages from same sender). */
+  showTail?: boolean;
+  children: React.ReactNode;
+  contentStyle?: object;
+}
+
+const SENT_GRADIENT = ["#FFB07B", "#F86F71", "#F04882"] as const;
+const FAILED_BG = "rgba(240, 72, 72, 0.15)";
+const FAILED_BORDER = "rgba(240, 72, 72, 0.4)";
+const RECEIVED_BG = "rgba(11, 17, 36, 0.35)";
+const RECEIVED_BORDER = "rgba(255, 255, 255, 0.12)";
+
+export const MaskedBubbleSurface: React.FC<MaskedBubbleSurfaceProps> = ({
+  variant,
+  side,
+  showTail = true,
+  children,
+  contentStyle,
+}) => {
+  const [size, setSize] = useState<{ w: number; h: number } | null>(null);
+
+  const onLayout = useCallback((e: LayoutChangeEvent) => {
+    const { width, height } = e.nativeEvent.layout;
+    setSize((prev) => {
+      if (
+        prev &&
+        Math.abs(prev.w - width) < 0.5 &&
+        Math.abs(prev.h - height) < 0.5
+      ) {
+        return prev;
+      }
+      return { w: width, h: height };
+    });
+  }, []);
+
+  // The tail droops down-and-outward from the bubble's bottom corner, so the
+  // background surface must extend both horizontally (a little, for the side
+  // bulge) and vertically (more, for the drop).
+  const tailW = showTail ? BUBBLE_TAIL_WIDTH : 0;
+  const tailH = showTail ? BUBBLE_TAIL_HEIGHT + 1 : 0;
+  const surfaceW = size ? size.w + tailW : 0;
+  const surfaceH = size ? size.h + tailH : 0;
+  const surfaceOffsetX = side === "left" ? -tailW : 0;
+
+  const surface = size ? (
+    variant === "received" ? (
+      <BlurView
+        intensity={30}
+        tint="dark"
+        style={{
+          width: surfaceW,
+          height: surfaceH,
+          backgroundColor: RECEIVED_BG,
+        }}
+      />
+    ) : variant === "failed" ? (
+      <View
+        style={{
+          width: surfaceW,
+          height: surfaceH,
+          backgroundColor: FAILED_BG,
+        }}
+      />
+    ) : (
+      <LinearGradient
+        colors={SENT_GRADIENT}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={{ width: surfaceW, height: surfaceH }}
+      />
+    )
+  ) : null;
+
+  const borderColor =
+    variant === "received"
+      ? RECEIVED_BORDER
+      : variant === "failed"
+        ? FAILED_BORDER
+        : null;
+
+  return (
+    <View style={styles.container}>
+      {/* Background masked surface (gradient or blur), behind the content. */}
+      {size ? (
+        <View
+          pointerEvents="none"
+          style={[
+            styles.surfaceLayer,
+            { left: surfaceOffsetX, width: surfaceW, height: surfaceH },
+          ]}
+        >
+          <MaskedView
+            style={{ width: surfaceW, height: surfaceH }}
+            maskElement={
+              <BubbleSilhouette
+                width={size.w}
+                height={size.h}
+                side={side}
+                withTail={showTail}
+              />
+            }
+          >
+            {surface}
+          </MaskedView>
+          {borderColor ? (
+            <View style={StyleSheet.absoluteFill} pointerEvents="none">
+              <BubbleSilhouette
+                width={size.w}
+                height={size.h}
+                side={side}
+                withTail={showTail}
+                stroke={borderColor}
+                strokeWidth={1}
+              />
+            </View>
+          ) : null}
+        </View>
+      ) : null}
+      {/* Foreground content — its layout determines bubble size. */}
+      <View onLayout={onLayout} style={contentStyle}>
+        {children}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    position: "relative",
+    alignSelf: "flex-start",
+  },
+  surfaceLayer: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+  },
+});

--- a/src/components/Chat/MaskedBubbleSurface.tsx
+++ b/src/components/Chat/MaskedBubbleSurface.tsx
@@ -9,7 +9,7 @@
  * the join. By masking ONE continuous surface, the seam disappears.
  */
 
-import React, { useState, useCallback } from "react";
+import React, { memo, useState, useCallback } from "react";
 import { View, StyleSheet, LayoutChangeEvent } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
 import { BlurView } from "expo-blur";
@@ -37,7 +37,37 @@ const FAILED_BORDER = "rgba(240, 72, 72, 0.4)";
 const RECEIVED_BG = "rgba(11, 17, 36, 0.35)";
 const RECEIVED_BORDER = "rgba(255, 255, 255, 0.12)";
 
-export const MaskedBubbleSurface: React.FC<MaskedBubbleSurfaceProps> = ({
+const VARIANT_BORDER: Record<Variant, string | null> = {
+  sent: null,
+  received: RECEIVED_BORDER,
+  failed: FAILED_BORDER,
+};
+
+function renderSurface(variant: Variant, w: number, h: number) {
+  const style = { width: w, height: h };
+  if (variant === "received") {
+    return (
+      <BlurView
+        intensity={30}
+        tint="dark"
+        style={[style, { backgroundColor: RECEIVED_BG }]}
+      />
+    );
+  }
+  if (variant === "failed") {
+    return <View style={[style, { backgroundColor: FAILED_BG }]} />;
+  }
+  return (
+    <LinearGradient
+      colors={SENT_GRADIENT}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 1 }}
+      style={style}
+    />
+  );
+}
+
+const MaskedBubbleSurfaceImpl: React.FC<MaskedBubbleSurfaceProps> = ({
   variant,
   side,
   showTail = true,
@@ -61,53 +91,16 @@ export const MaskedBubbleSurface: React.FC<MaskedBubbleSurfaceProps> = ({
   }, []);
 
   // The tail droops down-and-outward from the bubble's bottom corner, so the
-  // background surface must extend both horizontally (a little, for the side
-  // bulge) and vertically (more, for the drop).
+  // surface extends horizontally (slight side bulge) and vertically (drop).
   const tailW = showTail ? BUBBLE_TAIL_WIDTH : 0;
   const tailH = showTail ? BUBBLE_TAIL_HEIGHT + 1 : 0;
   const surfaceW = size ? size.w + tailW : 0;
   const surfaceH = size ? size.h + tailH : 0;
   const surfaceOffsetX = side === "left" ? -tailW : 0;
-
-  const surface = size ? (
-    variant === "received" ? (
-      <BlurView
-        intensity={30}
-        tint="dark"
-        style={{
-          width: surfaceW,
-          height: surfaceH,
-          backgroundColor: RECEIVED_BG,
-        }}
-      />
-    ) : variant === "failed" ? (
-      <View
-        style={{
-          width: surfaceW,
-          height: surfaceH,
-          backgroundColor: FAILED_BG,
-        }}
-      />
-    ) : (
-      <LinearGradient
-        colors={SENT_GRADIENT}
-        start={{ x: 0, y: 0 }}
-        end={{ x: 1, y: 1 }}
-        style={{ width: surfaceW, height: surfaceH }}
-      />
-    )
-  ) : null;
-
-  const borderColor =
-    variant === "received"
-      ? RECEIVED_BORDER
-      : variant === "failed"
-        ? FAILED_BORDER
-        : null;
+  const borderColor = VARIANT_BORDER[variant];
 
   return (
     <View style={styles.container}>
-      {/* Background masked surface (gradient or blur), behind the content. */}
       {size ? (
         <View
           pointerEvents="none"
@@ -127,7 +120,7 @@ export const MaskedBubbleSurface: React.FC<MaskedBubbleSurfaceProps> = ({
               />
             }
           >
-            {surface}
+            {renderSurface(variant, surfaceW, surfaceH)}
           </MaskedView>
           {borderColor ? (
             <View style={StyleSheet.absoluteFill} pointerEvents="none">
@@ -143,13 +136,14 @@ export const MaskedBubbleSurface: React.FC<MaskedBubbleSurfaceProps> = ({
           ) : null}
         </View>
       ) : null}
-      {/* Foreground content — its layout determines bubble size. */}
       <View onLayout={onLayout} style={contentStyle}>
         {children}
       </View>
     </View>
   );
 };
+
+export const MaskedBubbleSurface = memo(MaskedBubbleSurfaceImpl);
 
 const styles = StyleSheet.create({
   container: {

--- a/src/components/Chat/MessageBubble.tsx
+++ b/src/components/Chat/MessageBubble.tsx
@@ -32,7 +32,7 @@ import { MaskedBubbleSurface } from "./MaskedBubbleSurface";
 import { MessageStatusLabel } from "./MessageStatusLabel";
 import { useMessageSwipe } from "../../context/MessageSwipeContext";
 import { FormattedText } from "../../utils/textFormatter";
-import { isReachableUrl } from "../../utils";
+import { isReachableUrl, formatHourMinute } from "../../utils";
 import { getApiBaseUrl } from "../../services/apiBase";
 
 /**
@@ -634,10 +634,7 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
             pointerEvents="none"
           >
             <Text style={styles.swipeTimestamp}>
-              {new Date(message.sent_at).toLocaleTimeString("fr-FR", {
-                hour: "2-digit",
-                minute: "2-digit",
-              })}
+              {formatHourMinute(message.sent_at)}
             </Text>
           </Animated.View>
           <Animated.View
@@ -874,9 +871,32 @@ export default memo(MessageBubble, (prevProps, nextProps) => {
     prevProps.isLastSentByMe === nextProps.isLastSentByMe &&
     prevProps.isGroupConversation === nextProps.isGroupConversation &&
     prevProps.otherMembersCount === nextProps.otherMembersCount &&
-    JSON.stringify(prevProps.message.delivery_statuses) ===
-      JSON.stringify(nextProps.message.delivery_statuses) &&
+    // delivery_statuses only feeds MessageStatusLabel, which renders solely
+    // for the last-sent bubble — skip the deep compare elsewhere.
+    (!nextProps.isLastSentByMe ||
+      deliveryStatusesEqual(
+        prevProps.message.delivery_statuses,
+        nextProps.message.delivery_statuses,
+      )) &&
     JSON.stringify(prevProps.message.reactions) ===
       JSON.stringify(nextProps.message.reactions)
   );
 });
+
+function deliveryStatusesEqual(
+  a: MessageWithRelations["delivery_statuses"],
+  b: MessageWithRelations["delivery_statuses"],
+): boolean {
+  if (a === b) return true;
+  const al = a?.length ?? 0;
+  const bl = b?.length ?? 0;
+  if (al !== bl) return false;
+  if (al === 0) return true;
+  // Compare only the fields that affect the rendered status label.
+  for (let i = 0; i < al; i += 1) {
+    const x = a![i];
+    const y = b![i];
+    if (x.user_id !== y.user_id || x.read_at !== y.read_at) return false;
+  }
+  return true;
+}

--- a/src/components/Chat/MessageBubble.tsx
+++ b/src/components/Chat/MessageBubble.tsx
@@ -11,7 +11,6 @@ import {
   Pressable,
   Platform,
 } from "react-native";
-import { LinearGradient } from "expo-linear-gradient";
 import { Avatar } from "./Avatar";
 import {
   useSharedValue,
@@ -24,12 +23,14 @@ import * as Haptics from "expo-haptics";
 import { MessageWithRelations } from "../../types/messaging";
 import { useTheme } from "../../context/ThemeContext";
 import { colors } from "../../theme/colors";
-import { DeliveryStatus } from "./DeliveryStatus";
 import { ReactionBar } from "./ReactionBar";
 import { ReplyPreview } from "./ReplyPreview";
 import { ReactionPicker } from "./ReactionPicker";
 import { MediaMessage } from "./MediaMessage";
 import { AudioMessage } from "./AudioMessage";
+import { MaskedBubbleSurface } from "./MaskedBubbleSurface";
+import { MessageStatusLabel } from "./MessageStatusLabel";
+import { useMessageSwipe } from "../../context/MessageSwipeContext";
 import { FormattedText } from "../../utils/textFormatter";
 import { isReachableUrl } from "../../utils";
 import { getApiBaseUrl } from "../../services/apiBase";
@@ -172,6 +173,10 @@ interface MessageBubbleProps {
   senderAvatarUrl?: string | null;
   /** True when this message is from the same sender as the previous one (avatar is hidden but space is kept) */
   isConsecutive?: boolean;
+  /** True when this is the last message in a burst from the same sender —
+   * iMessage convention: only the bottom-most consecutive bubble carries a
+   * tail; the others are plain rounded rectangles. */
+  isLastInBurst?: boolean;
   /** When true, the conversation is a group and avatars should be shown for received messages */
   showSenderAvatar?: boolean;
   onReactionPress?: (messageId: string, emoji: string) => void;
@@ -191,6 +196,15 @@ interface MessageBubbleProps {
   };
   /** Called when the user taps "Contester" on a locally blocked image */
   onContest?: (message: MessageWithRelations) => void;
+  /** When true, renders a textual delivery status under the bubble (only the
+   * latest message sent by the current user should set this). */
+  isLastSentByMe?: boolean;
+  /** Group conversation flag — affects "Vu par" wording. */
+  isGroupConversation?: boolean;
+  /** Number of *other* members in the conversation (excludes sender). */
+  otherMembersCount?: number;
+  /** Display name resolver for read-receipt user ids. */
+  resolveMemberName?: (userId: string) => string;
 }
 
 export const MessageBubble: React.FC<MessageBubbleProps> = ({
@@ -200,6 +214,7 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
   senderName,
   senderAvatarUrl,
   isConsecutive = false,
+  isLastInBurst = true,
   showSenderAvatar = false,
   onReactionPress,
   onReactionDetailsPress,
@@ -210,10 +225,15 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
   searchQuery,
   pendingAppeal,
   onContest,
+  isLastSentByMe = false,
+  isGroupConversation = false,
+  otherMembersCount = 0,
+  resolveMemberName,
 }) => {
   const { getThemeColors } = useTheme();
   const themeColors = getThemeColors();
   const [showReactionPicker, setShowReactionPicker] = useState(false);
+  const swipe = useMessageSwipe();
 
   if (!message || !shouldRenderMessage(message)) {
     return null;
@@ -300,6 +320,19 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
     opacity: opacity.value,
   }));
 
+  const swipeStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: swipe && isSent ? swipe.translateX.value : 0 }],
+  }));
+
+  const swipeTimestampStyle = useAnimatedStyle(() => {
+    // Slide the timestamp in from the right edge of the screen as the user
+    // swipes left. The timestamp lives in absolute positioning at right: 6,
+    // and starts shifted off-screen by +40 px. As the gesture progresses it
+    // translates back toward 0 (its resting visible position).
+    const offset = swipe ? swipe.translateX.value + 40 : 40;
+    return { transform: [{ translateX: Math.max(0, offset) }] };
+  });
+
   const isForwarded =
     !!message.forwarded_from_id || message.metadata?.forwarded === true;
   const isFailed = message.status === "failed";
@@ -314,98 +347,186 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
     // Failed message: show error overlay with reason
     if (isFailed && isSent) {
       return (
-        <View
-          style={[
-            styles.sentBubble,
-            {
-              backgroundColor: "rgba(240, 72, 72, 0.15)",
-              borderWidth: 1,
-              borderColor: "rgba(240, 72, 72, 0.4)",
-            },
-          ]}
-        >
-          {hasMedia && firstAttachment && firstAttachment.metadata ? (
-            <MediaMessage
-              uri={resolveMediaUrl(
-                firstAttachment.metadata.media_url ||
-                  firstAttachment.metadata.thumbnail_url,
-                firstAttachment.media_id,
-                "blob",
-              )}
-              type={firstAttachment.media_type as any}
-              filename={firstAttachment.metadata.filename}
-              size={firstAttachment.metadata.size}
-              thumbnailUri={resolveMediaUrl(
-                firstAttachment.metadata.thumbnail_url,
-                firstAttachment.media_id,
-                "thumbnail",
-              )}
-            />
-          ) : null}
-          <View
-            style={{
-              flexDirection: "row",
-              alignItems: "center",
-              paddingHorizontal: 4,
-              paddingTop: hasMedia ? 6 : 0,
-            }}
+        <View style={styles.sentBubbleWrapper}>
+          <MaskedBubbleSurface
+            variant="failed"
+            side="right"
+            showTail={isLastInBurst}
+            contentStyle={styles.bubbleContent}
           >
-            <Text style={{ fontSize: 14, marginRight: 6 }}>⚠️</Text>
-            <Text style={{ color: "#F04848", fontSize: 13, flex: 1 }}>
-              {message.content || "Échec de l'envoi"}
-            </Text>
-          </View>
-          <View style={styles.footer}>
-            <Text style={styles.timestamp}>
-              {new Date(message.sent_at).toLocaleTimeString("fr-FR", {
-                hour: "2-digit",
-                minute: "2-digit",
-              })}
-            </Text>
-            <DeliveryStatus status="failed" />
-          </View>
-          {(message.metadata as any)?.blockedByModeration === true ? (
-            <View style={styles.appealRow}>
-              {!pendingAppeal && !(message.metadata as any)?.appealRejected ? (
-                <TouchableOpacity
-                  style={styles.contestBtn}
-                  onPress={() => onContest?.(message)}
-                  activeOpacity={0.7}
-                >
-                  <Text style={styles.contestBtnText}>Contester</Text>
-                </TouchableOpacity>
-              ) : null}
-              {pendingAppeal?.status === "pending" ? (
-                <View style={[styles.appealBadge, styles.appealBadgePending]}>
-                  <Text style={styles.appealBadgeText}>
-                    Contestation envoyée
-                  </Text>
-                </View>
-              ) : null}
-              {pendingAppeal?.status === "rejected" ||
-              (message.metadata as any)?.appealRejected ? (
-                <View style={[styles.appealBadge, styles.appealBadgeRejected]}>
-                  <Text style={styles.appealBadgeText}>
-                    Refusée par l'admin
-                  </Text>
-                </View>
-              ) : null}
+            {hasMedia && firstAttachment && firstAttachment.metadata ? (
+              <MediaMessage
+                uri={resolveMediaUrl(
+                  firstAttachment.metadata.media_url ||
+                    firstAttachment.metadata.thumbnail_url,
+                  firstAttachment.media_id,
+                  "blob",
+                )}
+                type={firstAttachment.media_type as any}
+                filename={firstAttachment.metadata.filename}
+                size={firstAttachment.metadata.size}
+                thumbnailUri={resolveMediaUrl(
+                  firstAttachment.metadata.thumbnail_url,
+                  firstAttachment.media_id,
+                  "thumbnail",
+                )}
+              />
+            ) : null}
+            <View
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                paddingHorizontal: 4,
+                paddingTop: hasMedia ? 6 : 0,
+              }}
+            >
+              <Text style={{ fontSize: 14, marginRight: 6 }}>⚠️</Text>
+              <Text style={{ color: "#F04848", fontSize: 13, flex: 1 }}>
+                {message.content || "Échec de l'envoi"}
+              </Text>
             </View>
-          ) : null}
+            {(message.metadata as any)?.blockedByModeration === true ? (
+              <View style={styles.appealRow}>
+                {!pendingAppeal &&
+                !(message.metadata as any)?.appealRejected ? (
+                  <TouchableOpacity
+                    style={styles.contestBtn}
+                    onPress={() => onContest?.(message)}
+                    activeOpacity={0.7}
+                  >
+                    <Text style={styles.contestBtnText}>Contester</Text>
+                  </TouchableOpacity>
+                ) : null}
+                {pendingAppeal?.status === "pending" ? (
+                  <View style={[styles.appealBadge, styles.appealBadgePending]}>
+                    <Text style={styles.appealBadgeText}>
+                      Contestation envoyée
+                    </Text>
+                  </View>
+                ) : null}
+                {pendingAppeal?.status === "rejected" ||
+                (message.metadata as any)?.appealRejected ? (
+                  <View
+                    style={[styles.appealBadge, styles.appealBadgeRejected]}
+                  >
+                    <Text style={styles.appealBadgeText}>
+                      Refusée par l'admin
+                    </Text>
+                  </View>
+                ) : null}
+              </View>
+            ) : null}
+          </MaskedBubbleSurface>
         </View>
       );
     }
 
     if (isSent) {
       return (
-        <LinearGradient
-          colors={["#FFB07B", "#F86F71", "#F04882"]}
-          start={{ x: 0, y: 0 }}
-          end={{ x: 1, y: 1 }}
-          style={styles.sentBubble}
+        <View style={styles.sentBubbleWrapper}>
+          <MaskedBubbleSurface
+            variant="sent"
+            side="right"
+            showTail={isLastInBurst}
+            contentStyle={styles.bubbleContent}
+          >
+            {isForwarded ? (
+              <Text style={styles.forwardedLabel}>Transféré</Text>
+            ) : null}
+            {message.reply_to ? (
+              <ReplyPreview
+                replyTo={message.reply_to}
+                currentUserId={currentUserId}
+                onPress={() => onReplyPress?.(message.reply_to!.id)}
+              />
+            ) : null}
+            {hasMedia && firstAttachment && firstAttachment.metadata ? (
+              <>
+                {firstAttachment.media_type === "audio" ? (
+                  <AudioMessage
+                    uri={resolveMediaUrl(
+                      firstAttachment.metadata.media_url,
+                      firstAttachment.media_id,
+                      "blob",
+                    )}
+                    duration={firstAttachment.metadata.duration}
+                    isSent={true}
+                  />
+                ) : (
+                  <MediaMessage
+                    uri={resolveMediaUrl(
+                      firstAttachment.metadata.media_url ||
+                        firstAttachment.metadata.thumbnail_url,
+                      firstAttachment.media_id,
+                      "blob",
+                    )}
+                    type={firstAttachment.media_type}
+                    filename={firstAttachment.metadata.filename}
+                    size={firstAttachment.metadata.size}
+                    thumbnailUri={resolveMediaUrl(
+                      firstAttachment.metadata.thumbnail_url,
+                      firstAttachment.media_id,
+                      "thumbnail",
+                    )}
+                  />
+                )}
+              </>
+            ) : null}
+            {displayContent ? (
+              isTombstoned ? (
+                <Text style={[styles.sentText, styles.deletedText]}>
+                  {displayContent}
+                </Text>
+              ) : (
+                <FormattedText
+                  text={displayContent}
+                  style={[styles.sentText, { color: colors.text.light }]}
+                  boldStyle={{ color: colors.text.light }}
+                  italicStyle={{ color: colors.text.light }}
+                  codeStyle={{
+                    color: colors.text.light,
+                    backgroundColor: "rgba(0, 0, 0, 0.2)",
+                  }}
+                />
+              )
+            ) : null}
+            {message.edited_at ? (
+              <View style={styles.footer}>
+                <Text
+                  style={[
+                    styles.editedLabel,
+                    { color: "rgba(255, 255, 255, 0.75)" },
+                  ]}
+                >
+                  édité
+                </Text>
+              </View>
+            ) : null}
+          </MaskedBubbleSurface>
+        </View>
+      );
+    }
+
+    return (
+      <View style={styles.receivedBubbleWrap}>
+        <MaskedBubbleSurface
+          variant="received"
+          side="left"
+          showTail={isLastInBurst}
+          contentStyle={styles.bubbleContent}
         >
+          {senderName ? (
+            <Text style={styles.senderNameLabel}>{senderName}</Text>
+          ) : null}
           {isForwarded ? (
-            <Text style={styles.forwardedLabel}>Transféré</Text>
+            <Text
+              style={[
+                styles.forwardedLabel,
+                { color: themeColors.text.tertiary },
+              ]}
+            >
+              Transféré
+            </Text>
           ) : null}
           {message.reply_to ? (
             <ReplyPreview
@@ -424,7 +545,7 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                     "blob",
                   )}
                   duration={firstAttachment.metadata.duration}
-                  isSent={true}
+                  isSent={false}
                 />
               ) : (
                 <MediaMessage
@@ -434,7 +555,9 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                     firstAttachment.media_id,
                     "blob",
                   )}
-                  type={firstAttachment.media_type}
+                  type={
+                    firstAttachment.media_type as "image" | "video" | "file"
+                  }
                   filename={firstAttachment.metadata.filename}
                   size={firstAttachment.metadata.size}
                   thumbnailUri={resolveMediaUrl(
@@ -448,152 +571,49 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
           ) : null}
           {displayContent ? (
             isTombstoned ? (
-              <Text style={[styles.sentText, styles.deletedText]}>
+              <Text
+                style={[
+                  styles.receivedText,
+                  { color: themeColors.text.primary },
+                  styles.deletedText,
+                ]}
+              >
                 {displayContent}
               </Text>
             ) : (
               <FormattedText
                 text={displayContent}
-                style={[styles.sentText, { color: colors.text.light }]}
-                boldStyle={{ color: colors.text.light }}
-                italicStyle={{ color: colors.text.light }}
+                style={[
+                  styles.receivedText,
+                  { color: themeColors.text.primary },
+                ]}
+                boldStyle={{ color: themeColors.text.primary }}
+                italicStyle={{ color: themeColors.text.primary }}
                 codeStyle={{
+                  color: themeColors.text.primary,
+                  backgroundColor: "rgba(255, 255, 255, 0.1)",
+                }}
+                searchQuery={searchQuery}
+                highlightStyle={{
+                  backgroundColor: colors.primary.main,
                   color: colors.text.light,
-                  backgroundColor: "rgba(0, 0, 0, 0.2)",
                 }}
               />
             )
           ) : null}
-          <View style={styles.footer}>
-            <Text style={styles.timestamp}>
-              {new Date(message.sent_at).toLocaleTimeString("fr-FR", {
-                hour: "2-digit",
-                minute: "2-digit",
-              })}
-            </Text>
-            {message.edited_at ? (
+          {message.edited_at ? (
+            <View style={styles.footer}>
               <Text
                 style={[
                   styles.editedLabel,
                   { color: themeColors.text.tertiary },
                 ]}
               >
-                {" "}
                 édité
               </Text>
-            ) : null}
-            {message.status ? <DeliveryStatus status={message.status} /> : null}
-          </View>
-        </LinearGradient>
-      );
-    }
-
-    return (
-      <View
-        style={[
-          styles.receivedBubble,
-          { backgroundColor: "rgba(26, 31, 58, 0.6)" }, // Dark card with transparency
-        ]}
-      >
-        {senderName ? (
-          <Text style={styles.senderNameLabel}>{senderName}</Text>
-        ) : null}
-        {isForwarded ? (
-          <Text
-            style={[
-              styles.forwardedLabel,
-              { color: themeColors.text.tertiary },
-            ]}
-          >
-            Transféré
-          </Text>
-        ) : null}
-        {message.reply_to ? (
-          <ReplyPreview
-            replyTo={message.reply_to}
-            currentUserId={currentUserId}
-            onPress={() => onReplyPress?.(message.reply_to!.id)}
-          />
-        ) : null}
-        {hasMedia && firstAttachment && firstAttachment.metadata ? (
-          <>
-            {firstAttachment.media_type === "audio" ? (
-              <AudioMessage
-                uri={resolveMediaUrl(
-                  firstAttachment.metadata.media_url,
-                  firstAttachment.media_id,
-                  "blob",
-                )}
-                duration={firstAttachment.metadata.duration}
-                isSent={false}
-              />
-            ) : (
-              <MediaMessage
-                uri={resolveMediaUrl(
-                  firstAttachment.metadata.media_url ||
-                    firstAttachment.metadata.thumbnail_url,
-                  firstAttachment.media_id,
-                  "blob",
-                )}
-                type={firstAttachment.media_type as "image" | "video" | "file"}
-                filename={firstAttachment.metadata.filename}
-                size={firstAttachment.metadata.size}
-                thumbnailUri={resolveMediaUrl(
-                  firstAttachment.metadata.thumbnail_url,
-                  firstAttachment.media_id,
-                  "thumbnail",
-                )}
-              />
-            )}
-          </>
-        ) : null}
-        {displayContent ? (
-          isTombstoned ? (
-            <Text
-              style={[
-                styles.receivedText,
-                { color: themeColors.text.primary },
-                styles.deletedText,
-              ]}
-            >
-              {displayContent}
-            </Text>
-          ) : (
-            <FormattedText
-              text={displayContent}
-              style={[styles.receivedText, { color: themeColors.text.primary }]}
-              boldStyle={{ color: themeColors.text.primary }}
-              italicStyle={{ color: themeColors.text.primary }}
-              codeStyle={{
-                color: themeColors.text.primary,
-                backgroundColor: "rgba(255, 255, 255, 0.1)",
-              }}
-              searchQuery={searchQuery}
-              highlightStyle={{
-                backgroundColor: colors.primary.main,
-                color: colors.text.light,
-              }}
-            />
-          )
-        ) : null}
-        <View style={styles.footer}>
-          <Text
-            style={[styles.timestamp, { color: themeColors.text.tertiary }]}
-          >
-            {new Date(message.sent_at).toLocaleTimeString("fr-FR", {
-              hour: "2-digit",
-              minute: "2-digit",
-            })}
-          </Text>
-          {message.edited_at ? (
-            <Text
-              style={[styles.editedLabel, { color: themeColors.text.tertiary }]}
-            >
-              {" "}
-              édité
-            </Text>
+            </View>
           ) : null}
-        </View>
+        </MaskedBubbleSurface>
       </View>
     );
   };
@@ -603,44 +623,70 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
       <Pressable
         onLongPress={handleLongPress}
         delayLongPress={300}
+        style={styles.pressableStretch}
         {...(Platform.OS === "web"
           ? ({ onContextMenu: handleContextMenu } as any)
           : {})}
       >
-        <Animated.View
-          style={[
-            isSent ? styles.sentContainer : styles.receivedContainer,
-            animatedStyle,
-          ]}
-        >
-          {shouldRenderAvatarSlot ? (
-            <View style={styles.receivedRow}>
-              <View style={styles.avatarSlot}>
-                {!isConsecutive ? (
-                  <Avatar uri={safeAvatarUri} name={senderName} size={32} />
-                ) : null}
+        <View style={styles.swipeRow}>
+          <Animated.View
+            style={[styles.swipeTimestampWrap, swipeTimestampStyle]}
+            pointerEvents="none"
+          >
+            <Text style={styles.swipeTimestamp}>
+              {new Date(message.sent_at).toLocaleTimeString("fr-FR", {
+                hour: "2-digit",
+                minute: "2-digit",
+              })}
+            </Text>
+          </Animated.View>
+          <Animated.View
+            style={[
+              isSent ? styles.sentContainer : styles.receivedContainer,
+              isLastInBurst ? styles.containerWithTail : styles.containerNoTail,
+              animatedStyle,
+              swipeStyle,
+            ]}
+          >
+            {shouldRenderAvatarSlot ? (
+              <View style={styles.receivedRow}>
+                <View style={styles.avatarSlot}>
+                  {!isConsecutive ? (
+                    <Avatar uri={safeAvatarUri} name={senderName} size={32} />
+                  ) : null}
+                </View>
+                <View style={styles.receivedBubbleWrapper}>
+                  {renderBubbleContent()}
+                </View>
               </View>
-              <View style={styles.receivedBubbleWrapper}>
-                {renderBubbleContent()}
-              </View>
-            </View>
-          ) : (
-            renderBubbleContent()
-          )}
-          {message.reactions && message.reactions.length > 0 ? (
-            <ReactionBar
-              reactions={message.reactions}
-              currentUserId={currentUserId}
-              onReactionPress={handleReactionSelect}
-              onReactionLongPress={
-                onReactionDetailsPress
-                  ? (emoji) => onReactionDetailsPress(message.id, emoji)
-                  : undefined
-              }
-              resolveReactorName={resolveReactorName}
+            ) : (
+              renderBubbleContent()
+            )}
+            {message.reactions && message.reactions.length > 0 ? (
+              <ReactionBar
+                reactions={message.reactions}
+                currentUserId={currentUserId}
+                onReactionPress={handleReactionSelect}
+                onReactionLongPress={
+                  onReactionDetailsPress
+                    ? (emoji) => onReactionDetailsPress(message.id, emoji)
+                    : undefined
+                }
+                resolveReactorName={resolveReactorName}
+              />
+            ) : null}
+          </Animated.View>
+        </View>
+        {isSent && isLastSentByMe ? (
+          <View style={styles.statusLabelRow}>
+            <MessageStatusLabel
+              message={message}
+              isGroup={isGroupConversation}
+              otherMembersCount={otherMembersCount}
+              resolveMemberName={resolveMemberName}
             />
-          ) : null}
-        </Animated.View>
+          </View>
+        ) : null}
       </Pressable>
       <ReactionPicker
         visible={showReactionPicker}
@@ -652,18 +698,58 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
 };
 
 const styles = StyleSheet.create({
+  pressableStretch: {
+    alignSelf: "stretch",
+  },
+  statusLabelRow: {
+    alignItems: "flex-end",
+    marginHorizontal: 16,
+    marginBottom: 4,
+  },
+  swipeRow: {
+    position: "relative",
+    alignSelf: "stretch",
+  },
+  swipeTimestampWrap: {
+    position: "absolute",
+    right: 6,
+    top: 0,
+    bottom: 0,
+    justifyContent: "center",
+  },
+  swipeTimestamp: {
+    fontSize: 11,
+    fontWeight: "500",
+    color: "rgba(255, 255, 255, 0.85)",
+    includeFontPadding: false,
+    // Subtle shadow so the timestamp stays legible on light gradient
+    // backgrounds (e.g. bottom of the chat where the orange/pink hue lifts).
+    textShadowColor: "rgba(0, 0, 0, 0.4)",
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 2,
+  },
   sentContainer: {
     alignItems: "flex-end",
-    marginVertical: 4,
+    marginTop: 4,
     marginHorizontal: 16,
+    position: "relative",
   },
-  sentBubble: {
+  containerWithTail: {
+    // Extra bottom spacing absorbs the tail that extends below the bubble
+    // (~11 px), so consecutive bubbles don't touch each other.
+    marginBottom: 14,
+  },
+  containerNoTail: {
+    // Tight spacing inside a burst — no tail to clear, bubbles can sit close.
+    marginBottom: 2,
+  },
+  sentBubbleWrapper: {
     maxWidth: "75%",
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-    borderRadius: 16,
-    borderBottomRightRadius: 4,
-    overflow: "visible", // Allow progress bar to be visible
+    position: "relative",
+  },
+  bubbleContent: {
+    paddingHorizontal: 14,
+    paddingVertical: 7,
   },
   sentText: {
     color: colors.text.light,
@@ -672,8 +758,9 @@ const styles = StyleSheet.create({
   },
   receivedContainer: {
     alignItems: "flex-start",
-    marginVertical: 4,
+    marginTop: 4,
     marginHorizontal: 16,
+    position: "relative",
   },
   receivedRow: {
     flexDirection: "row",
@@ -687,12 +774,9 @@ const styles = StyleSheet.create({
   receivedBubbleWrapper: {
     flexShrink: 1,
   },
-  receivedBubble: {
+  receivedBubbleWrap: {
     maxWidth: "75%",
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-    borderRadius: 16,
-    borderBottomLeftRadius: 4,
+    position: "relative",
   },
   receivedText: {
     fontSize: 15,
@@ -703,11 +787,6 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "flex-end",
     marginTop: 4,
-  },
-  timestamp: {
-    fontSize: 12,
-    color: colors.text.tertiary,
-    marginRight: 4,
   },
   editedLabel: {
     fontSize: 11,
@@ -782,6 +861,7 @@ export default memo(MessageBubble, (prevProps, nextProps) => {
     prevProps.senderName === nextProps.senderName &&
     prevProps.senderAvatarUrl === nextProps.senderAvatarUrl &&
     prevProps.isConsecutive === nextProps.isConsecutive &&
+    prevProps.isLastInBurst === nextProps.isLastInBurst &&
     prevProps.showSenderAvatar === nextProps.showSenderAvatar &&
     prevProps.onReactionDetailsPress === nextProps.onReactionDetailsPress &&
     prevProps.pendingAppeal?.status === nextProps.pendingAppeal?.status &&
@@ -791,6 +871,11 @@ export default memo(MessageBubble, (prevProps, nextProps) => {
       (nextProps.message.metadata as any)?.appealRejected &&
     (prevProps.message.metadata as any)?.media_url ===
       (nextProps.message.metadata as any)?.media_url &&
+    prevProps.isLastSentByMe === nextProps.isLastSentByMe &&
+    prevProps.isGroupConversation === nextProps.isGroupConversation &&
+    prevProps.otherMembersCount === nextProps.otherMembersCount &&
+    JSON.stringify(prevProps.message.delivery_statuses) ===
+      JSON.stringify(nextProps.message.delivery_statuses) &&
     JSON.stringify(prevProps.message.reactions) ===
       JSON.stringify(nextProps.message.reactions)
   );

--- a/src/components/Chat/MessageStatusLabel.tsx
+++ b/src/components/Chat/MessageStatusLabel.tsx
@@ -7,6 +7,9 @@
 import React from "react";
 import { Text, StyleSheet } from "react-native";
 import { MessageWithRelations } from "../../types/messaging";
+import { formatHourMinute } from "../../utils";
+
+type Status = NonNullable<MessageWithRelations["status"]>;
 
 interface MessageStatusLabelProps {
   message: MessageWithRelations;
@@ -17,11 +20,37 @@ interface MessageStatusLabelProps {
   otherMembersCount?: number;
 }
 
-function formatReadTime(isoDate: string): string {
-  return new Date(isoDate).toLocaleTimeString("fr-FR", {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+const STATIC_LABELS: Partial<Record<Status, string>> = {
+  sending: "Envoi…",
+  queued: "Envoi…",
+  failed: "Échec d'envoi",
+  sent: "Envoyé",
+  delivered: "Distribué",
+};
+
+function buildReadLabel(
+  message: MessageWithRelations,
+  isGroup: boolean,
+  otherMembersCount: number,
+  resolveMemberName?: (userId: string) => string,
+): string {
+  const readers = (message.delivery_statuses ?? []).filter((d) => !!d.read_at);
+  if (!isGroup) {
+    const reader = readers[0];
+    return reader?.read_at ? `Vu à ${formatHourMinute(reader.read_at)}` : "Vu";
+  }
+  if (readers.length === 0) return "Vu";
+  if (otherMembersCount > 0 && readers.length >= otherMembersCount) {
+    const lastReadAt = readers
+      .map((r) => r.read_at as string)
+      .sort()
+      .pop()!;
+    return `Vu par tous à ${formatHourMinute(lastReadAt)}`;
+  }
+  const names = readers
+    .map((r) => (resolveMemberName ? resolveMemberName(r.user_id) : r.user_id))
+    .filter(Boolean);
+  return names.length > 0 ? `Vu par ${names.join(", ")}` : "Vu";
 }
 
 export const MessageStatusLabel: React.FC<MessageStatusLabelProps> = ({
@@ -30,48 +59,13 @@ export const MessageStatusLabel: React.FC<MessageStatusLabelProps> = ({
   isGroup = false,
   otherMembersCount = 0,
 }) => {
-  const { status, delivery_statuses } = message;
-
+  const { status } = message;
   if (!status) return null;
-
-  let label: string | null = null;
-
-  if (status === "sending" || status === "queued") {
-    label = "Envoi…";
-  } else if (status === "failed") {
-    label = "Échec d'envoi";
-  } else if (status === "sent") {
-    label = "Envoyé";
-  } else if (status === "delivered") {
-    label = "Distribué";
-  } else if (status === "read") {
-    if (isGroup) {
-      const readers = (delivery_statuses ?? []).filter((d) => !!d.read_at);
-      if (readers.length === 0) {
-        label = "Vu";
-      } else if (otherMembersCount > 0 && readers.length >= otherMembersCount) {
-        // Use the most recent read_at across readers for the time stamp.
-        const lastReadAt = readers
-          .map((r) => r.read_at as string)
-          .sort()
-          .pop()!;
-        label = `Vu par tous à ${formatReadTime(lastReadAt)}`;
-      } else {
-        const names = readers
-          .map((r) =>
-            resolveMemberName ? resolveMemberName(r.user_id) : r.user_id,
-          )
-          .filter(Boolean);
-        label = names.length > 0 ? `Vu par ${names.join(", ")}` : "Vu";
-      }
-    } else {
-      const reader = (delivery_statuses ?? []).find((d) => !!d.read_at);
-      label = reader?.read_at ? `Vu à ${formatReadTime(reader.read_at)}` : "Vu";
-    }
-  }
-
+  const label =
+    status === "read"
+      ? buildReadLabel(message, isGroup, otherMembersCount, resolveMemberName)
+      : STATIC_LABELS[status];
   if (!label) return null;
-
   return <Text style={styles.label}>{label}</Text>;
 };
 

--- a/src/components/Chat/MessageStatusLabel.tsx
+++ b/src/components/Chat/MessageStatusLabel.tsx
@@ -1,0 +1,86 @@
+/**
+ * MessageStatusLabel — text-based delivery status shown under the most recent
+ * message sent by the current user. Replaces the per-bubble check-mark icons
+ * (sent/delivered/read) so the chat UI stays cleaner.
+ */
+
+import React from "react";
+import { Text, StyleSheet } from "react-native";
+import { MessageWithRelations } from "../../types/messaging";
+
+interface MessageStatusLabelProps {
+  message: MessageWithRelations;
+  /** Display name resolver for read receipts in group conversations. */
+  resolveMemberName?: (userId: string) => string;
+  isGroup?: boolean;
+  /** Total number of *other* members in the conversation (excludes the sender). */
+  otherMembersCount?: number;
+}
+
+function formatReadTime(isoDate: string): string {
+  return new Date(isoDate).toLocaleTimeString("fr-FR", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export const MessageStatusLabel: React.FC<MessageStatusLabelProps> = ({
+  message,
+  resolveMemberName,
+  isGroup = false,
+  otherMembersCount = 0,
+}) => {
+  const { status, delivery_statuses } = message;
+
+  if (!status) return null;
+
+  let label: string | null = null;
+
+  if (status === "sending" || status === "queued") {
+    label = "Envoi…";
+  } else if (status === "failed") {
+    label = "Échec d'envoi";
+  } else if (status === "sent") {
+    label = "Envoyé";
+  } else if (status === "delivered") {
+    label = "Distribué";
+  } else if (status === "read") {
+    if (isGroup) {
+      const readers = (delivery_statuses ?? []).filter((d) => !!d.read_at);
+      if (readers.length === 0) {
+        label = "Vu";
+      } else if (otherMembersCount > 0 && readers.length >= otherMembersCount) {
+        // Use the most recent read_at across readers for the time stamp.
+        const lastReadAt = readers
+          .map((r) => r.read_at as string)
+          .sort()
+          .pop()!;
+        label = `Vu par tous à ${formatReadTime(lastReadAt)}`;
+      } else {
+        const names = readers
+          .map((r) =>
+            resolveMemberName ? resolveMemberName(r.user_id) : r.user_id,
+          )
+          .filter(Boolean);
+        label = names.length > 0 ? `Vu par ${names.join(", ")}` : "Vu";
+      }
+    } else {
+      const reader = (delivery_statuses ?? []).find((d) => !!d.read_at);
+      label = reader?.read_at ? `Vu à ${formatReadTime(reader.read_at)}` : "Vu";
+    }
+  }
+
+  if (!label) return null;
+
+  return <Text style={styles.label}>{label}</Text>;
+};
+
+const styles = StyleSheet.create({
+  label: {
+    fontSize: 11,
+    color: "rgba(255, 255, 255, 0.6)",
+    marginTop: 2,
+    marginRight: 4,
+    textAlign: "right",
+  },
+});

--- a/src/context/MessageSwipeContext.tsx
+++ b/src/context/MessageSwipeContext.tsx
@@ -5,7 +5,7 @@
  * right edge. The chat screen owns the SharedValue and the gesture.
  */
 
-import React, { createContext, useContext } from "react";
+import React, { createContext, useContext, useMemo } from "react";
 import { SharedValue } from "react-native-reanimated";
 
 interface MessageSwipeContextValue {
@@ -25,8 +25,10 @@ export const MessageSwipeProvider: React.FC<ProviderProps> = ({
   translateX,
   children,
 }) => {
+  // Stable identity so consumers don't re-render on every parent render.
+  const value = useMemo(() => ({ translateX }), [translateX]);
   return (
-    <MessageSwipeContext.Provider value={{ translateX }}>
+    <MessageSwipeContext.Provider value={value}>
       {children}
     </MessageSwipeContext.Provider>
   );

--- a/src/context/MessageSwipeContext.tsx
+++ b/src/context/MessageSwipeContext.tsx
@@ -1,0 +1,37 @@
+/**
+ * MessageSwipeContext — exposes a single shared horizontal translation value
+ * driven by a pan gesture on the chat list. All MessageBubble rows subscribe
+ * to it so they translate left in sync, revealing each row's timestamp on the
+ * right edge. The chat screen owns the SharedValue and the gesture.
+ */
+
+import React, { createContext, useContext } from "react";
+import { SharedValue } from "react-native-reanimated";
+
+interface MessageSwipeContextValue {
+  translateX: SharedValue<number>;
+}
+
+const MessageSwipeContext = createContext<MessageSwipeContextValue | null>(
+  null,
+);
+
+interface ProviderProps {
+  translateX: SharedValue<number>;
+  children: React.ReactNode;
+}
+
+export const MessageSwipeProvider: React.FC<ProviderProps> = ({
+  translateX,
+  children,
+}) => {
+  return (
+    <MessageSwipeContext.Provider value={{ translateX }}>
+      {children}
+    </MessageSwipeContext.Provider>
+  );
+};
+
+export function useMessageSwipe(): MessageSwipeContextValue | null {
+  return useContext(MessageSwipeContext);
+}

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -43,6 +43,9 @@ import { contactsAPI } from "../../services/contacts/api";
 import { TokenService } from "../../services/TokenService";
 import { useWebSocket } from "../../hooks/useWebSocket";
 import { MessageBubble } from "../../components/Chat/MessageBubble";
+import { MessageSwipeProvider } from "../../context/MessageSwipeContext";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import { useSharedValue, withSpring } from "react-native-reanimated";
 import { MessageInput } from "../../components/Chat/MessageInput";
 import { TypingIndicator } from "../../components/Chat/TypingIndicator";
 import { Avatar } from "../../components/Chat/Avatar";
@@ -251,6 +254,34 @@ export const ChatScreen: React.FC = () => {
   const handleSendMediaRef = useRef<typeof handleSendMedia>(null!);
   const conversationChannelRef = useRef<any>(null);
   const flatListRef = useRef<FlatList>(null);
+  // Horizontal swipe to reveal per-message timestamps. The shared value is
+  // consumed by every MessageBubble through MessageSwipeProvider, so all rows
+  // translate together without re-rendering.
+  const swipeTranslateX = useSharedValue(0);
+  const swipeGesture = useMemo(
+    () =>
+      Gesture.Pan()
+        .activeOffsetX(-10)
+        .failOffsetY([-10, 10])
+        .onUpdate((e) => {
+          // Only allow leftward swipes (negative translation), capped at -40.
+          const next = Math.max(-40, Math.min(0, e.translationX));
+          swipeTranslateX.value = next;
+        })
+        .onEnd(() => {
+          swipeTranslateX.value = withSpring(0, {
+            damping: 18,
+            stiffness: 180,
+          });
+        })
+        .onFinalize(() => {
+          swipeTranslateX.value = withSpring(0, {
+            damping: 18,
+            stiffness: 180,
+          });
+        }),
+    [swipeTranslateX],
+  );
   const initialScrollDoneRef = useRef(false);
   const isNearBottomRef = useRef(true);
   const typingTimeoutsRef = useRef<Record<string, NodeJS.Timeout>>({});
@@ -1674,6 +1705,19 @@ export const ChatScreen: React.FC = () => {
     return result;
   }, [messages]);
 
+  // Id of the most recent message I sent — used to render a textual delivery
+  // status only under that bubble. messages[] is sorted newest-first, so the
+  // first entry whose sender_id matches mine is the latest one.
+  const lastSentByMeId = useMemo(() => {
+    if (!userId) return null;
+    for (const m of messages) {
+      if (m.sender_id === userId && m.message_type !== "system") {
+        return m.id;
+      }
+    }
+    return null;
+  }, [messages, userId]);
+
   // Initial scroll to the newest message once the list has rendered content.
   // Using `scrollToIndex({ index: 0 })` (rather than `scrollToOffset`) is
   // important on react-native-web: the inverted list is implemented via a
@@ -2133,6 +2177,7 @@ export const ChatScreen: React.FC = () => {
       }
 
       const isSent = message.sender_id === userId;
+      const isLastSentByMe = isSent && message.id === lastSentByMeId;
       const isHighlighted = Boolean(
         searchQuery.trim() && searchResults.some((r) => r.id === message.id),
       );
@@ -2164,6 +2209,22 @@ export const ChatScreen: React.FC = () => {
         }
       }
 
+      // iMessage convention: only the last bubble in a same-sender burst
+      // carries a tail. The message that comes chronologically AFTER this
+      // one (visually BELOW it in the inverted list, so index - 1) is the
+      // one we compare against. If it's from the same sender, we are not
+      // the last in the burst and the tail is suppressed.
+      let isLastInBurst = true;
+      const next = messagesWithSeparators[index - 1];
+      if (
+        next &&
+        !isDateSeparator(next) &&
+        next.sender_id === message.sender_id &&
+        next.message_type !== "system"
+      ) {
+        isLastInBurst = false;
+      }
+
       return (
         <MessageBubble
           message={message}
@@ -2173,6 +2234,7 @@ export const ChatScreen: React.FC = () => {
           senderAvatarUrl={senderAvatarUrl}
           showSenderAvatar={!isSent && isGroup}
           isConsecutive={isConsecutive}
+          isLastInBurst={isLastInBurst}
           onReactionPress={handleReactionPress}
           onReactionDetailsPress={handleReactionDetailsPress}
           resolveReactorName={resolveReactorDisplayName}
@@ -2181,6 +2243,10 @@ export const ChatScreen: React.FC = () => {
           isHighlighted={isHighlighted}
           searchQuery={searchQuery}
           pendingAppeal={pendingAppeals[message.id]}
+          isLastSentByMe={isLastSentByMe}
+          isGroupConversation={isGroup}
+          otherMembersCount={Math.max(0, conversationMembers.length - 1)}
+          resolveMemberName={resolveReactorDisplayName}
           onContest={(m) => {
             // metadata is already Record<string, any>; no cast needed
             const meta = m.metadata || {};
@@ -2208,6 +2274,7 @@ export const ChatScreen: React.FC = () => {
       searchResults,
       pendingAppeals,
       messagesWithSeparators,
+      lastSentByMeId,
     ],
   );
 
@@ -2374,13 +2441,20 @@ export const ChatScreen: React.FC = () => {
           // Sur web, on emballe la FlatList dans un viewport à overflow borné :
           // ainsi Chrome garde le wheel sur la ScrollView interne (scrollable)
           // sans qu'un overflow:hidden sur un ancêtre bloque l'event en amont.
+          const wrappedList =
+            Platform.OS === "web" ? (
+              <View style={styles.webListViewport}>{messageList}</View>
+            ) : (
+              <GestureDetector gesture={swipeGesture}>
+                <View style={{ flex: 1 }}>{messageList}</View>
+              </GestureDetector>
+            );
           const chatBody = (
             <>
-              {Platform.OS === "web" ? (
-                <View style={styles.webListViewport}>{messageList}</View>
-              ) : (
-                messageList
-              )}
+              <MessageSwipeProvider translateX={swipeTranslateX}>
+                {wrappedList}
+              </MessageSwipeProvider>
+
               {typingUsers.length > 0 && (
                 <View style={styles.typingContainer}>
                   <TypingIndicator

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -46,6 +46,9 @@ import { MessageBubble } from "../../components/Chat/MessageBubble";
 import { MessageSwipeProvider } from "../../context/MessageSwipeContext";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import { useSharedValue, withSpring } from "react-native-reanimated";
+
+const MESSAGE_SWIPE_DISTANCE = 40;
+const MESSAGE_SWIPE_SPRING = { damping: 18, stiffness: 180 };
 import { MessageInput } from "../../components/Chat/MessageInput";
 import { TypingIndicator } from "../../components/Chat/TypingIndicator";
 import { Avatar } from "../../components/Chat/Avatar";
@@ -264,21 +267,17 @@ export const ChatScreen: React.FC = () => {
         .activeOffsetX(-10)
         .failOffsetY([-10, 10])
         .onUpdate((e) => {
-          // Only allow leftward swipes (negative translation), capped at -40.
-          const next = Math.max(-40, Math.min(0, e.translationX));
+          // Only allow leftward swipes, capped at MESSAGE_SWIPE_DISTANCE.
+          const next = Math.max(
+            -MESSAGE_SWIPE_DISTANCE,
+            Math.min(0, e.translationX),
+          );
           swipeTranslateX.value = next;
         })
-        .onEnd(() => {
-          swipeTranslateX.value = withSpring(0, {
-            damping: 18,
-            stiffness: 180,
-          });
-        })
+        // onFinalize fires for both completed and cancelled gestures, so a
+        // separate onEnd is redundant.
         .onFinalize(() => {
-          swipeTranslateX.value = withSpring(0, {
-            damping: 18,
-            stiffness: 180,
-          });
+          swipeTranslateX.value = withSpring(0, MESSAGE_SWIPE_SPRING);
         }),
     [swipeTranslateX],
   );

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,6 +10,19 @@ export { isReachableUrl } from "./urlFilters";
  * Strips any existing leading "@" before prepending one,
  * preventing the "@@username" bug.
  */
+/**
+ * Format a Date / ISO date / timestamp as "HH:MM" using French 24-hour
+ * formatting. Used wherever a time-of-day string appears in the UI
+ * (timestamps, read receipts, scheduled-message previews).
+ */
+export const formatHourMinute = (date: Date | string | number): string => {
+  const d = date instanceof Date ? date : new Date(date);
+  return d.toLocaleTimeString("fr-FR", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+};
+
 export const formatUsername = (username: string | undefined | null): string => {
   if (!username) return "";
   const clean = username.replace(/^@+/, "");


### PR DESCRIPTION
## Summary
- Redesign message bubbles with an iMessage-style tail and a glass surface
- Add `BubbleSilhouette`, `MaskedBubbleSurface` and `MessageStatusLabel` components
- Introduce `MessageSwipeContext` to coordinate swipe gestures across bubbles
- Tighten bubble rendering performance and reuse logic in `MessageBubble`/`ChatScreen`

## Test plan
- [ ] Unit tests green
- [ ] Lint clean
- [ ] Tested on iOS simulator
- [ ] Tested on Android emulator

Closes WHISPR-1259