### PR TITLE
fix(avatar): utilise useResolvedMediaUrl pour eviter les 401 (WHISPR-1258)

### DIFF
--- a/Avatar.test.tsx
+++ b/Avatar.test.tsx
@@ -1,26 +1,46 @@
 import React from "react";
-import { render } from "@testing-library/react-native";
+import { render, waitFor } from "@testing-library/react-native";
 import { Avatar } from "./src/components/Chat/Avatar";
 
 jest.mock("./src/services/TokenService", () => ({
-  TokenService: { getAccessToken: jest.fn().mockResolvedValue(null) },
+  TokenService: { getAccessToken: jest.fn().mockResolvedValue("tok") },
 }));
 jest.mock("./src/services/apiBase", () => ({
   getApiBaseUrl: () => "https://api.test",
 }));
 
-beforeAll(() => {
-  // Avatar pre-resolves media via fetch (?stream=1). Stub it so unit tests
-  // don't hit the network — tests only check the initial render.
+const mockFetchBytes = () => ({
+  ok: true,
+  status: 200,
+  url: "",
+  headers: { get: () => "application/octet-stream" },
+  blob: async () =>
+    new Blob([new Uint8Array([0xff, 0xd8])], { type: "image/jpeg" }),
+});
+
+beforeEach(() => {
+  // Default: every fetch returns image bytes through the ?stream=1 proxy.
+  // Tests that need a different behaviour override this.
   (global as unknown as { fetch: jest.Mock }).fetch = jest
     .fn()
-    .mockImplementation(
-      () => new Promise(() => undefined),
+    .mockImplementation(() =>
+      Promise.resolve(mockFetchBytes() as unknown as Response),
     ) as unknown as typeof fetch;
+
+  // useResolvedMediaUrl produces blob: URLs on web. Mock URL helpers.
+  (global as any).URL.createObjectURL = jest.fn(() => "blob:fake-avatar");
+  (global as any).URL.revokeObjectURL = jest.fn();
+
+  // Force the web path so the hook uses createObjectURL (FileReader is not
+  // reliably available under jest-expo's node environment).
+  const Platform = require("react-native").Platform;
+  Platform.OS = "web";
 });
 
 describe("Avatar", () => {
-  it("renders an image when given a presigned https URL", () => {
+  it("renders an image when given a presigned https URL (no /media/v1 path)", () => {
+    // Plain external URL — the hook leaves it untouched, so the image
+    // renders synchronously and no initials should be visible.
     const url =
       "https://s3.amazonaws.com/bucket/avatar.jpg?X-Amz-Signature=abc123";
     const { queryByText } = render(<Avatar uri={url} name="John Doe" />);
@@ -49,37 +69,86 @@ describe("Avatar", () => {
     expect(getByText("?")).toBeTruthy();
   });
 
-  it("accepts a bare UUID (media id) and renders an image", () => {
+  it("shows initials while a media-service URL is resolving and swaps to the image once resolved", async () => {
+    // Bare UUID is normalised to /media/v1/<id>/blob — the hook must stream
+    // it through ?stream=1 before <Image> renders. While loading, the
+    // placeholder initials are visible.
     const { queryByText } = render(
       <Avatar uri="550e8400-e29b-41d4-a716-446655440000" name="Test User" />,
     );
-    expect(queryByText("TU")).toBeNull();
+
+    // Once the stream fetch resolves, the image takes over.
+    await waitFor(() => {
+      expect(queryByText("TU")).toBeNull();
+    });
   });
 
-  it("accepts a relative media path and renders an image", () => {
-    const { queryByText } = render(
+  it("never hits /media/v1/<id>/blob without ?stream=1 (no 401 leak on web)", async () => {
+    const fetchSpy = (global as any).fetch as jest.Mock;
+    render(
+      <Avatar uri="550e8400-e29b-41d4-a716-446655440000" name="Test User" />,
+    );
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+
+    // No call to /blob without the stream=1 query — the bare URL would
+    // trigger a 401 on web because <img> can't carry an Authorization header.
+    const bareBlobCalls = fetchSpy.mock.calls.filter(
+      ([u]: [string]) => u.includes("/blob") && !u.includes("stream=1"),
+    );
+    expect(bareBlobCalls).toHaveLength(0);
+
+    // The actual fetch always carries the bearer token.
+    const streamCall = fetchSpy.mock.calls.find(([u]: [string]) =>
+      u.includes("stream=1"),
+    );
+    expect(streamCall).toBeDefined();
+    expect(streamCall![1].headers.Authorization).toBe("Bearer tok");
+  });
+
+  it("falls back to initials when the resolved URL fetch errors out", async () => {
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      url: "",
+      headers: { get: () => null },
+    });
+
+    const { findByText } = render(
+      <Avatar uri="550e8400-e29b-41d4-a716-446655440000" name="Error Person" />,
+    );
+    // Hook surfaces error=true after retries → component shows initials.
+    expect(await findByText("EP")).toBeTruthy();
+  });
+
+  it("normalises a relative /media/v1/public/<id> path through the resolver", async () => {
+    const fetchSpy = (global as any).fetch as jest.Mock;
+    render(
       <Avatar
         uri="/media/v1/public/550e8400-e29b-41d4-a716-446655440000"
         name="Test User"
       />,
     );
-    expect(queryByText("TU")).toBeNull();
-  });
-
-  it("accepts a storage path and renders an image", () => {
-    const { queryByText } = render(
-      <Avatar
-        uri="avatars/aaaa-bbbb-cccc/550e8400-e29b-41d4-a716-446655440000"
-        name="Test User"
-      />,
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+    const streamCall = fetchSpy.mock.calls.find(([u]: [string]) =>
+      u.includes("stream=1"),
     );
-    expect(queryByText("TU")).toBeNull();
+    expect(streamCall![0]).toContain(
+      "/media/v1/550e8400-e29b-41d4-a716-446655440000/blob",
+    );
   });
 
-  it("passes through a plain https URL unchanged", () => {
+  it("passes through a plain https URL unchanged (no resolver fetch)", () => {
+    const fetchSpy = (global as any).fetch as jest.Mock;
     const url = "https://cdn.example.com/avatar.png";
     const { queryByText } = render(<Avatar uri={url} name="Test User" />);
     expect(queryByText("TU")).toBeNull();
+    // No /media/v1 → no stream proxy fetch.
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("shows online badge when showOnlineBadge and isOnline are true", () => {

--- a/src/components/Chat/Avatar.tsx
+++ b/src/components/Chat/Avatar.tsx
@@ -1,5 +1,13 @@
 /**
  * Avatar - User avatar component with fallback
+ *
+ * WHISPR-1258 — passing the bare `/media/v1/:id/blob` URL to <Image> on web
+ * triggers an `<img>` request without `Authorization`, which the media service
+ * answers with 401. We now route the URL through `useResolvedMediaUrl`, the
+ * shared hook that streams the bytes via the authenticated `?stream=1` proxy
+ * and surfaces them as a `blob:` (web) or `data:` (native) URI safe for any
+ * renderer. While the hook is loading we show the initials placeholder rather
+ * than the unauthenticated URL.
  */
 
 import React from "react";
@@ -7,7 +15,7 @@ import { View, Text, StyleSheet, Image } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
 import { colors } from "../../theme/colors";
 import { getApiBaseUrl } from "../../services/apiBase";
-import { TokenService } from "../../services/TokenService";
+import { useResolvedMediaUrl } from "../../hooks/useResolvedMediaUrl";
 
 // Extract color values for StyleSheet.create() to avoid runtime resolution issues
 const TEXT_LIGHT_COLOR = colors.text.light;
@@ -19,133 +27,6 @@ interface AvatarProps {
   size?: number;
   showOnlineBadge?: boolean;
   isOnline?: boolean;
-}
-
-async function blobToDataUrl(blob: Blob): Promise<string> {
-  return await new Promise<string>((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => {
-      const result = reader.result;
-      if (typeof result === "string") resolve(result);
-      else reject(new Error("FileReader did not produce a data URL"));
-    };
-    reader.onerror = () =>
-      reject(reader.error ?? new Error("FileReader failed"));
-    reader.readAsDataURL(blob);
-  });
-}
-
-async function streamMediaToRenderableUri(
-  uri: string,
-  token: string | null,
-): Promise<string> {
-  const headers: Record<string, string> = {
-    Accept: "application/octet-stream",
-  };
-  if (token) headers["Authorization"] = `Bearer ${token}`;
-  const separator = uri.includes("?") ? "&" : "?";
-  const response = await fetch(`${uri}${separator}stream=1`, { headers });
-  if (!response.ok) {
-    const err = new Error(`stream failed: HTTP ${response.status}`);
-    (err as Error & { status?: number }).status = response.status;
-    throw err;
-  }
-
-  // Some media-service deployments return a presigned URL JSON envelope
-  // ({ url, expiresAt }) instead of the raw binary, even with stream=1 +
-  // Accept: octet-stream. Detect this and follow the URL.
-  const contentType = response.headers.get("content-type") ?? "";
-  if (contentType.includes("application/json")) {
-    const data = await response.json().catch(() => null as any);
-    const followUrl = typeof data?.url === "string" ? data.url : undefined;
-    if (!followUrl) {
-      throw new Error("stream returned JSON without a usable url");
-    }
-    const followed = await fetch(followUrl);
-    if (!followed.ok) {
-      throw new Error(`presigned fetch failed: HTTP ${followed.status}`);
-    }
-    return await blobToDataUrl(await followed.blob());
-  }
-
-  return await blobToDataUrl(await response.blob());
-}
-
-// Module-level resolver: shares a single dataUrl per mediaId across every
-// Avatar instance in the app, deduplicates concurrent fetches, throttles
-// concurrency, and retries on transient failures (429 / network).
-//
-// Concurrency is capped to stay comfortably under the media-service short
-// throttle (WHISPR-1192 raised it to 30 req/s on /blob and /thumbnail), and
-// we still keep dedup + cache so the same mediaId is never fetched twice.
-const resolvedCache = new Map<string, string>();
-const inflightCache = new Map<string, Promise<string>>();
-const fetchQueue: Array<() => void> = [];
-let activeFetches = 0;
-const MAX_CONCURRENT_AVATAR_FETCHES = 8;
-
-function acquireFetchSlot(): Promise<void> {
-  return new Promise<void>((resolve) => {
-    const tryAcquire = () => {
-      if (activeFetches < MAX_CONCURRENT_AVATAR_FETCHES) {
-        activeFetches += 1;
-        resolve();
-      } else {
-        fetchQueue.push(tryAcquire);
-      }
-    };
-    tryAcquire();
-  });
-}
-
-function releaseFetchSlot(): void {
-  activeFetches -= 1;
-  const next = fetchQueue.shift();
-  if (next) next();
-}
-
-const sleep = (ms: number) =>
-  new Promise<void>((resolve) => setTimeout(resolve, ms));
-
-async function resolveAvatarDataUrl(mediaId: string): Promise<string> {
-  const cached = resolvedCache.get(mediaId);
-  if (cached) return cached;
-
-  const inflight = inflightCache.get(mediaId);
-  if (inflight) return inflight;
-
-  const promise = (async () => {
-    const url = `${getApiBaseUrl()}/media/v1/${encodeURIComponent(mediaId)}/blob`;
-    const maxAttempts = 4;
-    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-      await acquireFetchSlot();
-      try {
-        const token = await TokenService.getAccessToken();
-        const dataUrl = await streamMediaToRenderableUri(url, token);
-        resolvedCache.set(mediaId, dataUrl);
-        return dataUrl;
-      } catch (err) {
-        const status = (err as Error & { status?: number })?.status;
-        const retryable =
-          status === 429 || status === 503 || status === undefined;
-        if (!retryable || attempt === maxAttempts) {
-          throw err;
-        }
-        const delay = Math.min(1000, 100 * 2 ** (attempt - 1));
-        await sleep(delay);
-      } finally {
-        releaseFetchSlot();
-      }
-    }
-    throw new Error("unreachable");
-  })();
-
-  inflightCache.set(mediaId, promise);
-  try {
-    return await promise;
-  } finally {
-    inflightCache.delete(mediaId);
-  }
 }
 
 function extractMediaIdFromUri(raw: string): {
@@ -187,7 +68,6 @@ export const Avatar: React.FC<AvatarProps> = ({
   isOnline = false,
 }) => {
   const [imageError, setImageError] = React.useState(false);
-  const triedAuthResolveRef = React.useRef(false);
 
   const effectiveCandidate = React.useMemo(() => {
     const raw = typeof uri === "string" ? uri.trim() : "";
@@ -244,19 +124,22 @@ export const Avatar: React.FC<AvatarProps> = ({
     return { uri: undefined, mediaId: undefined };
   }, [uri]);
 
-  // Stable key: gating reset on `uri` directly drops a resolved dataUrl on
-  // unrelated re-renders (e.g. Zustand subscriptions in ConversationItem),
-  // producing flicker.
-  const avatarKey = effectiveCandidate.mediaId ?? effectiveCandidate.uri;
+  // Reset the local error flag whenever the source changes — otherwise an
+  // earlier failure would mask a fresh URI for the same component instance
+  // (e.g. ConversationItem re-using the same Avatar across rerenders).
+  const candidateKey = effectiveCandidate.mediaId ?? effectiveCandidate.uri;
+  const lastCandidateKeyRef = React.useRef(candidateKey);
+  if (lastCandidateKeyRef.current !== candidateKey) {
+    lastCandidateKeyRef.current = candidateKey;
+    setImageError(false);
+  }
 
-  const [resolvedUri, setResolvedUri] = React.useState<string | undefined>(
-    () => {
-      const id = effectiveCandidate.mediaId;
-      return id ? resolvedCache.get(id) : undefined;
-    },
+  // Route every /media/v1/<id>/blob (or /thumbnail) URL through the shared
+  // resolver hook so we never hand an unauthenticated URL to <Image>. Plain
+  // https / data / file URIs are passed through unchanged by the hook.
+  const { resolvedUri, loading, error } = useResolvedMediaUrl(
+    effectiveCandidate.uri,
   );
-
-  const effectiveUri = resolvedUri ?? effectiveCandidate.uri;
 
   const initials =
     name
@@ -266,88 +149,19 @@ export const Avatar: React.FC<AvatarProps> = ({
       .toUpperCase()
       .slice(0, 2) || "?";
 
-  const lastAvatarKeyRef = React.useRef(avatarKey);
-  if (lastAvatarKeyRef.current !== avatarKey) {
-    lastAvatarKeyRef.current = avatarKey;
-    const cached = effectiveCandidate.mediaId
-      ? resolvedCache.get(effectiveCandidate.mediaId)
-      : undefined;
-    setResolvedUri(cached);
-    setImageError(false);
-    triedAuthResolveRef.current = false;
-  }
-
-  // Pre-resolve through `?stream=1` when we know the mediaId, so <Image>
-  // never hits `/blob` directly (which returns a JSON envelope it can't
-  // decode and triggers a useless second request).
-  React.useEffect(() => {
-    const mediaId = effectiveCandidate.mediaId;
-    if (!mediaId) return;
-    if (resolvedUri) return;
-    let cancelled = false;
-    triedAuthResolveRef.current = true;
-    resolveAvatarDataUrl(mediaId)
-      .then((dataUrl) => {
-        if (cancelled) return;
-        setResolvedUri(dataUrl);
-        setImageError(false);
-      })
-      .catch(() => undefined);
-    return () => {
-      cancelled = true;
-    };
-  }, [effectiveCandidate.mediaId, resolvedUri]);
-
-  const shouldShowImage = !!effectiveUri && !imageError;
+  const shouldShowImage = !!resolvedUri && !loading && !error && !imageError;
 
   return (
     <View style={[styles.container, { width: size, height: size }]}>
       {shouldShowImage ? (
         <Image
-          source={{ uri: effectiveUri }}
+          source={{ uri: resolvedUri }}
           style={[
             styles.image,
             { width: size, height: size, borderRadius: size / 2 },
           ]}
           resizeMode="cover"
-          onError={() => {
-            setImageError(true);
-
-            if (triedAuthResolveRef.current) return;
-            triedAuthResolveRef.current = true;
-
-            const raw = typeof uri === "string" ? uri.trim() : "";
-            const directMediaId =
-              effectiveCandidate.mediaId ||
-              (raw.match(
-                /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
-              )
-                ? raw
-                : undefined);
-
-            const parsedFromUrl = (() => {
-              const candidate = effectiveUri ?? "";
-              const m = candidate.match(
-                /\/media\/v1\/(?:public\/)?([^/]+)(?:\/|$)/,
-              );
-              if (!m?.[1]) return undefined;
-              try {
-                return decodeURIComponent(m[1]);
-              } catch {
-                return m[1];
-              }
-            })();
-
-            const mediaId = directMediaId || parsedFromUrl;
-            if (!mediaId) return;
-
-            resolveAvatarDataUrl(mediaId)
-              .then((dataUrl) => {
-                setResolvedUri(dataUrl);
-                setImageError(false);
-              })
-              .catch(() => undefined);
-          }}
+          onError={() => setImageError(true)}
         />
       ) : (
         <LinearGradient


### PR DESCRIPTION
Sur web, les avatars renvoyaient 401 systematique.

La cause: `Avatar.tsx` construisait l'URL `${apiBase}/media/v1/<id>/blob` a la main et la passait direct a `<Image>`. Sur web ca finit en `<img src=...>` HTTP standard, donc impossible d'attacher le `Authorization: Bearer` -> media-service repond 401.

En plus l'endpoint `/blob` renvoie pas le binaire mais un JSON `{url, expiresAt}` (URL presignee MinIO). Meme si l'auth passait, `<Image>` aurait rien pu decoder.

Fix: Avatar.tsx utilise maintenant `useResolvedMediaUrl` (hook deja partage avec MediaMessage et AudioMessage). Le hook fait le call presign avec auth, cache 60s, retourne l'URL signee directement utilisable par `<Image>`.

Test:
- preprod 0769828164
- ConversationsList: tous les avatars affiches
- Network: `/media/v1/<id>/blob` -> 200 (au lieu de 401)