### PR TITLE
test(chat): assert archived list preserves last_message and unread_count

### DIFF
--- a/conversationsStore.test.ts
+++ b/conversationsStore.test.ts
@@ -18,18 +18,16 @@ jest.mock("./src/services/messaging/api", () => ({
     deleteConversation: jest.fn().mockResolvedValue(undefined),
     archiveConversation: jest.fn().mockResolvedValue(undefined),
     unarchiveConversation: jest.fn().mockResolvedValue(undefined),
-    getArchivedConversations: jest
-      .fn()
-      .mockResolvedValue({
-        data: [],
-        meta: {
-          count: 0,
-          limit: 50,
-          offset: 0,
-          has_more: false,
-          user_id: "",
-        },
-      }),
+    getArchivedConversations: jest.fn().mockResolvedValue({
+      data: [],
+      meta: {
+        count: 0,
+        limit: 50,
+        offset: 0,
+        has_more: false,
+        user_id: "",
+      },
+    }),
   },
 }));
 
@@ -862,6 +860,42 @@ describe("conversationsStore — fetchArchivedConversations / loadMoreArchivedCo
     expect(archived.hasMore).toBe(false);
     expect(archived.offset).toBe(2);
     expect(archived.items.every((c) => c.is_archived === true)).toBe(true);
+  });
+
+  it("preserves last_message and unread_count returned by the backend (WHISPR-1263)", async () => {
+    const lastMessage = {
+      id: "m-1",
+      conversation_id: "c-a",
+      sender_id: "other",
+      content: "hello from archived",
+      sent_at: "2026-04-25T10:00:00Z",
+    } as unknown as Record<string, unknown>;
+
+    mockedMessagingAPI.getArchivedConversations.mockResolvedValueOnce({
+      data: [
+        makeConv("c-a", { last_message: lastMessage, unread_count: 3 }),
+        makeConv("c-b", { last_message: null, unread_count: 0 }),
+      ],
+      meta: {
+        count: 2,
+        limit: 50,
+        offset: 0,
+        has_more: false,
+        user_id: "u-1",
+      },
+    });
+
+    await act(async () => {
+      await useConversationsStore.getState().fetchArchivedConversations();
+    });
+
+    const { archived } = useConversationsStore.getState();
+    const first = archived.items.find((c) => c.id === "c-a");
+    const second = archived.items.find((c) => c.id === "c-b");
+    expect(first?.last_message).toEqual(lastMessage);
+    expect(first?.unread_count).toBe(3);
+    expect(second?.last_message).toBeNull();
+    expect(second?.unread_count).toBe(0);
   });
 
   it("sets status=error when the API call rejects", async () => {


### PR DESCRIPTION
## Summary

WHISPR-1263 wires the archived conversations screen on the enriched
`last_message` / `unread_count` fields shipped by WHISPR-1262 on
`GET /conversations/archived`. Verification on the mobile side:

- The API client (`messagingAPI.getArchivedConversations`) already runs
  the response through `snakecaseKeys`, so `lastMessage` /
  `unreadCount` arrive as `last_message` / `unread_count` without code
  changes.
- The store (`fetchArchivedConversations` /
  `loadMoreArchivedConversations`) only spreads each item with
  `{ ...c, is_archived: true }` and never overwrites `last_message` or
  `unread_count`. `enrichWithDisplayNames` only touches display fields.
- `ConversationItem` already reads `conversation.last_message` and
  `conversation.unread_count` directly, so the badge and the message
  preview render as soon as the store carries those fields.
- The header `archivedUnreadCount` selector merges
  `s.conversations` (archived flagged via WS broadcast) with
  `s.archived.items` (already-loaded list). Keeping the merged source
  ensures the badge stays correct on cold start before the archived
  screen has been opened, where `archived.items` is still empty —
  simplifying it to `archived.items` only would regress the cold-start
  badge count.
- No temporary "option A" enrichment workaround was added during
  WHISPR-1260, so nothing to remove.

To pin the contract, this PR adds a regression test on
`fetchArchivedConversations` asserting that `last_message` and
`unread_count` returned by the backend survive the display-name
enrichment pass and land untouched in `archived.items`.

## Test plan

- [x] Unit tests green (`npm test -- --watchAll=false --testPathPattern="conversationsStore"`)
- [x] Lint clean (`npm run lint:fix` — 0 errors)
- [ ] Tested on iOS simulator (cold start → open archived screen → unread badge + last message preview visible)
- [ ] Tested on Android emulator (same scenario)
- [ ] Multi-device sanity: archive on device A → device B header badge updates without manual refresh

Closes WHISPR-1263