### PR TITLE
fix(tests): repare CI casse par les hotfix MessageInput recents

### DIFF
--- a/ConversationsListScreen.test.tsx
+++ b/ConversationsListScreen.test.tsx
@@ -7,6 +7,7 @@ const mockNavigate = jest.fn();
 jest.mock("@react-navigation/native", () => ({
   useNavigation: () => ({ navigate: mockNavigate, goBack: jest.fn() }),
   useRoute: () => ({ params: {} }),
+  useFocusEffect: jest.fn(),
 }));
 jest.mock("expo-linear-gradient", () => ({
   LinearGradient: ({ children }: any) => children,

--- a/MessageInput.test.tsx
+++ b/MessageInput.test.tsx
@@ -158,6 +158,23 @@ import {
   buildRecordingOptions,
   MessageInput,
 } from "./src/components/Chat/MessageInput";
+import {
+  MIN_INPUT_HEIGHT,
+  MAX_INPUT_HEIGHT,
+  INPUT_LINE_HEIGHT,
+  INPUT_VERTICAL_PADDING,
+} from "./src/components/Chat/MessageInput/ComposerInput";
+
+// Helper: calcule la hauteur attendue pour un nombre de lignes mesurees,
+// en fonction des constantes du ComposerInput (clamp entre MIN et MAX).
+const expectedShellHeight = (lineCount: number) =>
+  Math.max(
+    MIN_INPUT_HEIGHT,
+    Math.min(
+      MAX_INPUT_HEIGHT,
+      lineCount * INPUT_LINE_HEIGHT + INPUT_VERTICAL_PADDING * 2,
+    ),
+  );
 
 type MediaRecorderLike = { isTypeSupported?: (mime: string) => boolean };
 
@@ -279,7 +296,7 @@ describe("MessageInput auto-resize", () => {
     expect(shell.props.style).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          height: 80,
+          height: expectedShellHeight(3),
         }),
       ]),
     );
@@ -298,13 +315,15 @@ describe("MessageInput auto-resize", () => {
     fireEvent(shell, "layout", {
       nativeEvent: { layout: { width: 240, height: 40, x: 0, y: 0 } },
     });
-    fireEvent.changeText(
-      input,
-      "Une ligne\nDeux lignes\nTrois lignes\nQuatre lignes\nCinq lignes\nSix lignes",
-    );
+    // assez de lignes pour depasser MAX_INPUT_HEIGHT (cap + scroll active)
+    const linesNeeded =
+      Math.ceil(
+        (MAX_INPUT_HEIGHT - INPUT_VERTICAL_PADDING * 2) / INPUT_LINE_HEIGHT,
+      ) + 3;
+    fireEvent.changeText(input, Array(linesNeeded).fill("ligne").join("\n"));
 
     fireEvent(measure, "textLayout", {
-      nativeEvent: { lines: [{}, {}, {}, {}, {}, {}, {}] },
+      nativeEvent: { lines: Array(linesNeeded).fill({}) },
     });
 
     const updatedInput = getByTestId("message-composer-input");
@@ -312,7 +331,7 @@ describe("MessageInput auto-resize", () => {
     expect(shell.props.style).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          height: 120,
+          height: MAX_INPUT_HEIGHT,
         }),
       ]),
     );
@@ -336,10 +355,11 @@ describe("MessageInput auto-resize", () => {
       nativeEvent: { lines: [{}] },
     });
 
+    // "Premiere ligne\n".split("\n") => 2 entries, donc 2 lignes effectives
     expect(shell.props.style).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          height: 60,
+          height: expectedShellHeight(2),
         }),
       ]),
     );
@@ -363,7 +383,7 @@ describe("MessageInput auto-resize", () => {
     expect(shell.props.style).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          height: 60,
+          height: MIN_INPUT_HEIGHT,
         }),
       ]),
     );

--- a/conversationsStore.test.ts
+++ b/conversationsStore.test.ts
@@ -209,7 +209,7 @@ describe("conversationsStore — applyNewMessage unread_count (WHISPR-1050)", ()
     await act(async () => {
       await useConversationsStore
         .getState()
-        .applyNewMessage(msg("c1", "me"), "me");
+        .applyNewMessage(msg("c1", "me", "m-own-echo"), "me");
     });
 
     const conv = useConversationsStore
@@ -224,7 +224,9 @@ describe("conversationsStore — applyNewMessage unread_count (WHISPR-1050)", ()
     seed("c1", 0);
 
     await act(async () => {
-      await useConversationsStore.getState().applyNewMessage(msg("c1", "me"));
+      await useConversationsStore
+        .getState()
+        .applyNewMessage(msg("c1", "me", "m-legacy"));
     });
 
     const conv = useConversationsStore

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -24,6 +24,22 @@ if (typeof globalThis.TextEncoder === "undefined") {
   globalThis.TextDecoder = util.TextDecoder;
 }
 
+// jest-expo n'a pas de window.dispatchEvent par defaut. react-native-web et
+// certains hooks du theme le declenchent au mount, ce qui fait crasher le
+// rendu de plusieurs ecrans (Groups, etc). On stub le minimum requis.
+if (typeof globalThis.window === "undefined") {
+  globalThis.window = globalThis;
+}
+if (typeof globalThis.window.dispatchEvent !== "function") {
+  globalThis.window.dispatchEvent = () => true;
+}
+if (typeof globalThis.window.addEventListener !== "function") {
+  globalThis.window.addEventListener = () => {};
+}
+if (typeof globalThis.window.removeEventListener !== "function") {
+  globalThis.window.removeEventListener = () => {};
+}
+
 // react-native-safe-area-context — provide full API surface
 jest.mock("react-native-safe-area-context", () => {
   const React = require("react");

--- a/src/components/Chat/MessageInput/ComposerInput.tsx
+++ b/src/components/Chat/MessageInput/ComposerInput.tsx
@@ -114,7 +114,7 @@ export const ComposerInput = forwardRef<TextInput, ComposerInputProps>(
             }
           }}
           multiline
-          scrollEnabled
+          scrollEnabled={inputHeight >= MAX_INPUT_HEIGHT}
           placeholder={placeholder}
           placeholderTextColor={themeColors.text.tertiary}
           maxLength={1000}


### PR DESCRIPTION
Le push 5f3dbf4 "Hotfix: Message input resize" + commits suivants ont casse 3 test files sur deploy/preprod (CI red depuis le 4 mai).

Causes :
- MessageInput.test : valeurs MIN/MAX hard-codees alors que les constantes ont change (MIN 60->40 et MAX 120->350)
- ComposerInput.tsx : scrollEnabled etait conditionnel (`inputHeight >= MAX`), passe en true permanent -> mauvaise UX (scroll meme quand le contenu rentre)
- conversationsStore.test : IDs de message hard-codes "m1", le `wasMessageSeen` module-level n'est pas reset donc le 2eme test skippe le message
- ConversationsListScreen.test : mock `useFocusEffect` manquant dans react-navigation/native
- GroupManagementScreen.test : crash sur `window.dispatchEvent is not a function` (jsdom partiel)

Fix :
- tests utilisent les constantes du composant (MIN_INPUT_HEIGHT etc) pour eviter de futures regressions
- restaure scrollEnabled conditionnel
- IDs uniques par test
- mock useFocusEffect
- stub window.dispatchEvent + add/removeEventListener dans jest.setup

855/855 tests verts en local.