### PR TITLE
[WHISPR-1294] feat(settings): expose Moderation Test in preprod via EXPO_PUBLIC_ENV

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -11,6 +11,12 @@
     "preview": {
       "distribution": "internal"
     },
+    "preprod": {
+      "distribution": "internal",
+      "env": {
+        "EXPO_PUBLIC_ENV": "preprod"
+      }
+    },
     "production": {
       "autoIncrement": true
     }

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -317,7 +317,7 @@ export const SettingsScreen: React.FC = () => {
     loadSettings();
     fetchMyRole();
 
-    if (__DEV__) {
+    if (__DEV__ || process.env.EXPO_PUBLIC_ENV === "preprod") {
       getModerationModelVersion()
         .then((v) => setModerationModel(v))
         .catch(() => setModerationModel(DEFAULT_MODERATION_MODEL));
@@ -1154,8 +1154,8 @@ export const SettingsScreen: React.FC = () => {
           )}
         </SettingSection>
 
-        {/* Developer / Debug — stripped from production bundles */}
-        {__DEV__ && (
+        {/* Developer / Debug - visible en dev local + en build preprod (jamais en prod) */}
+        {(__DEV__ || process.env.EXPO_PUBLIC_ENV === "preprod") && (
           <SettingSection title="Debug" icon="bug-outline">
             <SettingItem
               label="Modèle de modération"
@@ -1264,7 +1264,7 @@ export const SettingsScreen: React.FC = () => {
         layout="auto"
       />
 
-      {__DEV__ && (
+      {(__DEV__ || process.env.EXPO_PUBLIC_ENV === "preprod") && (
         <SettingsChoiceAlert
           visible={showModerationModelModal}
           onClose={() => setShowModerationModelModal(false)}


### PR DESCRIPTION
## Summary
- Add a `preprod` profile in eas.json that injects EXPO_PUBLIC_ENV=preprod at build time.
- Extend the SettingsScreen Debug section gate from `__DEV__` to `__DEV__ || process.env.EXPO_PUBLIC_ENV === "preprod"` so the Moderation Test entry, the moderation model picker, and its modal show up on preprod builds.
- Production builds remain unaffected (no preprod env var leaks there).

## Test plan
- [x] Existing SettingsScreen tests still pass (6/6)
- [x] tsc --noEmit clean
- [x] Lint clean (0 errors)
- [ ] Manual: trigger a preprod EAS build and confirm the Debug section is visible
- [ ] Manual: verify production build still hides the Debug section

Closes WHISPR-1294