### PR TITLE
[WHISPR-1298] feat(settings): add privacy toggles for 7 backend fields

### DIFF
--- a/SettingsScreen.test.tsx
+++ b/SettingsScreen.test.tsx
@@ -97,6 +97,19 @@ describe("SettingsScreen", () => {
     });
   });
 
+  it("renders the 7 privacy toggles (4 existing + 3 backend orphans)", async () => {
+    const { getByText } = render(<SettingsScreen />);
+    await waitFor(() => {
+      expect(getByText("Photo de profil")).toBeTruthy();
+    });
+    expect(getByText("Prénom")).toBeTruthy();
+    expect(getByText("Nom de famille")).toBeTruthy();
+    expect(getByText("Biographie")).toBeTruthy();
+    expect(getByText("Dernière connexion")).toBeTruthy();
+    expect(getByText("Statut en ligne")).toBeTruthy();
+    expect(getByText("Permission d'ajout aux groupes")).toBeTruthy();
+  });
+
   it("renders notifications section", async () => {
     const { getByText } = render(<SettingsScreen />);
     await waitFor(() => {

--- a/UserService.test.ts
+++ b/UserService.test.ts
@@ -294,6 +294,22 @@ describe("UserService.getPrivacySettings", () => {
     expect(result.settings?.phoneNumberSearch).toBe("contacts");
   });
 
+  it("reads the lastSeen, onlineStatus and groupAdd fields", async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        body: {
+          lastSeenPrivacy: "contacts",
+          onlineStatus: "nobody",
+          groupAddPermission: "contacts",
+        },
+      }),
+    );
+    const result = await service.getPrivacySettings();
+    expect(result.settings?.lastSeenVisibility).toBe("contacts");
+    expect(result.settings?.onlineStatusVisibility).toBe("nobody");
+    expect(result.settings?.groupAddPermission).toBe("contacts");
+  });
+
   it("returns an error on non-OK", async () => {
     mockFetch.mockResolvedValueOnce(mockResponse({ status: 500 }));
     const result = await service.getPrivacySettings();
@@ -309,6 +325,9 @@ describe("UserService.updatePrivacySettings", () => {
       firstNameVisibility: "everyone",
       lastNameVisibility: "nobody",
       biographyVisibility: "everyone",
+      lastSeenVisibility: "contacts",
+      onlineStatusVisibility: "nobody",
+      groupAddPermission: "contacts",
       searchVisibility: true,
       phoneNumberSearch: "nobody",
     });
@@ -319,6 +338,9 @@ describe("UserService.updatePrivacySettings", () => {
       firstNamePrivacy: "everyone",
       lastNamePrivacy: "nobody",
       biographyPrivacy: "everyone",
+      lastSeenPrivacy: "contacts",
+      onlineStatus: "nobody",
+      groupAddPermission: "contacts",
       searchByPhone: false,
       searchByUsername: true,
     });

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -46,8 +46,11 @@ import {
 const PRIVACY_ALERT_TITLE: Record<string, string> = {
   profilePhoto: "Photo de profil",
   firstName: "Prénom",
-  lastName: "Nom",
+  lastName: "Nom de famille",
   biography: "Biographie",
+  lastSeen: "Dernière connexion",
+  onlineStatus: "Statut en ligne",
+  groupAdd: "Permission d'ajout aux groupes",
 };
 
 const PRIVACY_VALUE_LABELS: Record<string, string> = {
@@ -106,6 +109,9 @@ export const SettingsScreen: React.FC = () => {
     firstName: "Everyone",
     lastName: "Contacts",
     biography: "Everyone",
+    lastSeen: "Everyone",
+    onlineStatus: "Everyone",
+    groupAdd: "Everyone",
   });
 
   // Notification settings
@@ -167,6 +173,18 @@ export const SettingsScreen: React.FC = () => {
         | "everyone"
         | "contacts"
         | "nobody",
+      lastSeenVisibility: local.lastSeen.toLowerCase() as
+        | "everyone"
+        | "contacts"
+        | "nobody",
+      onlineStatusVisibility: local.onlineStatus.toLowerCase() as
+        | "everyone"
+        | "contacts"
+        | "nobody",
+      groupAddPermission: local.groupAdd.toLowerCase() as
+        | "everyone"
+        | "contacts"
+        | "nobody",
       searchVisibility: true,
       phoneNumberSearch: "everyone",
     }),
@@ -184,6 +202,9 @@ export const SettingsScreen: React.FC = () => {
       firstName: capitalize(api.firstNameVisibility),
       lastName: capitalize(api.lastNameVisibility),
       biography: capitalize(api.biographyVisibility),
+      lastSeen: capitalize(api.lastSeenVisibility),
+      onlineStatus: capitalize(api.onlineStatusVisibility),
+      groupAdd: capitalize(api.groupAddPermission),
     };
   }, []);
 
@@ -757,7 +778,7 @@ export const SettingsScreen: React.FC = () => {
             onPress={() => handlePrivacyItemPress("firstName")}
           />
           <SettingItem
-            label="Nom"
+            label="Nom de famille"
             value={translatePrivacyValue(privacySettings.lastName)}
             onPress={() => handlePrivacyItemPress("lastName")}
           />
@@ -765,6 +786,23 @@ export const SettingsScreen: React.FC = () => {
             label="Biographie"
             value={translatePrivacyValue(privacySettings.biography)}
             onPress={() => handlePrivacyItemPress("biography")}
+          />
+          {/* WHISPR-1298 : 3 toggles ajoutés (lastSeen, onlineStatus,
+              groupAdd) pour couvrir les fields backend orphelins. */}
+          <SettingItem
+            label="Dernière connexion"
+            value={translatePrivacyValue(privacySettings.lastSeen)}
+            onPress={() => handlePrivacyItemPress("lastSeen")}
+          />
+          <SettingItem
+            label="Statut en ligne"
+            value={translatePrivacyValue(privacySettings.onlineStatus)}
+            onPress={() => handlePrivacyItemPress("onlineStatus")}
+          />
+          <SettingItem
+            label="Permission d'ajout aux groupes"
+            value={translatePrivacyValue(privacySettings.groupAdd)}
+            onPress={() => handlePrivacyItemPress("groupAdd")}
           />
           {/* WHISPR-1056: entry point to the BlockedUsersScreen — the
               screen was already registered in AuthNavigator but unreachable

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -58,6 +58,9 @@ export interface PrivacySettings {
   firstNameVisibility: "everyone" | "contacts" | "nobody";
   lastNameVisibility: "everyone" | "contacts" | "nobody";
   biographyVisibility: "everyone" | "contacts" | "nobody";
+  lastSeenVisibility: "everyone" | "contacts" | "nobody";
+  onlineStatusVisibility: "everyone" | "contacts" | "nobody";
+  groupAddPermission: "everyone" | "contacts" | "nobody";
   searchVisibility: boolean;
   phoneNumberSearch: "everyone" | "contacts" | "nobody";
 }
@@ -592,6 +595,11 @@ export class UserService {
           raw?.lastNamePrivacy ?? raw?.lastNameVisibility ?? "everyone",
         biographyVisibility:
           raw?.biographyPrivacy ?? raw?.biographyVisibility ?? "everyone",
+        lastSeenVisibility:
+          raw?.lastSeenPrivacy ?? raw?.lastSeenVisibility ?? "everyone",
+        onlineStatusVisibility:
+          raw?.onlineStatus ?? raw?.onlineStatusVisibility ?? "everyone",
+        groupAddPermission: raw?.groupAddPermission ?? "everyone",
         searchVisibility:
           raw?.searchByUsername ?? raw?.searchVisibility ?? true,
         phoneNumberSearch:
@@ -622,6 +630,9 @@ export class UserService {
           firstNamePrivacy: settings.firstNameVisibility,
           lastNamePrivacy: settings.lastNameVisibility,
           biographyPrivacy: settings.biographyVisibility,
+          lastSeenPrivacy: settings.lastSeenVisibility,
+          onlineStatus: settings.onlineStatusVisibility,
+          groupAddPermission: settings.groupAddPermission,
           searchByPhone: settings.phoneNumberSearch !== "nobody",
           searchByUsername: settings.searchVisibility,
         }),


### PR DESCRIPTION
## Summary
- Étend la section Confidentialité de SettingsScreen avec 3 toggles manquants (lastSeen, onlineStatus, groupAdd) en plus des 4 existants (profilePhoto, firstName, lastName, biography), pour couvrir les 7 fields PrivacyLevel exposés par user-service.
- Étend l'interface PrivacySettings et le mapping privacy<->API dans UserService pour lire/écrire lastSeenPrivacy, onlineStatus, groupAddPermission.
- Tests : nouveau case sur getPrivacySettings et updatePrivacySettings, et test de rendu des 7 toggles dans SettingsScreen.

## Test plan
- [x] Unit tests verts (SettingsScreen + UserService)
- [x] Lint clean
- [x] Type-check clean
- [ ] Tested on iOS simulator
- [ ] Tested on Android emulator

Closes WHISPR-1298