### PR TITLE
[WHISPR-1299] fix(chat): handle message_deleted on user channel for group fanout

### DIFF
--- a/conversationsStore.test.ts
+++ b/conversationsStore.test.ts
@@ -1376,3 +1376,84 @@ describe("conversationsStore — applyNewMessage on archived conversations", () 
     expect(state.conversations.find((c) => c.id === "c-new")).toBeUndefined();
   });
 });
+
+describe("conversationsStore — applyMessageDeleted (WHISPR-1299 user channel fanout)", () => {
+  beforeEach(() => {
+    useConversationsStore.getState().reset();
+  });
+
+  function seedWithLastMessage(convId: string, msgId: string) {
+    const conv = {
+      id: convId,
+      type: "group",
+      display_name: "Crew",
+      avatar_url: null,
+      member_user_ids: ["a", "b", "c"],
+      last_message: {
+        id: msgId,
+        conversation_id: convId,
+        sender_id: "a",
+        message_type: "text",
+        content: "salut",
+        is_deleted: false,
+        sent_at: "2026-04-21T10:00:00Z",
+      },
+      unread_count: 0,
+      is_pinned: false,
+      is_muted: false,
+      is_active: true,
+      is_archived: false,
+      updated_at: "2026-04-21T10:00:00Z",
+    } as unknown as Parameters<
+      ReturnType<
+        typeof useConversationsStore.getState
+      >["applyConversationSummaries"]
+    >[0][number];
+    act(() => {
+      useConversationsStore.getState().applyConversationSummaries([conv]);
+    });
+  }
+
+  it("replaces the last_message preview when the deleted id matches", () => {
+    seedWithLastMessage("g1", "m-100");
+
+    act(() => {
+      useConversationsStore.getState().applyMessageDeleted("m-100", true);
+    });
+
+    const conv = useConversationsStore
+      .getState()
+      .conversations.find((c) => c.id === "g1");
+    expect(conv?.last_message?.is_deleted).toBe(true);
+    expect(conv?.last_message?.content).toBe("[Message supprimé]");
+  });
+
+  it("ignores soft-delete (deleteForEveryone=false) so private deletions stay local", () => {
+    seedWithLastMessage("g2", "m-200");
+
+    act(() => {
+      useConversationsStore.getState().applyMessageDeleted("m-200", false);
+    });
+
+    const conv = useConversationsStore
+      .getState()
+      .conversations.find((c) => c.id === "g2");
+    expect(conv?.last_message?.is_deleted).toBe(false);
+    expect(conv?.last_message?.content).toBe("salut");
+  });
+
+  it("leaves unrelated conversations untouched", () => {
+    seedWithLastMessage("g3", "m-300");
+
+    act(() => {
+      useConversationsStore
+        .getState()
+        .applyMessageDeleted("m-other-conv", true);
+    });
+
+    const conv = useConversationsStore
+      .getState()
+      .conversations.find((c) => c.id === "g3");
+    expect(conv?.last_message?.is_deleted).toBe(false);
+  });
+});

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -166,6 +166,20 @@ export const useWebSocket = (options: UseWebSocketOptions) => {
 
         navigate("IncomingCall");
       },
+      // message_deleted sur user channel : messaging-service fanout vers
+      // user:<id> pour les groupes, sinon ConversationsListScreen rate la
+      // suppression "for everyone" tant qu'elle n'est pas abonnée au
+      // canal de la conversation. Le payload backend est { id, conversation_id }.
+      onMsgDeletedUser: (data: {
+        id?: string;
+        message_id?: string;
+        conversation_id?: string;
+      }) => {
+        const messageId = data.id ?? data.message_id;
+        if (messageId) {
+          callbacksRef.current.onMessageDeleted?.(messageId, true);
+        }
+      },
       // call_ended: remote party hung up or server timed out the call.
       // WHISPR-1203 : reset() disconnect la Room LiveKit + clear active +
       // clear incoming. setIncoming(null) seul laissait l'autre côté
@@ -202,6 +216,7 @@ export const useWebSocket = (options: UseWebSocketOptions) => {
     // duplicate subscriptions when the component re-renders during reconnect.
     userChannel.off("new_message", userHandlers.onMsg);
     userChannel.off("message_created", userHandlers.onMsg);
+    userChannel.off("message_deleted", userHandlers.onMsgDeletedUser);
     userChannel.off("delivery_status", userHandlers.onDelivery);
     userChannel.off("conversation_summaries", userHandlers.onConvSummaries);
     userChannel.off("conversation_archived", userHandlers.onConvArchived);
@@ -210,6 +225,7 @@ export const useWebSocket = (options: UseWebSocketOptions) => {
 
     userChannel.on("new_message", userHandlers.onMsg);
     userChannel.on("message_created", userHandlers.onMsg);
+    userChannel.on("message_deleted", userHandlers.onMsgDeletedUser);
     userChannel.on("delivery_status", userHandlers.onDelivery);
     userChannel.on("conversation_summaries", userHandlers.onConvSummaries);
     userChannel.on("conversation_archived", userHandlers.onConvArchived);
@@ -219,6 +235,7 @@ export const useWebSocket = (options: UseWebSocketOptions) => {
     return () => {
       userChannel.off("new_message", userHandlers.onMsg);
       userChannel.off("message_created", userHandlers.onMsg);
+      userChannel.off("message_deleted", userHandlers.onMsgDeletedUser);
       userChannel.off("delivery_status", userHandlers.onDelivery);
       userChannel.off("conversation_summaries", userHandlers.onConvSummaries);
       userChannel.off("conversation_archived", userHandlers.onConvArchived);


### PR DESCRIPTION
## Summary
- Le PR messaging-service #87 fanout `message_deleted` sur le canal `user:<id>` pour les groupes (la liste des conversations rate sinon la suppression "for everyone" tant qu'elle n'est pas abonnée au canal de la conversation).
- Ajoute le handler `onMsgDeletedUser` dans `userHandlers` de `useWebSocket.ts` et l'enregistre/désinscrit en parallèle des autres listeners user channel. Le callback existant `onMessageDeleted` du store gère déjà la mise à jour `last_message`.
- Tests : 3 cas sur `applyMessageDeleted` (preview remplacée, soft-delete ignoré, autres conversations préservées).

## Test plan
- [x] Unit tests verts (conversationsStore)
- [x] Lint clean
- [x] Type-check clean
- [ ] Validé manuellement en supprimant un message dans un groupe en preprod

Closes WHISPR-1299