### PR TITLE
[WHISPR-1300] docs(comments): traduction FR + cleanup paraphrases (mobile-app)

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,13 +1,13 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
-// Global Jest setup: shared mocks for native/expo modules.
+// Setup global Jest : mocks partages pour les modules natifs / expo.
 
-// IndexedDB polyfill so the web-only services that persist a wrapping key
-// (see src/services/webCryptoVault.web.ts) can run under Jest.
+// polyfill IndexedDB pour que les services web qui persistent une wrapping
+// key (cf. src/services/webCryptoVault.web.ts) tournent sous Jest.
 require("fake-indexeddb/auto");
 
-// jsdom < 24 ships a partial crypto without SubtleCrypto. webcrypto from
-// node:crypto is API-compatible with the browser globals webCryptoVault
-// relies on (subtle, getRandomValues), so swap in the full implementation.
+// jsdom < 24 livre un crypto partiel sans SubtleCrypto. webcrypto de
+// node:crypto est compatible API avec les globals navigateur que
+// webCryptoVault attend (subtle, getRandomValues), on swap.
 if (!globalThis.crypto || !globalThis.crypto.subtle) {
   Object.defineProperty(globalThis, "crypto", {
     value: require("crypto").webcrypto,
@@ -16,17 +16,17 @@ if (!globalThis.crypto || !globalThis.crypto.subtle) {
   });
 }
 
-// jsdom on the Node version pinned by jest-expo doesn't expose
-// TextEncoder/TextDecoder on the test global; node:util has the same API.
+// jsdom (sur la version de Node pinned par jest-expo) n'expose pas
+// TextEncoder / TextDecoder en global de test. node:util a la meme API.
 if (typeof globalThis.TextEncoder === "undefined") {
   const util = require("util");
   globalThis.TextEncoder = util.TextEncoder;
   globalThis.TextDecoder = util.TextDecoder;
 }
 
-// jest-expo n'a pas de window.dispatchEvent par defaut. react-native-web et
-// certains hooks du theme le declenchent au mount, ce qui fait crasher le
-// rendu de plusieurs ecrans (Groups, etc). On stub le minimum requis.
+// jest-expo n'expose pas window.dispatchEvent par defaut. react-native-web et
+// certains hooks du theme l'appellent au mount, ce qui crashe le rendu de
+// plusieurs ecrans (Groups, etc). On stub le minimum requis.
 if (typeof globalThis.window === "undefined") {
   globalThis.window = globalThis;
 }
@@ -40,7 +40,7 @@ if (typeof globalThis.window.removeEventListener !== "function") {
   globalThis.window.removeEventListener = () => {};
 }
 
-// react-native-safe-area-context — provide full API surface
+// react-native-safe-area-context : on expose l'API complete
 jest.mock("react-native-safe-area-context", () => {
   const React = require("react");
   const insets = { top: 0, right: 0, bottom: 0, left: 0 };
@@ -59,21 +59,21 @@ jest.mock("react-native-safe-area-context", () => {
   };
 });
 
-// expo-linear-gradient — default pass-through
+// expo-linear-gradient : pass-through par defaut
 jest.mock("expo-linear-gradient", () => ({
   LinearGradient: ({ children }) => children,
 }));
 
-// @expo/vector-icons — render nothing
+// @expo/vector-icons : rien afficher
 jest.mock("@expo/vector-icons", () => {
   const Noop = () => null;
   return new Proxy({ __esModule: true, default: Noop }, { get: () => Noop });
 });
 
-// expo-secure-store — WHISPR-994: src/services/storage.ts now imports this
-// unconditionally (no more dynamic require fallback), so every test that
-// touches storage would crash without a stable mock at the setup level.
-jest.mock('expo-secure-store', () => ({
+// expo-secure-store : WHISPR-994 : src/services/storage.ts l'importe en
+// statique (pas de fallback require dynamique). Sans ce mock setup-level,
+// chaque test qui touche storage plante.
+jest.mock("expo-secure-store", () => ({
   getItemAsync: jest.fn().mockResolvedValue(null),
   setItemAsync: jest.fn().mockResolvedValue(undefined),
   deleteItemAsync: jest.fn().mockResolvedValue(undefined),

--- a/src/components/Chat/AudioMessage.tsx
+++ b/src/components/Chat/AudioMessage.tsx
@@ -1,6 +1,5 @@
 /**
- * AudioMessage - Playback component for voice messages
- * Uses expo-av Audio.Sound for playback with play/pause and duration display.
+ * AudioMessage - lecture des messages vocaux via expo-av Audio.Sound.
  */
 
 import React, {
@@ -45,15 +44,17 @@ function getAudioModule(): any | null {
 interface AudioMessageProps {
   uri: string;
   mediaId?: string;
-  duration?: number; // duration in seconds from metadata
+  duration?: number; // en secondes, depuis les metadata
   isSent?: boolean;
 }
 
 function isStableMediaId(value?: string): boolean {
-  return !!value &&
+  return (
+    !!value &&
     /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
       value,
-    );
+    )
+  );
 }
 
 function formatDuration(seconds: number): string {
@@ -96,14 +97,16 @@ export const AudioMessage: React.FC<AudioMessageProps> = ({
     uriNeedsAuthResolution(uri);
   const [nativeAudioUri, setNativeAudioUri] = useState("");
 
-  // `/media/v1/:id/blob` returns `{ url, expiresAt }` JSON — not the raw
-  // audio bytes. On web we resolve it to a streamed blob URL. On native iOS/
-  // Android, prefer a real local `file://` path because expo-av playback is
-  // more reliable there than `data:` URIs for audio.
+  // `/media/v1/:id/blob` renvoie un JSON `{ url, expiresAt }`, pas les bytes.
+  // Sur web on resoud vers un blob URL streame ; sur natif iOS/Android on
+  // prefere un vrai chemin local `file://` car expo-av est plus fiable la
+  // qu'avec un `data:` URI audio.
   const { resolvedUri: streamedResolvedUri } = useResolvedMediaUrl(
     shouldCacheNativeAudio ? undefined : uri,
   );
-  const resolvedUri = shouldCacheNativeAudio ? nativeAudioUri : streamedResolvedUri;
+  const resolvedUri = shouldCacheNativeAudio
+    ? nativeAudioUri
+    : streamedResolvedUri;
 
   useEffect(() => {
     if (!shouldCacheNativeAudio || !mediaId) {
@@ -133,7 +136,6 @@ export const AudioMessage: React.FC<AudioMessageProps> = ({
 
   useEffect(() => {
     return () => {
-      // Cleanup sound on unmount
       if (soundRef.current) {
         soundRef.current.unloadAsync().catch(() => {});
         soundRef.current = null;
@@ -141,8 +143,8 @@ export const AudioMessage: React.FC<AudioMessageProps> = ({
     };
   }, []);
 
-  // Unload any previously-loaded sound when the resolved URI changes so the
-  // next play reloads from the fresh source.
+  // l'URI resolue change (ex: refresh d'un signed URL) : decharger l'ancien
+  // sound pour que la prochaine lecture reparte de la nouvelle source.
   useEffect(() => {
     if (soundRef.current) {
       soundRef.current.unloadAsync().catch(() => {});
@@ -188,7 +190,6 @@ export const AudioMessage: React.FC<AudioMessageProps> = ({
       }
       setIsPlaying(status.isPlaying || false);
 
-      // Reset when playback finishes
       if (status.didJustFinish) {
         setIsPlaying(false);
         setCurrentPosition(0);
@@ -202,7 +203,7 @@ export const AudioMessage: React.FC<AudioMessageProps> = ({
     if (!audioModule) return;
 
     try {
-      // Configure audio mode for playback
+      // bascule en mode lecture (allowsRecordingIOS:false, silentMode:true)
       await audioModule.setAudioModeAsync({
         allowsRecordingIOS: false,
         playsInSilentModeIOS: true,
@@ -256,7 +257,9 @@ export const AudioMessage: React.FC<AudioMessageProps> = ({
         activeOpacity={0.7}
         accessibilityRole="button"
         accessibilityLabel={
-          isPlaying ? "Mettre en pause le message vocal" : "Lire le message vocal"
+          isPlaying
+            ? "Mettre en pause le message vocal"
+            : "Lire le message vocal"
         }
       >
         <Ionicons
@@ -278,7 +281,9 @@ export const AudioMessage: React.FC<AudioMessageProps> = ({
                   {
                     height,
                     backgroundColor:
-                      index < playedBarCount ? activeBarColor : inactiveBarColor,
+                      index < playedBarCount
+                        ? activeBarColor
+                        : inactiveBarColor,
                     marginRight: index === waveformBars.length - 1 ? 0 : 3,
                   },
                 ]}

--- a/src/components/Chat/Avatar.tsx
+++ b/src/components/Chat/Avatar.tsx
@@ -1,13 +1,11 @@
 /**
- * Avatar - User avatar component with fallback
+ * Avatar - avatar utilisateur avec fallback initiales.
  *
- * WHISPR-1258 — passing the bare `/media/v1/:id/blob` URL to <Image> on web
- * triggers an `<img>` request without `Authorization`, which the media service
- * answers with 401. We now route the URL through `useResolvedMediaUrl`, the
- * shared hook that streams the bytes via the authenticated `?stream=1` proxy
- * and surfaces them as a `blob:` (web) or `data:` (native) URI safe for any
- * renderer. While the hook is loading we show the initials placeholder rather
- * than the unauthenticated URL.
+ * WHISPR-1258 : passer le URL brut `/media/v1/:id/blob` a <Image> sur web
+ * declenche un GET <img> sans Authorization, donc 401 cote media service.
+ * On passe par `useResolvedMediaUrl` qui streame via le proxy authentifie
+ * `?stream=1` et expose un URI `blob:` (web) ou `data:` (natif). Pendant
+ * le chargement, on affiche les initiales plutot que l'URL non auth.
  */
 
 import React from "react";
@@ -17,7 +15,8 @@ import { colors } from "../../theme/colors";
 import { getApiBaseUrl } from "../../services/apiBase";
 import { useResolvedMediaUrl } from "../../hooks/useResolvedMediaUrl";
 
-// Extract color values for StyleSheet.create() to avoid runtime resolution issues
+// extraire les couleurs en const : StyleSheet.create() les resoud au mount,
+// pas a chaque render.
 const TEXT_LIGHT_COLOR = colors.text.light;
 const BACKGROUND_PRIMARY_COLOR = colors.background.primary;
 
@@ -124,9 +123,9 @@ export const Avatar: React.FC<AvatarProps> = ({
     return { uri: undefined, mediaId: undefined };
   }, [uri]);
 
-  // Reset the local error flag whenever the source changes — otherwise an
-  // earlier failure would mask a fresh URI for the same component instance
-  // (e.g. ConversationItem re-using the same Avatar across rerenders).
+  // reset du flag d'erreur quand la source change : sinon un ancien echec
+  // masque une nouvelle URI valide pour la meme instance (cf. ConversationItem
+  // qui reutilise Avatar entre re-renders).
   const candidateKey = effectiveCandidate.mediaId ?? effectiveCandidate.uri;
   const lastCandidateKeyRef = React.useRef(candidateKey);
   if (lastCandidateKeyRef.current !== candidateKey) {
@@ -134,9 +133,9 @@ export const Avatar: React.FC<AvatarProps> = ({
     setImageError(false);
   }
 
-  // Route every /media/v1/<id>/blob (or /thumbnail) URL through the shared
-  // resolver hook so we never hand an unauthenticated URL to <Image>. Plain
-  // https / data / file URIs are passed through unchanged by the hook.
+  // toute URL /media/v1/<id>/blob (ou /thumbnail) passe par le hook resolver
+  // pour eviter de filer une URL non auth a <Image>. Les URIs https / data /
+  // file sont retournees telles quelles par le hook.
   const { resolvedUri, loading, error } = useResolvedMediaUrl(
     effectiveCandidate.uri,
   );

--- a/src/components/Chat/MessageInput/index.tsx
+++ b/src/components/Chat/MessageInput/index.tsx
@@ -1,5 +1,5 @@
 /**
- * MessageInput - Message input component with send button
+ * MessageInput - barre de saisie + bouton d'envoi.
  */
 
 import React, { useState, useCallback, useEffect, useRef } from "react";
@@ -68,10 +68,11 @@ interface MessageInputProps {
   conversationType?: "direct" | "group";
   members?: MentionMember[];
   /**
-   * When true, MessageInput adds its own bottom inset padding so the bar sits
-   * above the home indicator / nav bar. Default false because most screens
-   * already wrap MessageInput in a SafeAreaView with edges=["bottom"]; setting
-   * this to true outside such a wrapper avoids the bar from being clipped.
+   * Quand true, on ajoute soi-même le padding bottom safe-area pour que la
+   * barre passe au-dessus du home indicator. Par defaut false : la plupart
+   * des ecrans wrappent deja MessageInput dans une SafeAreaView avec
+   * edges=["bottom"]. A activer uniquement quand ce n'est pas le cas, sinon
+   * la barre se fait clipper.
    */
   applySafeAreaBottom?: boolean;
 }
@@ -123,9 +124,9 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     onSendMediaRef.current = onSendMedia;
   }, [onSendMedia]);
 
-  // Track keyboard visibility so we can drop the safe-area bottom padding
-  // when the keyboard is up (it covers the home indicator anyway, and the
-  // KeyboardAvoidingView already pushes the bar above it).
+  // Quand le clavier est ouvert, on degage le padding bottom safe-area : il
+  // recouvre deja le home indicator, et le KeyboardAvoidingView pousse la
+  // barre au-dessus.
   useEffect(() => {
     const showEvent =
       Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow";
@@ -184,7 +185,6 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     setRecordedAudio(null);
   }, []);
 
-  // Update text when editing message changes
   useEffect(() => {
     if (editingMessage) {
       setText(editingMessage.content);
@@ -206,8 +206,8 @@ export const MessageInput: React.FC<MessageInputProps> = ({
         setMentionStartIndex(detection.startIndex);
         setShowMentions(true);
       } else if (conversationType === "group" && members.length > 0) {
-        // Only clear mentions when we're in a group — matches the previous
-        // behaviour which only toggled mentions in that branch.
+        // ne fermer le picker de mentions que dans les groupes : ailleurs
+        // l'ancien comportement laissait l'etat ouvert.
         setShowMentions(false);
       }
     },
@@ -305,7 +305,6 @@ export const MessageInput: React.FC<MessageInputProps> = ({
       setMentionQuery("");
       setMentionStartIndex(-1);
 
-      // Focus back on input
       inputRef.current?.focus();
     },
     [text, mentionStartIndex],
@@ -315,7 +314,6 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     if (text.trim()) {
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
 
-      // Extract mentions from text
       const mentionRegex = /@(\w+)/g;
       const mentions: string[] = [];
       let match;
@@ -351,7 +349,6 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     }
   }, [text, onScheduleSend]);
 
-  // Open camera capture modal
   const handleOpenCamera = useCallback(() => {
     setShowCameraCapture(true);
   }, []);
@@ -365,10 +362,9 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     setShowAttachmentSheet(true);
   }, []);
 
-  // Handle camera capture result
   const handleCameraCapture = useCallback(
     (result: CameraCaptureResult) => {
-      // Send media with caption integrated in the same message
+      // envoie le media + caption dans le meme message (un seul tour reseau)
       onSendMedia?.(
         result.uri,
         result.type,
@@ -396,14 +392,12 @@ export const MessageInput: React.FC<MessageInputProps> = ({
         return;
       }
 
-      // Launch image picker without forcing a crop: WHISPR-1039 wants the
-      // user to send images in their native ratio (portrait/landscape/square).
-      // WHISPR-1197 : on ne passe PAS `quality` ici — sur iOS/Android
-      // expo-image-picker re-encode en JPEG dès que `quality` est défini,
-      // ce qui aplatit les GIFs animés (premier frame seulement) et perd
-      // la compression native HEIC. La taille du fichier est déjà bornée
-      // côté upload par WHISPR-1220, on accepte donc un léger surcoût
-      // réseau pour préserver l'animation et le format Apple.
+      // WHISPR-1039 : pas de crop force, on garde le ratio natif de l'image.
+      // WHISPR-1197 : ne pas passer `quality` non plus - des qu'il est defini,
+      // expo-image-picker re-encode en JPEG sur iOS/Android, ce qui aplatit
+      // les GIFs animes (1er frame seulement) et casse le HEIC. La taille
+      // est deja bornee a l'upload (WHISPR-1220), donc on accepte le leger
+      // surcout reseau pour preserver l'animation et le format Apple.
       const result = await ImagePicker.launchImageLibraryAsync({
         mediaTypes: ["images"],
         allowsEditing: false,
@@ -442,7 +436,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
       }
       const asset = result.assets[0];
 
-      // Cap document size client-side to avoid surprise upload failures.
+      // borne client-side pour eviter un upload qui echoue cote serveur.
       const MAX_BYTES = 25 * 1024 * 1024;
       if (typeof asset.size === "number" && asset.size > MAX_BYTES) {
         Alert.alert(
@@ -500,8 +494,8 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     }
   }, [isRecording, startRecording, stopRecording]);
 
-  // While the keyboard is up we still want a small breathing gap between
-  // the bar and the keyboard. Otherwise the bar uses the home indicator inset.
+  // clavier ouvert : on veut un petit espace entre la barre et le clavier.
+  // Sinon on utilise l'inset du home indicator.
   const KEYBOARD_OPEN_GAP = 8;
   const bottomPadding = isKeyboardVisible
     ? KEYBOARD_OPEN_GAP

--- a/src/services/contacts/api.ts
+++ b/src/services/contacts/api.ts
@@ -134,9 +134,9 @@ const fetchUserById = async (userId: string): Promise<User | null> => {
   return promise;
 };
 
-// Some backend search endpoints return `200` with an empty body when no
-// match is found, which makes `response.json()` throw. Read as text first
-// and treat empty/whitespace-only payloads as `null` to avoid noisy errors.
+// certains endpoints search renvoient 200 avec un body vide quand pas de
+// match -> response.json() throw. On passe par text() et on considere
+// payload vide = null pour eviter les erreurs bruyantes.
 const parseJsonSafe = async (response: Response): Promise<unknown> => {
   const text = await response.text().catch(() => "");
   if (!text.trim()) return null;
@@ -170,9 +170,8 @@ const buildSearchResult = (
       is_active: u.isActive ?? u.is_active ?? true,
     },
     is_contact: contactIds ? contactIds.has(userId) : false,
-    // WHISPR-1215 — couvre le sens "je l'ai bloqué". Le sens inverse
-    // ("il m'a bloqué") demande un flag côté serveur et fait l'objet d'un
-    // ticket séparé.
+    // WHISPR-1215 : couvre le sens "je l'ai bloque". Le sens inverse
+    // ("il m'a bloque") demande un flag cote serveur, ticket separe.
     is_blocked: blockedIds ? blockedIds.has(userId) : false,
   };
 };
@@ -247,7 +246,7 @@ export const contactsAPI = {
           : [];
       const contacts = items.map(normalizeContact);
 
-      // Enrich contacts with user data in parallel
+      // enrichissement profils utilisateur en parallele (1 fetch / contact)
       const enriched = await Promise.all(
         contacts.map(async (contact: Contact) => {
           if (contact.contact_id) {
@@ -408,8 +407,8 @@ export const contactsAPI = {
       return [];
     }
 
-    // WHISPR-1215 — fetch contacts and blocked users in parallel so each
-    // result carries the real is_blocked flag (was hard-coded to false).
+    // WHISPR-1215 : fetch contacts + bloques en parallele pour que chaque
+    // resultat porte le vrai is_blocked (auparavant hard-code a false).
     const [contactIds, blockedIds] = await Promise.all([
       this.getContacts()
         .then(({ contacts }) => new Set(contacts.map((c) => c.contact_id)))
@@ -419,10 +418,10 @@ export const contactsAPI = {
         .catch(() => new Set<string>()),
     ]);
 
-    // Run all search strategies in parallel for fuzzy matching
+    // les 3 strategies de recherche tournent en parallele (fuzzy matching)
     const searches: Promise<UserSearchResult[]>[] = [];
 
-    // 1. Search by username (exact match from API)
+    // 1. par username (match exact API)
     searches.push(
       fetch(
         `${API_BASE_URL}/search/username?username=${encodeURIComponent(query)}`,
@@ -433,8 +432,8 @@ export const contactsAPI = {
         .then(async (r) => {
           if (!r.ok) return [];
           const data = (await parseJsonSafe(r)) as any;
-          // WHISPR-1233 — backend wraps the response as `{ user: User | null }`.
-          // Fall back to the raw payload for backwards compatibility.
+          // WHISPR-1233 : le backend wrap la reponse en `{ user: User | null }`.
+          // Fallback raw payload pour retro-compat.
           const user = data?.user ?? data;
           if (!user?.id && !user?.userId) return [];
           return [buildSearchResult(user, contactIds, blockedIds)];
@@ -442,7 +441,7 @@ export const contactsAPI = {
         .catch(() => []),
     );
 
-    // 2. Search by name (fuzzy — backend supports partial match)
+    // 2. par nom (fuzzy, le backend gere le match partiel)
     searches.push(
       fetch(
         `${API_BASE_URL}/search/name?query=${encodeURIComponent(query)}&limit=20`,
@@ -465,7 +464,7 @@ export const contactsAPI = {
         .catch(() => []),
     );
 
-    // 3. Search by phone number (if input looks like a phone number)
+    // 3. par numero (uniquement si la query a une tete de telephone)
     const looksLikePhone = /^[+\d\s()-]{3,}$/.test(query);
     if (looksLikePhone) {
       searches.push(
@@ -479,8 +478,8 @@ export const contactsAPI = {
             if (!r.ok) return [];
             const data = (await parseJsonSafe(r)) as any;
             if (!data) return [];
-            // WHISPR-1233 — backend wraps the response as `{ user: User | null }`.
-            // Unwrap it; fall back to the raw payload for backwards compatibility.
+            // WHISPR-1233 : reponse `{ user: User | null }` -> on unwrap.
+            // Fallback raw payload pour retro-compat.
             const payload = data?.user !== undefined ? data.user : data;
             if (!payload) return [];
             const items = Array.isArray(payload)
@@ -498,7 +497,7 @@ export const contactsAPI = {
 
     const allResults = await Promise.all(searches);
 
-    // Deduplicate by user id
+    // dedup par user id
     const seen = new Set<string>();
     const merged: UserSearchResult[] = [];
     for (const batch of allResults) {
@@ -525,13 +524,13 @@ export const contactsAPI = {
 
     if (!phoneNumbers.length) return [];
 
-    // WHISPR-1215 — pull the user's blocked list once, before issuing the
-    // search calls, so each result reflects the real is_blocked state.
+    // WHISPR-1215 : on tire la liste des bloques une seule fois en amont,
+    // chaque resultat a son vrai is_blocked.
     const blockedIds = await this.getBlockedUsers()
       .then(({ blocked }) => new Set(blocked.map((b) => b.blocked_user_id)))
       .catch(() => new Set<string>());
 
-    // Try batch endpoint first
+    // 1er essai : endpoint batch
     try {
       const batchResponse = await fetch(`${API_BASE_URL}/search/phone/batch`, {
         method: "POST",
@@ -559,12 +558,12 @@ export const contactsAPI = {
         return results;
       }
 
-      // Non-OK response (e.g. 404) — fall through to sequential fallback
+      // 404 ou autre non-OK -> fallback sequentiel
     } catch {
-      // Batch endpoint unavailable — fall through to sequential fallback
+      // batch indispo -> fallback sequentiel
     }
 
-    // Fallback: sequential requests (one per phone number)
+    // fallback : 1 fetch par numero, sequentiel
     const results: UserSearchResult[] = [];
     const seen = new Set<string>();
 
@@ -579,8 +578,7 @@ export const contactsAPI = {
         const data = (await parseJsonSafe(response)) as any;
         if (!data) continue;
 
-        // WHISPR-1233 — backend wraps the response as `{ user: User | null }`.
-        // Unwrap it; fall back to the raw payload for backwards compatibility.
+        // WHISPR-1233 : `{ user: User | null }` -> unwrap, fallback raw.
         const payload = data?.user !== undefined ? data.user : data;
         if (!payload) continue;
 
@@ -598,7 +596,7 @@ export const contactsAPI = {
           }
         }
       } catch {
-        // Skip contacts that fail to resolve
+        // un fetch qui echoue : on saute le contact, pas la suite
       }
     }
 
@@ -784,8 +782,8 @@ export const contactsAPI = {
     };
   },
 
-  // The backend returns all blocked users at once (no pagination support).
-  // page/limit are kept in the signature for interface compatibility.
+  // le backend renvoie tous les utilisateurs bloques en une fois (pas de
+  // pagination). page/limit gardes pour compat de signature.
   async getBlockedUsers(
     _page: number = 1,
     _limit: number = 50,

--- a/src/services/linkPreview.ts
+++ b/src/services/linkPreview.ts
@@ -307,7 +307,7 @@ async function writeStoredCache(
   try {
     await AsyncStorage.setItem(cacheKey(url), JSON.stringify(entry));
   } catch {
-    // Best effort only — memory cache still protects the current session.
+    // best-effort : le cache memoire couvre deja la session courante.
   }
 }
 


### PR DESCRIPTION
## Summary
- Traduit en FR les commentaires explicatifs des fichiers ciblés par l'audit (MessageInput, AudioMessage, Avatar, linkPreview, contacts/api, jest.setup) en suivant les règles du repo (§18c) : ton humain, expliquer le pourquoi, pas le quoi.
- Supprime les paraphrases pures (commentaires qui ne faisaient que redire ce que la ligne fait).
- Nettoie les em-dashes dans les commentaires impactés en faveur de tirets simples (§16).

## Test plan
- [x] Unit tests verts sur les zones touchées (72+ tests)
- [x] Lint clean
- [x] Type-check clean
- [ ] Aucun em-dash résiduel dans les fichiers modifiés

Closes WHISPR-1300