### PR TITLE
[WHISPR-1302] feat(settings): implement read receipts WhatsApp punitive symmetry

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -7,10 +7,7 @@ import { enableScreens } from "react-native-screens";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ImageBackground, Platform, StyleSheet, View } from "react-native";
 import { StatusBar } from "expo-status-bar";
-import {
-  DefaultTheme,
-  NavigationContainer,
-} from "@react-navigation/native";
+import { DefaultTheme, NavigationContainer } from "@react-navigation/native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import * as SplashScreen from "expo-splash-screen";
@@ -27,6 +24,7 @@ import { navigationRef } from "./src/navigation/navigationRef";
 import { ThemeProvider, useTheme } from "./src/context/ThemeContext";
 import { AuthProvider } from "./src/context/AuthContext";
 import { BottomTabBar } from "./src/components/Navigation/BottomTabBar";
+import { hydrateReadReceiptsPref } from "./src/services/messaging/readReceiptsPref";
 
 enableScreens(false);
 
@@ -113,6 +111,12 @@ export default function App() {
       SplashScreen.hideAsync().catch(() => {});
     }
   }, [fontsLoaded, fontsError]);
+
+  // hydrate la preference accuses de lecture des le boot pour que useWebSocket
+  // l ait deja en cache au premier message envoye/recu
+  useEffect(() => {
+    hydrateReadReceiptsPref().catch(() => {});
+  }, []);
 
   const onLayoutRootView = useCallback(async () => {
     if (fontsLoaded || fontsError) {

--- a/conversationsStore.test.ts
+++ b/conversationsStore.test.ts
@@ -18,6 +18,7 @@ jest.mock("./src/services/messaging/api", () => ({
     deleteConversation: jest.fn().mockResolvedValue(undefined),
     archiveConversation: jest.fn().mockResolvedValue(undefined),
     unarchiveConversation: jest.fn().mockResolvedValue(undefined),
+    markMessageAsUnread: jest.fn().mockResolvedValue(undefined),
     getArchivedConversations: jest.fn().mockResolvedValue({
       data: [],
       meta: {
@@ -1455,5 +1456,182 @@ describe("conversationsStore — applyMessageDeleted (WHISPR-1299 user channel f
       .getState()
       .conversations.find((c) => c.id === "g3");
     expect(conv?.last_message?.is_deleted).toBe(false);
+  });
+});
+
+describe("conversationsStore — applyMessageUnread (WHISPR-1302)", () => {
+  function seedWithReadStatus(convId: string, messageId: string) {
+    const conv = {
+      id: convId,
+      type: "direct",
+      display_name: "Alice",
+      avatar_url: null,
+      member_user_ids: ["other", "me"],
+      last_message: {
+        id: messageId,
+        conversation_id: convId,
+        sender_id: "me",
+        message_type: "text",
+        content: "salut",
+        metadata: {},
+        client_random: 1,
+        sent_at: "2026-04-21T10:00:00Z",
+        is_deleted: false,
+        status: "read",
+      },
+      unread_count: 0,
+      is_pinned: false,
+      is_muted: false,
+      is_active: true,
+      is_archived: false,
+      updated_at: "2026-04-21T10:00:00Z",
+    } as unknown as Parameters<
+      ReturnType<
+        typeof useConversationsStore.getState
+      >["applyConversationSummaries"]
+    >[0][number];
+    act(() => {
+      useConversationsStore.getState().applyConversationSummaries([conv]);
+    });
+  }
+
+  it("revert le status read en delivered sur la preview last_message", () => {
+    seedWithReadStatus("c-rr", "m-rr-1");
+
+    act(() => {
+      useConversationsStore.getState().applyMessageUnread({
+        messageId: "m-rr-1",
+        conversationId: "c-rr",
+      });
+    });
+
+    const conv = useConversationsStore
+      .getState()
+      .conversations.find((c) => c.id === "c-rr");
+    expect(conv?.last_message?.status).toBe("delivered");
+  });
+
+  it("ne touche pas une conversation inconnue", () => {
+    seedWithReadStatus("c-rr", "m-rr-1");
+
+    act(() => {
+      useConversationsStore.getState().applyMessageUnread({
+        messageId: "m-rr-1",
+        conversationId: "c-other",
+      });
+    });
+
+    const conv = useConversationsStore
+      .getState()
+      .conversations.find((c) => c.id === "c-rr");
+    expect(conv?.last_message?.status).toBe("read");
+  });
+
+  it("ne touche pas si le message id ne match pas le last_message", () => {
+    seedWithReadStatus("c-rr", "m-rr-1");
+
+    act(() => {
+      useConversationsStore.getState().applyMessageUnread({
+        messageId: "m-other",
+        conversationId: "c-rr",
+      });
+    });
+
+    const conv = useConversationsStore
+      .getState()
+      .conversations.find((c) => c.id === "c-rr");
+    expect(conv?.last_message?.status).toBe("read");
+  });
+});
+
+describe("conversationsStore — markAsUnread API call (WHISPR-1302)", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { messagingAPI } = require("./src/services/messaging/api") as {
+    messagingAPI: { markMessageAsUnread: jest.Mock };
+  };
+
+  function seedConversation(convId: string, lastMessageId?: string) {
+    const conv = {
+      id: convId,
+      type: "direct",
+      display_name: "Alice",
+      avatar_url: null,
+      member_user_ids: ["other", "me"],
+      last_message: lastMessageId
+        ? {
+            id: lastMessageId,
+            conversation_id: convId,
+            sender_id: "other",
+            message_type: "text",
+            content: "salut",
+            metadata: {},
+            client_random: 1,
+            sent_at: "2026-04-21T10:00:00Z",
+            is_deleted: false,
+          }
+        : undefined,
+      unread_count: 0,
+      is_pinned: false,
+      is_muted: false,
+      is_active: true,
+      is_archived: false,
+      updated_at: "2026-04-21T10:00:00Z",
+    } as unknown as Parameters<
+      ReturnType<
+        typeof useConversationsStore.getState
+      >["applyConversationSummaries"]
+    >[0][number];
+    act(() => {
+      useConversationsStore.getState().applyConversationSummaries([conv]);
+    });
+  }
+
+  beforeEach(() => {
+    messagingAPI.markMessageAsUnread.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("appelle messagingAPI.markMessageAsUnread avec le last message id", async () => {
+    seedConversation("c-mu", "m-mu-1");
+
+    await act(async () => {
+      await useConversationsStore.getState().markAsUnread("c-mu");
+    });
+
+    expect(messagingAPI.markMessageAsUnread).toHaveBeenCalledWith(
+      "m-mu-1",
+      "c-mu",
+    );
+    const state = useConversationsStore.getState();
+    expect(state.manuallyUnreadIds.has("c-mu")).toBe(true);
+    const conv = state.conversations.find((c) => c.id === "c-mu");
+    expect(conv?.unread_count).toBeGreaterThanOrEqual(1);
+  });
+
+  it("skip l API call quand la conversation n a pas de last_message", async () => {
+    seedConversation("c-empty");
+
+    await act(async () => {
+      await useConversationsStore.getState().markAsUnread("c-empty");
+    });
+
+    expect(messagingAPI.markMessageAsUnread).not.toHaveBeenCalled();
+    expect(
+      useConversationsStore.getState().manuallyUnreadIds.has("c-empty"),
+    ).toBe(true);
+  });
+
+  it("rollback l etat local si l API call echoue", async () => {
+    seedConversation("c-fail", "m-fail-1");
+    messagingAPI.markMessageAsUnread.mockRejectedValueOnce(
+      new Error("network fail"),
+    );
+
+    await act(async () => {
+      await useConversationsStore.getState().markAsUnread("c-fail");
+    });
+
+    expect(messagingAPI.markMessageAsUnread).toHaveBeenCalled();
+    const state = useConversationsStore.getState();
+    expect(state.manuallyUnreadIds.has("c-fail")).toBe(false);
   });
 });

--- a/readReceiptsPref.test.ts
+++ b/readReceiptsPref.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests pour readReceiptsPref - cache local du toggle accuses de lecture.
+ *
+ * Note : AsyncStorage est mappe sur le mock officiel dans la config Jest
+ * (moduleNameMapper). On manipule donc ce mock directement plutot que de
+ * le re-mock localement.
+ */
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+import {
+  hydrateReadReceiptsPref,
+  getReadReceiptsEnabled,
+  setReadReceiptsEnabled,
+  isReadReceiptsPrefHydrated,
+  __resetReadReceiptsPrefForTests,
+} from "./src/services/messaging/readReceiptsPref";
+
+const STORAGE_KEY = "@whispr_settings_messaging";
+
+beforeEach(async () => {
+  __resetReadReceiptsPrefForTests();
+  await AsyncStorage.clear();
+});
+
+describe("readReceiptsPref", () => {
+  it("retourne true par defaut quand AsyncStorage est vide", async () => {
+    const value = await hydrateReadReceiptsPref();
+    expect(value).toBe(true);
+    expect(getReadReceiptsEnabled()).toBe(true);
+    expect(isReadReceiptsPrefHydrated()).toBe(true);
+  });
+
+  it("hydrate la valeur depuis le JSON stocke", async () => {
+    await AsyncStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ readReceipts: false }),
+    );
+    const value = await hydrateReadReceiptsPref();
+    expect(value).toBe(false);
+    expect(getReadReceiptsEnabled()).toBe(false);
+  });
+
+  it("ignore les payloads sans champ readReceipts boolean", async () => {
+    await AsyncStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ typingIndicator: false }),
+    );
+    const value = await hydrateReadReceiptsPref();
+    expect(value).toBe(true);
+  });
+
+  it("garde le defaut true si AsyncStorage throw", async () => {
+    const original = AsyncStorage.getItem;
+    (AsyncStorage as { getItem: jest.Mock }).getItem = jest
+      .fn()
+      .mockRejectedValue(new Error("boom"));
+    try {
+      const value = await hydrateReadReceiptsPref();
+      expect(value).toBe(true);
+    } finally {
+      (AsyncStorage as { getItem: typeof original }).getItem = original;
+    }
+  });
+
+  it("setReadReceiptsEnabled met a jour le mirror immediatement", () => {
+    setReadReceiptsEnabled(false);
+    expect(getReadReceiptsEnabled()).toBe(false);
+    setReadReceiptsEnabled(true);
+    expect(getReadReceiptsEnabled()).toBe(true);
+  });
+});

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -15,6 +15,7 @@ import {
 import { Conversation, Message } from "../types/messaging";
 import { usePresenceStore } from "../store/presenceStore";
 import { useCallsStore } from "../store/callsStore";
+import { useConversationsStore } from "../store/conversationsStore";
 import { navigate, navigationRef } from "../navigation/navigationRef";
 import type { CallType } from "../types/calls";
 import {
@@ -22,6 +23,7 @@ import {
   systemCallProvider,
 } from "../services/calls/systemCallProvider";
 import { isCallsAvailable } from "./useCallsAvailable";
+import { getReadReceiptsEnabled } from "../services/messaging/readReceiptsPref";
 
 /** Payload normalisé (snake_case) pour reaction_added / reaction_removed */
 export interface ReactionRealtimePayload {
@@ -99,7 +101,29 @@ export const useWebSocket = (options: UseWebSocketOptions) => {
         if (msg?.id) callbacksRef.current.onNewMessage?.(msg);
       },
       onDelivery: (data: { message_id: string; status: string }) => {
+        // symetrie punitive : si l user a desactive ses accuses, il ne doit
+        // pas voir non plus les accuses des autres. Les statuts sent /
+        // delivered passent toujours, seul "read" est filtre.
+        if (data.status === "read" && !getReadReceiptsEnabled()) return;
         callbacksRef.current.onDeliveryStatus?.(data.message_id, data.status);
+      },
+      // message_unread : symetrique de message_read, emis quand un destinataire
+      // a appuye sur "Marquer comme non-lu". Le backend revert le delivery_status
+      // -> on retire le read_at de l affichage. Filtre par toggle local : si l
+      // user a coupe ses accuses, il ignore aussi cet event.
+      onMessageUnread: (data: {
+        message_id?: string;
+        conversation_id?: string;
+      }) => {
+        if (!getReadReceiptsEnabled()) return;
+        if (!data?.message_id || !data?.conversation_id) return;
+        useConversationsStore.getState().applyMessageUnread({
+          messageId: data.message_id,
+          conversationId: data.conversation_id,
+        });
+        // re-broadcast en delivery_status "delivered" pour les ChatScreen
+        // ouverts qui ecoutent l event et veulent rafraichir leurs bulles
+        callbacksRef.current.onDeliveryStatus?.(data.message_id, "delivered");
       },
       onConvUpdate: (data: { conversation: Conversation }) => {
         callbacksRef.current.onConversationUpdate?.(data.conversation);
@@ -218,6 +242,7 @@ export const useWebSocket = (options: UseWebSocketOptions) => {
     userChannel.off("message_created", userHandlers.onMsg);
     userChannel.off("message_deleted", userHandlers.onMsgDeletedUser);
     userChannel.off("delivery_status", userHandlers.onDelivery);
+    userChannel.off("message_unread", userHandlers.onMessageUnread);
     userChannel.off("conversation_summaries", userHandlers.onConvSummaries);
     userChannel.off("conversation_archived", userHandlers.onConvArchived);
     userChannel.off("incoming_call", userHandlers.onIncomingCall);
@@ -227,6 +252,7 @@ export const useWebSocket = (options: UseWebSocketOptions) => {
     userChannel.on("message_created", userHandlers.onMsg);
     userChannel.on("message_deleted", userHandlers.onMsgDeletedUser);
     userChannel.on("delivery_status", userHandlers.onDelivery);
+    userChannel.on("message_unread", userHandlers.onMessageUnread);
     userChannel.on("conversation_summaries", userHandlers.onConvSummaries);
     userChannel.on("conversation_archived", userHandlers.onConvArchived);
     userChannel.on("incoming_call", userHandlers.onIncomingCall);
@@ -237,6 +263,7 @@ export const useWebSocket = (options: UseWebSocketOptions) => {
       userChannel.off("message_created", userHandlers.onMsg);
       userChannel.off("message_deleted", userHandlers.onMsgDeletedUser);
       userChannel.off("delivery_status", userHandlers.onDelivery);
+      userChannel.off("message_unread", userHandlers.onMessageUnread);
       userChannel.off("conversation_summaries", userHandlers.onConvSummaries);
       userChannel.off("conversation_archived", userHandlers.onConvArchived);
       userChannel.off("incoming_call", userHandlers.onIncomingCall);
@@ -276,6 +303,8 @@ export const useWebSocket = (options: UseWebSocketOptions) => {
       }
     };
     const onDelivery = (data: { message_id: string; status: string }) => {
+      // cf. user channel : on filtre "read" quand l user a coupe ses accuses
+      if (data.status === "read" && !getReadReceiptsEnabled()) return;
       callbacksRef.current.onDeliveryStatus?.(data.message_id, data.status);
     };
     const onPresenceDiff = (data: {
@@ -413,6 +442,11 @@ export const useWebSocket = (options: UseWebSocketOptions) => {
 
   const markAsRead = useCallback(
     (conversationId: string, messageId: string) => {
+      // symetrie WhatsApp punitive : si l user a desactive les accuses de
+      // lecture, on ne broadcast pas message_read aux autres. Le marquage
+      // local "lu" en zustand reste, mais aucun delivery_status n est emis.
+      if (!getReadReceiptsEnabled()) return;
+
       const socket = getSharedSocket();
       if (!socket.isConnected()) return;
 

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -34,6 +34,7 @@ import {
   NotificationService,
   NotificationSettings,
 } from "../../services/NotificationService";
+import { setReadReceiptsEnabled } from "../../services/messaging/readReceiptsPref";
 import { SettingsChoiceAlert } from "./SettingsChoiceAlert";
 import { FLOATING_TAB_BAR_RESERVED_SPACE } from "../../components/Navigation/floatingTabBarLayout";
 import {
@@ -296,7 +297,13 @@ export const SettingsScreen: React.FC = () => {
 
         if (privacyJson) setPrivacySettings(JSON.parse(privacyJson));
         if (notifJson) setNotificationSettings(JSON.parse(notifJson));
-        if (msgJson) setMessagingSettings(JSON.parse(msgJson));
+        if (msgJson) {
+          const parsedMsg = JSON.parse(msgJson);
+          setMessagingSettings(parsedMsg);
+          if (typeof parsedMsg.readReceipts === "boolean") {
+            setReadReceiptsEnabled(parsedMsg.readReceipts);
+          }
+        }
         if (appJson) setAppSettings(JSON.parse(appJson));
         if (secJson) setSecuritySettings(JSON.parse(secJson));
 
@@ -310,6 +317,21 @@ export const SettingsScreen: React.FC = () => {
             STORAGE_KEYS.privacy,
             JSON.stringify(localPrivacy),
           );
+          // synchronise readReceipts depuis le backend pour coherence multi-device.
+          // Si la cle est presente on met a jour le state messaging et le mirror
+          // memoire utilise par useWebSocket.
+          if (typeof result.settings.readReceipts === "boolean") {
+            const readReceiptsValue = result.settings.readReceipts;
+            setReadReceiptsEnabled(readReceiptsValue);
+            setMessagingSettings((prev) => {
+              const updated = { ...prev, readReceipts: readReceiptsValue };
+              AsyncStorage.setItem(
+                STORAGE_KEYS.messaging,
+                JSON.stringify(updated),
+              ).catch(() => {});
+              return updated;
+            });
+          }
         }
 
         // Fetch notification settings from notification-service backend (takes precedence over local)
@@ -359,6 +381,47 @@ export const SettingsScreen: React.FC = () => {
         setMessagingSettings((prev) => {
           const updated = { ...prev, [key]: value };
           persistSettings(STORAGE_KEYS.messaging, updated);
+          // accuses de lecture : symetrie WhatsApp punitive. On met a jour le
+          // mirror memoire immediatement pour que useWebSocket le voie au
+          // prochain markAsRead, puis on push au backend (privacy_settings).
+          // Si le backend echoue on rollback : la coherence multi-device
+          // depend de la valeur serveur.
+          if (key === "readReceipts") {
+            setReadReceiptsEnabled(value);
+            const userService = UserService.getInstance();
+            userService
+              .updatePrivacySettings({ readReceipts: value })
+              .then((result) => {
+                if (!result.success) {
+                  // rollback en memoire et en state
+                  setReadReceiptsEnabled(prev.readReceipts);
+                  setMessagingSettings((curr) => {
+                    const reverted = {
+                      ...curr,
+                      readReceipts: prev.readReceipts,
+                    };
+                    persistSettings(STORAGE_KEYS.messaging, reverted);
+                    return reverted;
+                  });
+                  Alert.alert(
+                    "Erreur",
+                    "Impossible de synchroniser ce parametre. Veuillez reessayer.",
+                  );
+                }
+              })
+              .catch(() => {
+                setReadReceiptsEnabled(prev.readReceipts);
+                setMessagingSettings((curr) => {
+                  const reverted = { ...curr, readReceipts: prev.readReceipts };
+                  persistSettings(STORAGE_KEYS.messaging, reverted);
+                  return reverted;
+                });
+                Alert.alert(
+                  "Erreur reseau",
+                  "Impossible de synchroniser ce parametre.",
+                );
+              });
+          }
           return updated;
         });
         break;

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -63,6 +63,8 @@ export interface PrivacySettings {
   groupAddPermission: "everyone" | "contacts" | "nobody";
   searchVisibility: boolean;
   phoneNumberSearch: "everyone" | "contacts" | "nobody";
+  // toggle WhatsApp punitive : si false on n envoie pas et on ne voit pas
+  readReceipts?: boolean;
 }
 
 export class UserService {
@@ -604,6 +606,8 @@ export class UserService {
           raw?.searchByUsername ?? raw?.searchVisibility ?? true,
         phoneNumberSearch:
           raw?.searchByPhone ?? raw?.phoneNumberSearch ?? "everyone",
+        // backend renvoie read_receipts (snake) ou readReceipts selon la version
+        readReceipts: raw?.readReceipts ?? raw?.read_receipts ?? true,
       };
       return { success: true, settings: data };
     } catch (error) {
@@ -616,26 +620,50 @@ export class UserService {
   }
 
   /**
-   * Update privacy settings
+   * Update privacy settings (PATCH partiel : seuls les champs definis sont
+   * envoyes au backend)
    */
   async updatePrivacySettings(
-    settings: PrivacySettings,
+    settings: Partial<PrivacySettings>,
   ): Promise<UpdateProfileResponse> {
     try {
+      // PATCH partiel : on n envoie que les champs definis. Permet aux callers
+      // de toucher uniquement readReceipts sans ecraser le reste de la privacy.
+      const body: Record<string, unknown> = {};
+      if (settings.profilePictureVisibility !== undefined) {
+        body.profilePicturePrivacy = settings.profilePictureVisibility;
+      }
+      if (settings.firstNameVisibility !== undefined) {
+        body.firstNamePrivacy = settings.firstNameVisibility;
+      }
+      if (settings.lastNameVisibility !== undefined) {
+        body.lastNamePrivacy = settings.lastNameVisibility;
+      }
+      if (settings.biographyVisibility !== undefined) {
+        body.biographyPrivacy = settings.biographyVisibility;
+      }
+      if (settings.lastSeenVisibility !== undefined) {
+        body.lastSeenPrivacy = settings.lastSeenVisibility;
+      }
+      if (settings.onlineStatusVisibility !== undefined) {
+        body.onlineStatus = settings.onlineStatusVisibility;
+      }
+      if (settings.groupAddPermission !== undefined) {
+        body.groupAddPermission = settings.groupAddPermission;
+      }
+      if (settings.phoneNumberSearch !== undefined) {
+        body.searchByPhone = settings.phoneNumberSearch !== "nobody";
+      }
+      if (settings.searchVisibility !== undefined) {
+        body.searchByUsername = settings.searchVisibility;
+      }
+      if (settings.readReceipts !== undefined) {
+        body.readReceipts = settings.readReceipts;
+      }
       const response = await this.authFetch("/privacy/{userId}", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          profilePicturePrivacy: settings.profilePictureVisibility,
-          firstNamePrivacy: settings.firstNameVisibility,
-          lastNamePrivacy: settings.lastNameVisibility,
-          biographyPrivacy: settings.biographyVisibility,
-          lastSeenPrivacy: settings.lastSeenVisibility,
-          onlineStatus: settings.onlineStatusVisibility,
-          groupAddPermission: settings.groupAddPermission,
-          searchByPhone: settings.phoneNumberSearch !== "nobody",
-          searchByUsername: settings.searchVisibility,
-        }),
+        body: JSON.stringify(body),
       });
 
       if (!response.ok) {

--- a/src/services/messaging/api.ts
+++ b/src/services/messaging/api.ts
@@ -497,6 +497,24 @@ export const messagingAPI = {
     return unwrap(response);
   },
 
+  async markMessageAsUnread(
+    messageId: string,
+    conversationId: string,
+  ): Promise<void> {
+    // POST /messages/:id/unread?conversation_id=... — backend revert le
+    // delivery_status du message pour le user courant et broadcast un
+    // event message_unread sur le user channel des autres participants.
+    const url = `${API_BASE_URL}/messages/${encodeURIComponent(
+      messageId,
+    )}/unread?conversation_id=${encodeURIComponent(conversationId)}`;
+
+    const response = await authenticatedFetch(url, { method: "POST" });
+
+    if (!response.ok) {
+      throw httpError("Failed to mark message as unread", response);
+    }
+  },
+
   async deleteMessage(
     messageId: string,
     conversationId: string,

--- a/src/services/messaging/readReceiptsPref.ts
+++ b/src/services/messaging/readReceiptsPref.ts
@@ -1,0 +1,69 @@
+/**
+ * readReceiptsPref - Cache local du toggle "Accusés de lecture"
+ *
+ * Le toggle vit dans AsyncStorage sous la clé @whispr_settings_messaging.
+ * Pour eviter une lecture asynchrone a chaque envoi/reception WS, on garde
+ * un mirror en memoire hydrate au boot via hydrateReadReceiptsPref().
+ *
+ * Symetrie WhatsApp punitive : si OFF -> on n envoie pas message_read ET
+ * on ignore les message_read recus des autres.
+ */
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const STORAGE_KEY = "@whispr_settings_messaging";
+
+// par defaut on respecte l ancien comportement : accuses actives
+let cached: boolean = true;
+let hydrated = false;
+
+/**
+ * Lit la preference depuis AsyncStorage et met a jour le mirror memoire.
+ * A appeler au boot (App.tsx) et avant tout consumer qui veut etre sur
+ * d avoir la valeur courante.
+ */
+export async function hydrateReadReceiptsPref(): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (typeof parsed?.readReceipts === "boolean") {
+        cached = parsed.readReceipts;
+      }
+    }
+  } catch {
+    // si AsyncStorage casse, on garde la valeur par defaut (true)
+  }
+  hydrated = true;
+  return cached;
+}
+
+/**
+ * Lecture synchrone du mirror memoire. Si pas hydrate -> defaut true.
+ */
+export function getReadReceiptsEnabled(): boolean {
+  return cached;
+}
+
+/**
+ * Mise a jour synchrone du mirror (appelee depuis SettingsScreen quand le
+ * user toggle, avant meme le persist async).
+ */
+export function setReadReceiptsEnabled(value: boolean): void {
+  cached = value;
+  hydrated = true;
+}
+
+/**
+ * Helper test-only : reset l etat module pour repartir d un cache vierge.
+ */
+export function __resetReadReceiptsPrefForTests(): void {
+  cached = true;
+  hydrated = false;
+}
+
+/**
+ * Indique si la preference a deja ete chargee. Utile pour les tests.
+ */
+export function isReadReceiptsPrefHydrated(): boolean {
+  return hydrated;
+}

--- a/src/store/conversationsStore.ts
+++ b/src/store/conversationsStore.ts
@@ -138,6 +138,10 @@ interface ConversationsActions {
   applyNewMessage: (message: Message, currentUserId?: string) => Promise<void>;
   applyMessageUpdated: (message: Message) => void;
   applyMessageDeleted: (messageId: string, deleteForEveryone: boolean) => void;
+  applyMessageUnread: (params: {
+    messageId: string;
+    conversationId: string;
+  }) => void;
   deleteConversation: (id: string) => Promise<void>;
   removeConversationLocal: (id: string) => void;
   archiveConversation: (id: string) => Promise<void>;
@@ -614,6 +618,47 @@ export const useConversationsStore = create<
                 }
               : c,
           ),
+        },
+      });
+    }
+  },
+
+  applyMessageUnread: ({ messageId, conversationId }) => {
+    // symetrique de applyMessageDeleted : si le destinataire repasse un message
+    // en non-lu, on retire le status "read" de la preview locale (le ticker
+    // bleu redevient gris). Le delivery_status broadcast par le backend sera
+    // intercepte par useWebSocket et gere par les ChatScreen ouverts.
+    const { conversations, archived } = get();
+
+    const updateLastMessage = (conv: Conversation): Conversation => {
+      if (conv.id !== conversationId) return conv;
+      if (!conv.last_message || conv.last_message.id !== messageId) return conv;
+      const last = conv.last_message;
+      const nextStatus =
+        last.status === "read" ? ("delivered" as const) : last.status;
+      return {
+        ...conv,
+        last_message: {
+          ...last,
+          status: nextStatus,
+        },
+      };
+    };
+
+    const mainIndex = conversations.findIndex((c) => c.id === conversationId);
+    if (mainIndex !== -1) {
+      const next = conversations.map(updateLastMessage);
+      set({ conversations: next });
+    }
+
+    const archivedIndex = archived.items.findIndex(
+      (c) => c.id === conversationId,
+    );
+    if (archivedIndex !== -1) {
+      set({
+        archived: {
+          ...archived,
+          items: archived.items.map(updateLastMessage),
         },
       });
     }

--- a/src/store/conversationsStore.ts
+++ b/src/store/conversationsStore.ts
@@ -979,23 +979,51 @@ export const useConversationsStore = create<
 
   markAsUnread: async (id) => {
     const { conversations, manuallyUnreadIds } = get();
+    const target = conversations.find((c) => c.id === id);
+    const lastMessageId = target?.last_message?.id;
+
+    // optimistic local update : ajoute au Set + bump unread_count, comme avant
     const nextIds = new Set(manuallyUnreadIds);
     nextIds.add(id);
+    const optimisticConvs = conversations.map((c) =>
+      c.id === id
+        ? { ...c, unread_count: Math.max(c.unread_count || 0, 1) }
+        : c,
+    );
     set({
       manuallyUnreadIds: nextIds,
-      conversations: conversations.map((c) =>
-        c.id === id
-          ? { ...c, unread_count: Math.max(c.unread_count || 0, 1) }
-          : c,
-      ),
+      conversations: optimisticConvs,
     });
+    AsyncStorage.setItem(
+      MANUALLY_UNREAD_KEY,
+      JSON.stringify([...nextIds]),
+    ).catch(() => {});
+
+    if (!lastMessageId) {
+      // pas de message a marquer cote backend (conv vide), on garde juste le
+      // flag local pour l affichage
+      return;
+    }
+
     try {
-      await AsyncStorage.setItem(
+      await messagingAPI.markMessageAsUnread(lastMessageId, id);
+    } catch (err) {
+      // rollback : retire le flag, restore unread_count
+      const { manuallyUnreadIds: currentIds, conversations: currentConvs } =
+        get();
+      const rolledBackIds = new Set(currentIds);
+      rolledBackIds.delete(id);
+      set({
+        manuallyUnreadIds: rolledBackIds,
+        conversations: currentConvs.map((c) =>
+          c.id === id ? { ...c, unread_count: target?.unread_count || 0 } : c,
+        ),
+      });
+      AsyncStorage.setItem(
         MANUALLY_UNREAD_KEY,
-        JSON.stringify([...nextIds]),
-      );
-    } catch {
-      // Storage write failed — local state is still correct for this session
+        JSON.stringify([...rolledBackIds]),
+      ).catch(() => {});
+      logger.warn("conversationsStore", "markAsUnread API failed", err);
     }
   },
 

--- a/useWebSocket.test.tsx
+++ b/useWebSocket.test.tsx
@@ -1,0 +1,223 @@
+/**
+ * Tests pour useWebSocket - symetrie WhatsApp punitive accuses de lecture.
+ *
+ * Verifie que :
+ * - markAsRead skip le push WS quand le toggle est OFF
+ * - le handler delivery_status filtre "read" quand le toggle est OFF
+ * - le handler message_unread est ignore quand le toggle est OFF
+ * - le handler message_unread appelle applyMessageUnread quand le toggle est ON
+ */
+
+const mockChannelPush = jest.fn();
+const mockChannelOn = jest.fn();
+const mockChannelOff = jest.fn();
+const mockChannelJoin = jest.fn();
+const mockIsConnected = jest.fn(() => true);
+const mockChannel = {
+  push: mockChannelPush,
+  on: mockChannelOn,
+  off: mockChannelOff,
+  join: mockChannelJoin,
+  leave: jest.fn(),
+};
+const mockSocket = {
+  channel: jest.fn(() => mockChannel),
+  isConnected: mockIsConnected,
+  connect: jest.fn(),
+  connectionState: "connected" as const,
+  addConnectionStateListener: jest.fn(() => () => {}),
+};
+
+jest.mock("../mobile-app/src/services/messaging/websocket", () => ({
+  getSharedSocket: () => mockSocket,
+}));
+// re-mock via relative path used by the hook
+jest.mock("./src/services/messaging/websocket", () => ({
+  getSharedSocket: () => mockSocket,
+}));
+
+const mockApplyMessageUnread = jest.fn();
+jest.mock("./src/store/conversationsStore", () => ({
+  useConversationsStore: {
+    getState: () => ({
+      applyMessageUnread: mockApplyMessageUnread,
+    }),
+  },
+}));
+
+jest.mock("./src/store/presenceStore", () => ({
+  usePresenceStore: {
+    getState: () => ({
+      applyPresenceDiff: jest.fn(),
+      setPresenceState: jest.fn(),
+    }),
+  },
+}));
+
+jest.mock("./src/store/callsStore", () => ({
+  useCallsStore: {
+    getState: () => ({
+      setIncoming: jest.fn(),
+      reset: jest.fn(),
+      incoming: null,
+      active: null,
+    }),
+  },
+}));
+
+jest.mock("./src/navigation/navigationRef", () => ({
+  navigate: jest.fn(),
+  navigationRef: {
+    isReady: () => false,
+    getCurrentRoute: () => null,
+  },
+}));
+
+jest.mock("./src/services/calls/systemCallProvider", () => ({
+  buildIncomingCallPresentation: jest.fn(),
+  systemCallProvider: {
+    isSupported: () => false,
+    showIncomingCall: jest.fn(),
+    endCall: jest.fn(),
+  },
+}));
+
+jest.mock("./src/hooks/useCallsAvailable", () => ({
+  isCallsAvailable: () => true,
+}));
+
+const mockGetReadReceiptsEnabled = jest.fn(() => true);
+jest.mock("./src/services/messaging/readReceiptsPref", () => ({
+  getReadReceiptsEnabled: () => mockGetReadReceiptsEnabled(),
+}));
+
+import React from "react";
+import { renderHook, act } from "@testing-library/react-native";
+import { useWebSocket } from "./src/hooks/useWebSocket";
+
+beforeEach(() => {
+  mockChannelPush.mockClear();
+  mockChannelOn.mockClear();
+  mockChannelOff.mockClear();
+  mockChannelJoin.mockClear();
+  mockIsConnected.mockClear();
+  mockIsConnected.mockReturnValue(true);
+  mockApplyMessageUnread.mockClear();
+  mockGetReadReceiptsEnabled.mockReset();
+  mockGetReadReceiptsEnabled.mockReturnValue(true);
+});
+
+const baseOptions = {
+  userId: "user-1",
+  token: "token-abc",
+};
+
+describe("useWebSocket - markAsRead", () => {
+  it("push message_read sur le canal quand toggle ON", () => {
+    mockGetReadReceiptsEnabled.mockReturnValue(true);
+    const { result } = renderHook(() => useWebSocket(baseOptions));
+
+    act(() => {
+      result.current.markAsRead("conv-1", "msg-42");
+    });
+
+    expect(mockChannelPush).toHaveBeenCalledWith("message_read", {
+      message_id: "msg-42",
+    });
+  });
+
+  it("skip le push quand toggle OFF (symetrie punitive)", () => {
+    mockGetReadReceiptsEnabled.mockReturnValue(false);
+    const { result } = renderHook(() => useWebSocket(baseOptions));
+
+    act(() => {
+      result.current.markAsRead("conv-1", "msg-42");
+    });
+
+    expect(mockChannelPush).not.toHaveBeenCalled();
+  });
+});
+
+describe("useWebSocket - delivery_status filter", () => {
+  function getRegisteredHandler(eventName: string): (data: any) => void {
+    const entry = mockChannelOn.mock.calls.find((c) => c[0] === eventName);
+    if (!entry) throw new Error(`handler ${eventName} not registered`);
+    return entry[1];
+  }
+
+  it("propage delivery_status read quand toggle ON", () => {
+    mockGetReadReceiptsEnabled.mockReturnValue(true);
+    const onDeliveryStatus = jest.fn();
+    renderHook(() => useWebSocket({ ...baseOptions, onDeliveryStatus }));
+
+    const handler = getRegisteredHandler("delivery_status");
+    handler({ message_id: "msg-1", status: "read" });
+    expect(onDeliveryStatus).toHaveBeenCalledWith("msg-1", "read");
+  });
+
+  it("ignore delivery_status read quand toggle OFF", () => {
+    mockGetReadReceiptsEnabled.mockReturnValue(false);
+    const onDeliveryStatus = jest.fn();
+    renderHook(() => useWebSocket({ ...baseOptions, onDeliveryStatus }));
+
+    const handler = getRegisteredHandler("delivery_status");
+    handler({ message_id: "msg-1", status: "read" });
+    expect(onDeliveryStatus).not.toHaveBeenCalled();
+  });
+
+  it("laisse passer sent et delivered meme quand toggle OFF", () => {
+    mockGetReadReceiptsEnabled.mockReturnValue(false);
+    const onDeliveryStatus = jest.fn();
+    renderHook(() => useWebSocket({ ...baseOptions, onDeliveryStatus }));
+
+    const handler = getRegisteredHandler("delivery_status");
+    handler({ message_id: "msg-1", status: "delivered" });
+    handler({ message_id: "msg-2", status: "sent" });
+    expect(onDeliveryStatus).toHaveBeenCalledTimes(2);
+    expect(onDeliveryStatus).toHaveBeenNthCalledWith(1, "msg-1", "delivered");
+    expect(onDeliveryStatus).toHaveBeenNthCalledWith(2, "msg-2", "sent");
+  });
+});
+
+describe("useWebSocket - message_unread handler", () => {
+  function getRegisteredHandler(eventName: string): (data: any) => void {
+    const entry = mockChannelOn.mock.calls.find((c) => c[0] === eventName);
+    if (!entry) throw new Error(`handler ${eventName} not registered`);
+    return entry[1];
+  }
+
+  it("appelle applyMessageUnread sur le store quand toggle ON", () => {
+    mockGetReadReceiptsEnabled.mockReturnValue(true);
+    renderHook(() => useWebSocket(baseOptions));
+
+    const handler = getRegisteredHandler("message_unread");
+    handler({ message_id: "msg-7", conversation_id: "conv-9" });
+
+    expect(mockApplyMessageUnread).toHaveBeenCalledWith({
+      messageId: "msg-7",
+      conversationId: "conv-9",
+    });
+  });
+
+  it("ignore l event quand toggle OFF (symetrie punitive)", () => {
+    mockGetReadReceiptsEnabled.mockReturnValue(false);
+    renderHook(() => useWebSocket(baseOptions));
+
+    const handler = getRegisteredHandler("message_unread");
+    handler({ message_id: "msg-7", conversation_id: "conv-9" });
+
+    expect(mockApplyMessageUnread).not.toHaveBeenCalled();
+  });
+
+  it("ignore les payloads incomplets", () => {
+    mockGetReadReceiptsEnabled.mockReturnValue(true);
+    renderHook(() => useWebSocket(baseOptions));
+
+    const handler = getRegisteredHandler("message_unread");
+    handler({ message_id: "msg-7" });
+    handler({ conversation_id: "conv-9" });
+    handler({});
+
+    expect(mockApplyMessageUnread).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Implements complete WhatsApp-style punitive symmetry for read receipts on mobile. When a user disables the toggle, both directions are blocked: they no longer broadcast their reads AND they no longer see other users' reads.

Three coordinated mechanisms:
- **Toggle sync**: `Settings -> Accuses de lecture` now persists to backend `privacy_settings.read_receipts` via `PATCH /user/v1/privacy/{userId}` (rollback on failure). Hydrated at boot from backend for multi-device coherence.
- **Send gate**: `useWebSocket.markAsRead` no-ops when toggle OFF; no `message_read` push.
- **Receive filter**: `delivery_status` events with `status="read"` are dropped when toggle OFF, so the blue tick never appears for the user. Sent / delivered statuses still pass through.

Also adds the symmetric `message_unread` handler on the user channel and converts the local-only "Mark as unread" button into a real API call (`POST /messaging/api/v1/messages/:id/unread?conversation_id=...`) with optimistic state and rollback on failure.

## Test plan

- [x] Unit tests green (879 / 879)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint:fix` 0 errors
- [x] `npx prettier --write src/**/*.{ts,tsx}` applied
- [ ] Live preprod : toggle OFF on device A, send a message from B -> B sees no blue tick. Re-enable -> blue tick syncs.
- [ ] Live preprod : "Mark as unread" -> backend round-trip persists; conversation list shows badge after refresh.

Depends on backend PRs:
- user-service `GET /internal/users/:id/privacy` + `read_receipts` field on privacy_settings
- messaging-service `POST /messages/:id/unread` endpoint + `message_unread` user-channel broadcast

Closes WHISPR-1302