### PR TITLE
[WHISPR-1309] feat(profile): add mini-card profil with click/long-press triggers

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -24,6 +24,7 @@ import { navigationRef } from "./src/navigation/navigationRef";
 import { ThemeProvider, useTheme } from "./src/context/ThemeContext";
 import { AuthProvider } from "./src/context/AuthContext";
 import { BottomTabBar } from "./src/components/Navigation/BottomTabBar";
+import { MiniProfileCardHost } from "./src/components/Profile";
 import { hydrateReadReceiptsPref } from "./src/services/messaging/readReceiptsPref";
 
 enableScreens(false);
@@ -80,6 +81,7 @@ function AppShell() {
           </View>
         </View>
         <BottomTabBar currentRouteName={currentRouteName} />
+        <MiniProfileCardHost />
         <StatusBar style="light" />
       </NavigationContainer>
     </AuthProvider>

--- a/MiniProfileCache.test.ts
+++ b/MiniProfileCache.test.ts
@@ -1,0 +1,67 @@
+import {
+  getCached,
+  setCached,
+  clearCache,
+  _internalSize,
+} from "./src/services/profile/miniProfileCache";
+import { UserProfile } from "./src/services/UserService";
+
+const baseProfile = (id: string): UserProfile => ({
+  id,
+  firstName: "Test",
+  lastName: "User",
+  username: `u_${id}`,
+  phoneNumber: "",
+  biography: "",
+  isOnline: false,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+});
+
+beforeEach(() => {
+  clearCache();
+});
+
+describe("miniProfileCache", () => {
+  it("returns null on cache miss", () => {
+    expect(getCached("u1")).toBeNull();
+  });
+
+  it("returns the profile and isStale=false on a fresh hit", () => {
+    setCached("u1", baseProfile("u1"));
+    const hit = getCached("u1");
+    expect(hit).not.toBeNull();
+    expect(hit!.profile.id).toBe("u1");
+    expect(hit!.isStale).toBe(false);
+  });
+
+  it("marks an entry as stale after 5 minutes", () => {
+    const realNow = Date.now;
+    Date.now = jest.fn(() => 1_000_000_000_000);
+    setCached("u1", baseProfile("u1"));
+    Date.now = jest.fn(() => 1_000_000_000_000 + 6 * 60 * 1000);
+    const hit = getCached("u1");
+    expect(hit!.isStale).toBe(true);
+    Date.now = realNow;
+  });
+
+  it("evicts the least recently used entry past 50 items", () => {
+    for (let i = 0; i < 50; i++) setCached(`u${i}`, baseProfile(`u${i}`));
+    expect(_internalSize()).toBe(50);
+    setCached("u50", baseProfile("u50"));
+    expect(_internalSize()).toBe(50);
+    // u0 etait le plus ancien et n'a pas ete relu, il doit etre evicte
+    expect(getCached("u0")).toBeNull();
+    expect(getCached("u50")).not.toBeNull();
+  });
+
+  it("refreshes LRU position on read", () => {
+    for (let i = 0; i < 50; i++) setCached(`u${i}`, baseProfile(`u${i}`));
+    // on accede a u0 pour le re-promouvoir
+    getCached("u0");
+    // on insere u50 -> c'est u1 qui doit tomber, pas u0
+    setCached("u50", baseProfile("u50"));
+    expect(getCached("u0")).not.toBeNull();
+    expect(getCached("u1")).toBeNull();
+  });
+});

--- a/MiniProfileCard.test.tsx
+++ b/MiniProfileCard.test.tsx
@@ -1,0 +1,181 @@
+import React from "react";
+import { render, waitFor, act, fireEvent } from "@testing-library/react-native";
+import { MiniProfileCard } from "./src/components/Profile/MiniProfileCard";
+import { clearCache } from "./src/services/profile/miniProfileCache";
+
+const mockGetUserProfile = jest.fn();
+jest.mock("./src/services/UserService", () => ({
+  UserService: {
+    getInstance: () => ({
+      getUserProfile: (...args: unknown[]) => mockGetUserProfile(...args),
+    }),
+  },
+}));
+
+const mockGetBlockedUsers = jest.fn();
+const mockGetContacts = jest.fn();
+const mockBlockUser = jest.fn();
+const mockUnblockUser = jest.fn();
+jest.mock("./src/services/contacts/api", () => ({
+  contactsAPI: {
+    getBlockedUsers: () => mockGetBlockedUsers(),
+    getContacts: () => mockGetContacts(),
+    blockUser: (id: string) => mockBlockUser(id),
+    unblockUser: (id: string) => mockUnblockUser(id),
+  },
+}));
+
+const buildProfile = (overrides = {}) => ({
+  id: "u1",
+  firstName: "Alice",
+  lastName: "Doe",
+  username: "alice",
+  phoneNumber: "",
+  biography: "Bio courte",
+  isOnline: false,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+  ...overrides,
+});
+
+beforeEach(() => {
+  clearCache();
+  mockGetUserProfile.mockReset();
+  mockGetBlockedUsers.mockReset().mockResolvedValue({ blocked: [], total: 0 });
+  mockGetContacts.mockReset().mockResolvedValue({ contacts: [], total: 0 });
+  mockBlockUser.mockReset().mockResolvedValue(undefined);
+  mockUnblockUser.mockReset().mockResolvedValue(undefined);
+});
+
+describe("MiniProfileCard", () => {
+  it("renders the loading state initially", () => {
+    mockGetUserProfile.mockReturnValue(new Promise(() => {})); // never resolves
+    const { getByTestId } = render(
+      <MiniProfileCard
+        userId="u1"
+        currentUserId="me"
+        onClose={() => {}}
+        onOpenFullProfile={() => {}}
+        onOpenSelfProfile={() => {}}
+        onMessage={() => {}}
+      />,
+    );
+    expect(getByTestId("mini-profile-card-loading")).toBeTruthy();
+  });
+
+  it("renders the loaded state with profile data", async () => {
+    mockGetUserProfile.mockResolvedValue({
+      success: true,
+      profile: buildProfile(),
+    });
+    const { getByText, getByTestId } = render(
+      <MiniProfileCard
+        userId="u1"
+        currentUserId="me"
+        onClose={() => {}}
+        onOpenFullProfile={() => {}}
+        onOpenSelfProfile={() => {}}
+        onMessage={() => {}}
+      />,
+    );
+    await waitFor(() => {
+      expect(getByTestId("mini-profile-card-loaded")).toBeTruthy();
+    });
+    expect(getByText("Alice Doe")).toBeTruthy();
+    expect(getByText("@alice")).toBeTruthy();
+    expect(getByText("Bio courte")).toBeTruthy();
+  });
+
+  it("renders the error state with retry button on network failure", async () => {
+    mockGetUserProfile.mockRejectedValue(new Error("network down"));
+    const { getByTestId, getByText } = render(
+      <MiniProfileCard
+        userId="u1"
+        currentUserId="me"
+        onClose={() => {}}
+        onOpenFullProfile={() => {}}
+        onOpenSelfProfile={() => {}}
+        onMessage={() => {}}
+      />,
+    );
+    await waitFor(() => {
+      expect(getByTestId("mini-profile-card-error")).toBeTruthy();
+    });
+    expect(getByText("Reessayer")).toBeTruthy();
+  });
+
+  it("renders the blocked badge when the user is in the blocked list", async () => {
+    mockGetUserProfile.mockResolvedValue({
+      success: true,
+      profile: buildProfile(),
+    });
+    mockGetBlockedUsers.mockResolvedValue({
+      blocked: [
+        {
+          id: "b1",
+          user_id: "me",
+          blocked_user_id: "u1",
+          blocked_at: "",
+        },
+      ],
+      total: 1,
+    });
+    const { getByTestId } = render(
+      <MiniProfileCard
+        userId="u1"
+        currentUserId="me"
+        onClose={() => {}}
+        onOpenFullProfile={() => {}}
+        onOpenSelfProfile={() => {}}
+        onMessage={() => {}}
+      />,
+    );
+    await waitFor(() => {
+      expect(getByTestId("mini-profile-card-blocked")).toBeTruthy();
+    });
+  });
+
+  it("renders the notFound state on a 404 response", async () => {
+    mockGetUserProfile.mockResolvedValue({
+      success: false,
+      message: "Erreur 404",
+    });
+    const { getByTestId, getByText } = render(
+      <MiniProfileCard
+        userId="u1"
+        currentUserId="me"
+        onClose={() => {}}
+        onOpenFullProfile={() => {}}
+        onOpenSelfProfile={() => {}}
+        onMessage={() => {}}
+      />,
+    );
+    await waitFor(() => {
+      expect(getByTestId("mini-profile-card-notfound")).toBeTruthy();
+    });
+    expect(getByText("Compte supprime")).toBeTruthy();
+  });
+
+  it("triggers onMessage when the user taps Message", async () => {
+    mockGetUserProfile.mockResolvedValue({
+      success: true,
+      profile: buildProfile(),
+    });
+    const onMessage = jest.fn();
+    const { getByText } = render(
+      <MiniProfileCard
+        userId="u1"
+        currentUserId="me"
+        onClose={() => {}}
+        onOpenFullProfile={() => {}}
+        onOpenSelfProfile={() => {}}
+        onMessage={onMessage}
+      />,
+    );
+    await waitFor(() => getByText("Message"));
+    await act(async () => {
+      fireEvent.press(getByText("Message"));
+    });
+    expect(onMessage).toHaveBeenCalled();
+  });
+});

--- a/MiniProfileCardStore.test.ts
+++ b/MiniProfileCardStore.test.ts
@@ -1,0 +1,36 @@
+import { useMiniProfileCardStore } from "./src/store/miniProfileCardStore";
+
+beforeEach(() => {
+  useMiniProfileCardStore.getState().close();
+});
+
+describe("miniProfileCardStore singleton", () => {
+  it("starts closed", () => {
+    const s = useMiniProfileCardStore.getState();
+    expect(s.isOpen).toBe(false);
+    expect(s.userId).toBeNull();
+  });
+
+  it("open sets userId and isOpen", () => {
+    useMiniProfileCardStore.getState().open("u1", null);
+    const s = useMiniProfileCardStore.getState();
+    expect(s.isOpen).toBe(true);
+    expect(s.userId).toBe("u1");
+  });
+
+  it("openning B over A switches to B (singleton)", () => {
+    useMiniProfileCardStore.getState().open("uA", null);
+    useMiniProfileCardStore.getState().open("uB", null);
+    const s = useMiniProfileCardStore.getState();
+    expect(s.isOpen).toBe(true);
+    expect(s.userId).toBe("uB");
+  });
+
+  it("close clears state", () => {
+    useMiniProfileCardStore.getState().open("u1", null);
+    useMiniProfileCardStore.getState().close();
+    const s = useMiniProfileCardStore.getState();
+    expect(s.isOpen).toBe(false);
+    expect(s.userId).toBeNull();
+  });
+});

--- a/ProfileTrigger.test.tsx
+++ b/ProfileTrigger.test.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { Text } from "react-native";
+import { render, fireEvent } from "@testing-library/react-native";
+import { ProfileTrigger } from "./src/components/Profile/ProfileTrigger";
+import { useMiniProfileCardStore } from "./src/store/miniProfileCardStore";
+
+beforeEach(() => {
+  useMiniProfileCardStore.getState().close();
+  const Platform = require("react-native").Platform;
+  Platform.OS = "ios";
+});
+
+describe("ProfileTrigger", () => {
+  it("opens the mini-card on long press (touch)", () => {
+    const { getByText } = render(
+      <ProfileTrigger userId="u1">
+        <Text>avatar</Text>
+      </ProfileTrigger>,
+    );
+    fireEvent(getByText("avatar"), "longPress");
+    const s = useMiniProfileCardStore.getState();
+    expect(s.isOpen).toBe(true);
+    expect(s.userId).toBe("u1");
+  });
+
+  it("ignores a short press on touch (no card opened)", () => {
+    const { getByText } = render(
+      <ProfileTrigger userId="u1">
+        <Text>avatar</Text>
+      </ProfileTrigger>,
+    );
+    fireEvent.press(getByText("avatar"));
+    expect(useMiniProfileCardStore.getState().isOpen).toBe(false);
+  });
+});

--- a/docs/superpowers/specs/2026-05-09-mini-card-profil-design.md
+++ b/docs/superpowers/specs/2026-05-09-mini-card-profil-design.md
@@ -1,0 +1,160 @@
+# Mini-card profil — design
+
+Date : 2026-05-09
+Repo principal : `mobile-app`
+Repo secondaire (prérequis F2) : `user-service`, `mobile-app/Settings`
+Ticket Jira : à créer (WHISPR-XXXX) au moment du dispatch.
+
+## Contexte
+
+Les utilisateurs Whispr peuvent croiser un profil tiers à plusieurs endroits dans l'app : conversations, contacts, members d'un groupe, résultats de recherche. Aujourd'hui, le seul accès au profil tiers passe par `UserProfileScreen` (écran complet). Pour les interactions courtes (vérifier qui est l'expéditeur, voir un avatar plus grand, accéder rapidement à "envoyer un message"), un écran complet est trop lourd.
+
+L'objectif : afficher une mini-card profil légère sur clic gauche (desktop) ou appui long (mobile) sur n'importe quel avatar/nom utilisateur dans les listes.
+
+Sujet connexe : la feature **F2** (toggles privacy mobile manquants) doit être implémentée AVANT la mini-card pour que les gates `lastSeenPrivacy` et autres soient pilotables côté UI. Sans F2, le gate fonctionne déjà côté backend (default `CONTACTS`) mais l'utilisateur ne peut pas modifier son comportement.
+
+## Non-objectifs
+
+- Pas de remplacement de `UserProfileScreen`. La mini-card pointe vers cet écran via le bouton "Voir profil complet".
+- Pas de nouveau endpoint backend. On réutilise `GET /profile/:userId` existant qui applique déjà les privacy gates côté user-service.
+- Pas de chat embed. La mini-card est une vue read-only avec actions basiques.
+
+## Composants
+
+### `MiniProfileCard`
+
+Composant React Native standalone, autonome.
+
+- Props : `userId: string`, `anchorRef: RefObject` (élément déclencheur pour positionnement), `onClose: () => void`.
+- Internal state : `loading`, `profile`, `error`, `relation` (`isContact | isBlocked | isSelf | unknown`).
+- Rendu :
+  - Photo profil ronde (large, ~80x80).
+  - Display name = `firstName + lastName` (fallback `username`).
+  - `@username` en sous-titre.
+  - Bio courte (2 lignes max, ellipsis).
+  - Last seen formaté (ex : "vu il y a 5 min", "en ligne", "vu hier"). Caché si la réponse backend ne contient pas le champ (privacy gate appliqué côté serveur).
+  - Boutons (utilisateur tiers) : `Message` / `Voir profil complet` / `Bloquer` (`Débloquer` si déjà bloqué).
+  - Bouton (self) : `Modifier mon profil` → `MyProfileScreen`.
+  - Compte supprimé : photo placeholder + "Compte supprimé".
+- Animation : fade-in 150ms.
+
+### `useMiniProfileCard()` hook
+
+Hook singleton (Zustand store ou Context dédié) qui maintient au plus une mini-card visible.
+
+- API : `open(userId, anchorRef)`, `close()`, `currentUserId`, `isOpen`.
+- Comportement : ouvrir une mini-card B alors que A est ouverte → close A puis open B.
+- Click outside / Escape → `close()`.
+
+### `ProfileTrigger`
+
+Wrapper réutilisable qui détecte le device et bind le bon handler.
+
+- Props : `userId: string`, `children: ReactNode`.
+- Sur device tactile (PWA mobile + iOS/Android natif) : `onLongPress` 500ms.
+- Sur device souris (desktop web) : `onPress` (clic gauche).
+- Détection automatique via `Pressable` (`delayLongPress={500}`).
+- Capture `anchorRef` du child et passe à `useMiniProfileCard().open(userId, ref)`.
+
+### Cache LRU
+
+Map LRU en mémoire (`Map<userId, { profile, fetchedAt }>` avec eviction LIFO size 50).
+
+- Reset au reload app.
+- TTL implicite de 5 min : si `Date.now() - fetchedAt > 5*60*1000`, refetch en background tout en affichant la version cachée immédiatement.
+
+## Flux de données
+
+1. User clique sur avatar dans `ConversationsListScreen`.
+2. `ProfileTrigger.onPress` capture `event` + `anchorRef`.
+3. Appel `useMiniProfileCard().open(userId, anchorRef)`.
+4. `MiniProfileCard` monté (singleton).
+5. Lookup cache LRU :
+   - Cache HIT frais (< 5 min) → render immediate.
+   - Cache HIT stale → render immediate puis refetch background.
+   - Cache MISS → loading state puis fetch.
+6. `UserService.getUserProfile(userId)` → `GET /profile/:userId` user-service.
+7. Réponse mappée + relation calculée (contact ? bloqué ? self ?).
+8. State updated → render final.
+
+## Gestion des erreurs
+
+| Cas | Comportement |
+|-----|--------------|
+| Network error | State `error` dans la card + bouton "Réessayer" |
+| 404 user not found | "Cet utilisateur n'existe plus" + bouton "Fermer" |
+| 403 / user a bloqué reader | "Indisponible" + photo placeholder |
+| Timeout 8s | Considéré comme network error |
+
+## Privacy gates last seen
+
+Backend `user-service` applique déjà les règles `lastSeenPrivacy` :
+
+- `EVERYONE` → `lastSeen` retourné dans la réponse.
+- `CONTACTS` → `lastSeen` retourné si `reader` est dans les contacts du `target`, sinon null.
+- `NOBODY` → `lastSeen` toujours null.
+
+Mobile : si `lastSeen === null`, ne pas afficher la ligne. Pas de logique mobile dédiée pour reproduire les règles.
+
+Idem pour les autres champs privacy (firstName, lastName, biography, profilePicture) : déjà masqués backend.
+
+## Layout et positionnement
+
+### Desktop / web
+
+- Popover absolu ancré au DOM rect du trigger.
+- Auto-flip si proche du bord (top → bottom, left → right).
+- Lib : `react-native-popover-view` ou implémentation custom avec `measure()` + position absolute.
+
+### Mobile (touch)
+
+- Bottom sheet centered (Modal RN) ou `react-native-modal`.
+- Hauteur auto, largeur 90% screen, max-width 360.
+- Backdrop sombre 60%.
+
+### Tests
+
+- Snapshot `MiniProfileCard` × 4 states : `loading`, `loaded`, `error`, `blocked`.
+- Hook `useMiniProfileCard` singleton : open A puis open B → A close auto.
+- `ProfileTrigger` : long-press 500ms touch, click mouse, no-op autres gestures.
+- Integration : long-press avatar `ConversationsList` → card open → click "Voir profil complet" → navigation `UserProfile`.
+
+## Locations à instrumenter (initial)
+
+| Lieu | Fichier | Élément trigger |
+|------|---------|-----------------|
+| Liste conversations | `src/screens/Chat/ConversationsListScreen.tsx` | Avatar de l'item |
+| Bulle message (groupe) | `src/components/Chat/MessageBubble.tsx` | Avatar à gauche |
+| Liste contacts | `src/screens/Contacts/ContactsScreen.tsx` | Avatar de l'item |
+| Members groupe | `src/screens/Groups/GroupDetailsScreen.tsx` | Avatar member |
+| Résultats recherche | `src/screens/Search/...` | Avatar utilisateur |
+
+Exclu : `ChatScreen` header (déjà bindé à navigation profile complet).
+
+## Effort estimé
+
+- mobile-app : ~400 LoC code + ~100 LoC tests.
+- user-service : aucune modif (réutilise endpoint).
+- Aucun changement d'API.
+- 1 ticket Jira `[WHISPR-XXXX] feat(profile): mini-card profil click gauche / appui long`.
+
+## Dépendances
+
+- F2 (toggles privacy mobile) à finir avant pour cohérence end-to-end.
+- Aucune dépendance bloquante côté backend.
+
+## Risques
+
+- Conflit potentiel avec d'autres handlers `onPress` existants sur les avatars (notamment dans MessageBubble et ContactsScreen). À vérifier en exploration avant implémentation : si un autre handler existe, le `ProfileTrigger` doit le préserver via `onPressIn`/`onPress` chaining.
+- React-native-web compatibility de `react-native-popover-view` : à vérifier avant de figer la lib. Fallback custom si KO.
+- Cache LRU non-persistant : un user qui ouvre plusieurs cards en boucle après reload paie un fetch chaque première vue. Acceptable pour MVP, AsyncStorage en V2 si pertinent.
+
+## Étapes d'implémentation
+
+1. Implémenter F2 (toggles privacy mobile) — séparé.
+2. Créer le store/hook `useMiniProfileCard`.
+3. Créer le composant `MiniProfileCard` avec rendu + states.
+4. Créer le wrapper `ProfileTrigger`.
+5. Brancher sur les 5 locations.
+6. Tester sur iOS / Android / web mobile / web desktop.
+7. Tests unitaires + integration.

--- a/src/components/Chat/ConversationItem.tsx
+++ b/src/components/Chat/ConversationItem.tsx
@@ -23,6 +23,7 @@ import { useAuth } from "../../context/AuthContext";
 import { getConversationDisplayName } from "../../utils";
 import { messagingAPI } from "../../services/messaging/api";
 import { buildConversationPreviewSnippet } from "../../utils/conversationPreview";
+import { ProfileTrigger } from "../Profile/ProfileTrigger";
 
 const EMPTY_GROUP_AVATARS: Array<{ uri?: string; name: string }> = [];
 
@@ -351,6 +352,17 @@ export const ConversationItem: React.FC<ConversationItemProps> = ({
                   </View>
                 ))}
               </View>
+            ) : conversation.type === "direct" && otherUserId ? (
+              // mini-card profil sur clic gauche / appui long de l'avatar direct
+              <ProfileTrigger userId={otherUserId}>
+                <Avatar
+                  size={48}
+                  uri={conversation.avatar_url}
+                  name={displayName}
+                  showOnlineBadge
+                  isOnline={isOtherOnline}
+                />
+              </ProfileTrigger>
             ) : (
               <Avatar
                 size={48}

--- a/src/components/Chat/MessageBubble.tsx
+++ b/src/components/Chat/MessageBubble.tsx
@@ -12,6 +12,7 @@ import {
   Platform,
 } from "react-native";
 import { Avatar } from "./Avatar";
+import { ProfileTrigger } from "../Profile/ProfileTrigger";
 import {
   useSharedValue,
   useAnimatedStyle,
@@ -738,7 +739,9 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
               <View style={styles.receivedRow}>
                 <View style={styles.avatarSlot}>
                   {!isConsecutive ? (
-                    <Avatar uri={safeAvatarUri} name={senderName} size={32} />
+                    <ProfileTrigger userId={message.sender_id}>
+                      <Avatar uri={safeAvatarUri} name={senderName} size={32} />
+                    </ProfileTrigger>
                   ) : null}
                 </View>
                 <View style={styles.receivedBubbleWrapper}>

--- a/src/components/Contacts/ContactItem.tsx
+++ b/src/components/Contacts/ContactItem.tsx
@@ -8,6 +8,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { BlurView } from "expo-blur";
 import { Contact } from "../../types/contact";
 import { Avatar } from "../Chat/Avatar";
+import { ProfileTrigger } from "../Profile/ProfileTrigger";
 import { useTheme } from "../../context/ThemeContext";
 import { colors, withOpacity } from "../../theme/colors";
 
@@ -50,15 +51,17 @@ export const ContactItem: React.FC<ContactItemProps> = ({
         onLongPress={handleLongPress}
         activeOpacity={0.82}
       >
-        <View style={styles.avatarRing}>
-          <Avatar
-            uri={user?.avatar_url}
-            name={displayName}
-            size={52}
-            showOnlineBadge={false}
-            isOnline={false}
-          />
-        </View>
+        <ProfileTrigger userId={contact.contact_id}>
+          <View style={styles.avatarRing}>
+            <Avatar
+              uri={user?.avatar_url}
+              name={displayName}
+              size={52}
+              showOnlineBadge={false}
+              isOnline={false}
+            />
+          </View>
+        </ProfileTrigger>
         <View style={styles.info}>
           <View style={styles.nameRow}>
             <Text

--- a/src/components/Profile/MiniProfileCard.tsx
+++ b/src/components/Profile/MiniProfileCard.tsx
@@ -1,0 +1,484 @@
+/**
+ * MiniProfileCard - aperçu rapide d'un profil utilisateur ouvert via clic
+ * gauche (web desktop) ou appui long (touch). Read-only, ne remplace pas
+ * UserProfileScreen.
+ *
+ * Le composant ne gere PAS le positionnement : il rend uniquement le contenu
+ * de la card. Le wrapping (Modal mobile / Popover web) est dans le host.
+ */
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ActivityIndicator,
+  Pressable,
+  Image,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { colors, withOpacity } from "../../theme/colors";
+import { UserService, UserProfile } from "../../services/UserService";
+import { contactsAPI } from "../../services/contacts/api";
+import { getCached, setCached } from "../../services/profile/miniProfileCache";
+
+type Relation = "self" | "blocked" | "contact" | "unknown";
+type CardState = "loading" | "loaded" | "error" | "notFound";
+
+interface ErrorInfo {
+  kind: "network" | "forbidden" | "timeout";
+  retriable: boolean;
+}
+
+interface MiniProfileCardProps {
+  userId: string;
+  /** id du user authentifie - sert a detecter le mode "self" */
+  currentUserId: string | null;
+  onClose: () => void;
+  onOpenFullProfile: () => void;
+  onOpenSelfProfile: () => void;
+  onMessage: () => void;
+}
+
+const FETCH_TIMEOUT_MS = 8000;
+
+function fetchWithTimeout<T>(p: Promise<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error("timeout")), FETCH_TIMEOUT_MS);
+    p.then(
+      (v) => {
+        clearTimeout(t);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(t);
+        reject(e);
+      },
+    );
+  });
+}
+
+function formatLastSeen(iso?: string): string | null {
+  if (!iso) return null;
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return null;
+  const diffMin = Math.max(0, Math.round((Date.now() - ts) / 60000));
+  if (diffMin < 1) return "vu a l'instant";
+  if (diffMin < 60) return `vu il y a ${diffMin} min`;
+  const diffH = Math.round(diffMin / 60);
+  if (diffH < 24) return `vu il y a ${diffH} h`;
+  const diffD = Math.round(diffH / 24);
+  if (diffD === 1) return "vu hier";
+  if (diffD < 7) return `vu il y a ${diffD} j`;
+  return `vu le ${new Date(ts).toLocaleDateString("fr-FR")}`;
+}
+
+function buildDisplayName(profile: UserProfile): string {
+  const full = `${profile.firstName ?? ""} ${profile.lastName ?? ""}`.trim();
+  return full.length > 0 ? full : profile.username || "Utilisateur";
+}
+
+export const MiniProfileCard: React.FC<MiniProfileCardProps> = ({
+  userId,
+  currentUserId,
+  onClose,
+  onOpenFullProfile,
+  onOpenSelfProfile,
+  onMessage,
+}) => {
+  const [state, setState] = useState<CardState>("loading");
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [error, setError] = useState<ErrorInfo | null>(null);
+  const [relation, setRelation] = useState<Relation>("unknown");
+  const [busyAction, setBusyAction] = useState<null | "block" | "unblock">(
+    null,
+  );
+
+  const isSelf = !!currentUserId && currentUserId === userId;
+
+  const computeRelation = useCallback(
+    async (id: string): Promise<Relation> => {
+      if (currentUserId && currentUserId === id) return "self";
+      try {
+        const { blocked } = await contactsAPI.getBlockedUsers();
+        if (blocked.some((b) => b.blocked_user_id === id)) return "blocked";
+      } catch {
+        // ne pas bloquer le rendu si la liste blocked echoue
+      }
+      try {
+        const { contacts } = await contactsAPI.getContacts();
+        if (contacts.some((c) => c.contact_id === id)) return "contact";
+      } catch {
+        // idem
+      }
+      return "unknown";
+    },
+    [currentUserId],
+  );
+
+  const load = useCallback(
+    async (opts: { forceRefresh?: boolean } = {}) => {
+      // 1. cache hit
+      const cached = getCached(userId);
+      if (cached && !opts.forceRefresh) {
+        setProfile(cached.profile);
+        setState("loaded");
+        // si stale, on continue jusqu'au fetch en background
+        if (!cached.isStale) {
+          // on resoud quand meme la relation
+          computeRelation(userId).then(setRelation);
+          return;
+        }
+      } else if (!cached) {
+        setState("loading");
+      }
+
+      try {
+        const result = await fetchWithTimeout(
+          UserService.getInstance().getUserProfile(userId),
+        );
+        if (!result.success || !result.profile) {
+          // 404 -> on l'identifie par message contenant "404"
+          if (result.message?.includes("404")) {
+            setState("notFound");
+            return;
+          }
+          if (result.message?.includes("403")) {
+            setError({ kind: "forbidden", retriable: false });
+            setState("error");
+            return;
+          }
+          setError({ kind: "network", retriable: true });
+          setState("error");
+          return;
+        }
+        setCached(userId, result.profile);
+        setProfile(result.profile);
+        setState("loaded");
+        const rel = await computeRelation(userId);
+        setRelation(rel);
+      } catch (e) {
+        const isTimeout = (e as Error)?.message === "timeout";
+        setError({
+          kind: isTimeout ? "timeout" : "network",
+          retriable: true,
+        });
+        // si on a deja une version cachee on reste en loaded, sinon error
+        if (!cached) setState("error");
+      }
+    },
+    [userId, computeRelation],
+  );
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleBlock = useCallback(async () => {
+    if (busyAction) return;
+    setBusyAction("block");
+    try {
+      await contactsAPI.blockUser(userId);
+      setRelation("blocked");
+    } catch {
+      // si l'appel rate, on garde le relation precedent
+    } finally {
+      setBusyAction(null);
+    }
+  }, [userId, busyAction]);
+
+  const handleUnblock = useCallback(async () => {
+    if (busyAction) return;
+    setBusyAction("unblock");
+    try {
+      await contactsAPI.unblockUser(userId);
+      setRelation("contact");
+    } catch {
+      // idem
+    } finally {
+      setBusyAction(null);
+    }
+  }, [userId, busyAction]);
+
+  // ----- rendu states -----
+
+  if (state === "loading") {
+    return (
+      <View style={styles.card} testID="mini-profile-card-loading">
+        <ActivityIndicator color={colors.primary.main} />
+        <Text style={styles.helperText}>Chargement…</Text>
+      </View>
+    );
+  }
+
+  if (state === "notFound") {
+    return (
+      <View style={styles.card} testID="mini-profile-card-notfound">
+        <View style={styles.placeholder}>
+          <Ionicons name="person-outline" size={36} color="#FFF" />
+        </View>
+        <Text style={styles.title}>Compte supprime</Text>
+        <Text style={styles.helperText}>Cet utilisateur n'existe plus.</Text>
+        <Pressable
+          style={[styles.btn, styles.btnPrimary]}
+          onPress={onClose}
+          accessibilityRole="button"
+        >
+          <Text style={styles.btnPrimaryText}>Fermer</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  if (state === "error" && (!profile || !error)) {
+    return (
+      <View style={styles.card} testID="mini-profile-card-error">
+        <View style={styles.placeholder}>
+          <Ionicons name="alert-circle-outline" size={36} color="#FFF" />
+        </View>
+        <Text style={styles.title}>
+          {error?.kind === "forbidden" ? "Indisponible" : "Erreur"}
+        </Text>
+        {error?.kind !== "forbidden" && (
+          <Text style={styles.helperText}>
+            Impossible de charger le profil.
+          </Text>
+        )}
+        {error?.retriable && (
+          <Pressable
+            style={[styles.btn, styles.btnPrimary]}
+            onPress={() => void load({ forceRefresh: true })}
+            accessibilityRole="button"
+          >
+            <Text style={styles.btnPrimaryText}>Reessayer</Text>
+          </Pressable>
+        )}
+      </View>
+    );
+  }
+
+  if (!profile) return null;
+
+  const displayName = buildDisplayName(profile);
+  const lastSeenText = profile.isOnline
+    ? "en ligne"
+    : formatLastSeen(profile.lastSeen);
+
+  return (
+    <View style={styles.card} testID="mini-profile-card-loaded">
+      {profile.profilePicture ? (
+        <Image
+          source={{ uri: profile.profilePicture }}
+          style={styles.avatar}
+          accessibilityIgnoresInvertColors
+        />
+      ) : (
+        <View style={styles.avatar}>
+          <Text style={styles.avatarFallback}>
+            {displayName.slice(0, 1).toUpperCase()}
+          </Text>
+        </View>
+      )}
+
+      <Text style={styles.title}>{displayName}</Text>
+      {profile.username ? (
+        <Text style={styles.subtitle}>@{profile.username}</Text>
+      ) : null}
+
+      {profile.biography ? (
+        <Text style={styles.bio} numberOfLines={2}>
+          {profile.biography}
+        </Text>
+      ) : null}
+
+      {lastSeenText ? (
+        <Text style={styles.lastSeen}>{lastSeenText}</Text>
+      ) : null}
+
+      {relation === "blocked" ? (
+        <View style={styles.blockedBadge} testID="mini-profile-card-blocked">
+          <Ionicons name="ban" size={14} color="#FFF" />
+          <Text style={styles.blockedBadgeText}>Bloque</Text>
+        </View>
+      ) : null}
+
+      <View style={styles.actionsRow}>
+        {isSelf ? (
+          <Pressable
+            style={[styles.btn, styles.btnPrimary]}
+            onPress={onOpenSelfProfile}
+            accessibilityRole="button"
+          >
+            <Text style={styles.btnPrimaryText}>Modifier mon profil</Text>
+          </Pressable>
+        ) : (
+          <>
+            {relation !== "blocked" ? (
+              <Pressable
+                style={[styles.btn, styles.btnPrimary]}
+                onPress={onMessage}
+                accessibilityRole="button"
+              >
+                <Ionicons name="chatbubble" size={16} color="#FFF" />
+                <Text style={styles.btnPrimaryText}>Message</Text>
+              </Pressable>
+            ) : null}
+            <Pressable
+              style={[styles.btn, styles.btnSecondary]}
+              onPress={onOpenFullProfile}
+              accessibilityRole="button"
+            >
+              <Text style={styles.btnSecondaryText}>Voir profil complet</Text>
+            </Pressable>
+            {relation === "blocked" ? (
+              <Pressable
+                style={[styles.btn, styles.btnSecondary]}
+                onPress={handleUnblock}
+                disabled={busyAction !== null}
+                accessibilityRole="button"
+              >
+                <Text style={styles.btnSecondaryText}>
+                  {busyAction === "unblock" ? "…" : "Debloquer"}
+                </Text>
+              </Pressable>
+            ) : (
+              <Pressable
+                style={[styles.btn, styles.btnDanger]}
+                onPress={handleBlock}
+                disabled={busyAction !== null}
+                accessibilityRole="button"
+              >
+                <Text style={styles.btnDangerText}>
+                  {busyAction === "block" ? "…" : "Bloquer"}
+                </Text>
+              </Pressable>
+            )}
+          </>
+        )}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: colors.background.darkCard,
+    borderRadius: 20,
+    padding: 20,
+    alignItems: "center",
+    width: "100%",
+    maxWidth: 360,
+    gap: 6,
+  },
+  avatar: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    backgroundColor: withOpacity(colors.primary.main, 0.4),
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 4,
+  },
+  avatarFallback: {
+    color: "#FFF",
+    fontSize: 28,
+    fontWeight: "700",
+  },
+  placeholder: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    backgroundColor: withOpacity("#FFFFFF", 0.1),
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 4,
+  },
+  title: {
+    color: "#FFF",
+    fontSize: 18,
+    fontWeight: "700",
+    textAlign: "center",
+  },
+  subtitle: {
+    color: withOpacity("#FFFFFF", 0.7),
+    fontSize: 14,
+  },
+  bio: {
+    color: withOpacity("#FFFFFF", 0.85),
+    fontSize: 13,
+    textAlign: "center",
+    marginTop: 6,
+    lineHeight: 18,
+  },
+  lastSeen: {
+    color: withOpacity("#FFFFFF", 0.55),
+    fontSize: 12,
+    marginTop: 4,
+  },
+  helperText: {
+    color: withOpacity("#FFFFFF", 0.7),
+    fontSize: 13,
+    marginTop: 6,
+    textAlign: "center",
+  },
+  blockedBadge: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    backgroundColor: colors.ui.error,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 12,
+    marginTop: 6,
+  },
+  blockedBadgeText: {
+    color: "#FFF",
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  actionsRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "center",
+    gap: 8,
+    marginTop: 14,
+    width: "100%",
+  },
+  btn: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    borderRadius: 12,
+    minWidth: 110,
+  },
+  btnPrimary: {
+    backgroundColor: colors.primary.main,
+  },
+  btnPrimaryText: {
+    color: "#FFF",
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  btnSecondary: {
+    backgroundColor: withOpacity("#FFFFFF", 0.1),
+    borderWidth: 1,
+    borderColor: withOpacity("#FFFFFF", 0.18),
+  },
+  btnSecondaryText: {
+    color: "#FFF",
+    fontSize: 14,
+    fontWeight: "500",
+  },
+  btnDanger: {
+    backgroundColor: withOpacity(colors.ui.error, 0.18),
+    borderWidth: 1,
+    borderColor: withOpacity(colors.ui.error, 0.4),
+  },
+  btnDangerText: {
+    color: colors.ui.error,
+    fontSize: 14,
+    fontWeight: "600",
+  },
+});

--- a/src/components/Profile/MiniProfileCardHost.tsx
+++ b/src/components/Profile/MiniProfileCardHost.tsx
@@ -1,0 +1,142 @@
+/**
+ * MiniProfileCardHost - mount point pour la mini-card profil. Doit etre rendu
+ * une fois en haut de l'app (apres NavigationContainer pour pouvoir naviguer).
+ *
+ * Sur natif (iOS/Android) on utilise Modal avec backdrop sombre.
+ * Sur web on utilise un overlay absolu en plein ecran avec la card centree
+ * (le positionnement par rapport a l'anchor est laisse a une V2 ; pour le MVP
+ * la card est centree, ce qui marche sur petits ecrans web et est lisible
+ * partout).
+ *
+ * Click outside / Escape / back press = close.
+ */
+import React, { useCallback, useEffect } from "react";
+import {
+  Modal,
+  View,
+  StyleSheet,
+  Pressable,
+  Platform,
+  Alert,
+} from "react-native";
+import { useNavigation } from "@react-navigation/native";
+import type { StackNavigationProp } from "@react-navigation/stack";
+import { useMiniProfileCard } from "../../store/miniProfileCardStore";
+import { useAuth } from "../../context/AuthContext";
+import { messagingAPI } from "../../services/messaging/api";
+import { MiniProfileCard } from "./MiniProfileCard";
+import type { AuthStackParamList } from "../../navigation/AuthNavigator";
+
+export const MiniProfileCardHost: React.FC = () => {
+  const { isOpen, currentUserId: viewedUserId, close } = useMiniProfileCard();
+  const { userId: authUserId } = useAuth();
+  const navigation = useNavigation<StackNavigationProp<AuthStackParamList>>();
+
+  // Echap fermeture sur web
+  useEffect(() => {
+    if (!isOpen || Platform.OS !== "web") return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    const w = globalThis as unknown as {
+      addEventListener: (t: string, h: (e: KeyboardEvent) => void) => void;
+      removeEventListener: (t: string, h: (e: KeyboardEvent) => void) => void;
+    };
+    w.addEventListener("keydown", onKey);
+    return () => {
+      w.removeEventListener("keydown", onKey);
+    };
+  }, [isOpen, close]);
+
+  const handleOpenFullProfile = useCallback(() => {
+    if (!viewedUserId) return;
+    close();
+    navigation.navigate("UserProfile", { userId: viewedUserId });
+  }, [viewedUserId, close, navigation]);
+
+  const handleOpenSelfProfile = useCallback(() => {
+    close();
+    navigation.navigate("MyProfile");
+  }, [close, navigation]);
+
+  const handleMessage = useCallback(async () => {
+    if (!viewedUserId) return;
+    try {
+      const conversation =
+        await messagingAPI.createDirectConversation(viewedUserId);
+      close();
+      navigation.navigate("Chat", { conversationId: conversation.id });
+    } catch (e: unknown) {
+      const message =
+        e instanceof Error ? e.message : "Impossible de creer la conversation";
+      Alert.alert("Erreur", message);
+    }
+  }, [viewedUserId, close, navigation]);
+
+  if (!isOpen || !viewedUserId) return null;
+
+  const cardEl = (
+    <MiniProfileCard
+      userId={viewedUserId}
+      currentUserId={authUserId}
+      onClose={close}
+      onOpenFullProfile={handleOpenFullProfile}
+      onOpenSelfProfile={handleOpenSelfProfile}
+      onMessage={handleMessage}
+    />
+  );
+
+  if (Platform.OS === "web") {
+    return (
+      <View style={styles.webOverlay} pointerEvents="auto">
+        <Pressable style={StyleSheet.absoluteFill} onPress={close} />
+        <View style={styles.webCenter}>{cardEl}</View>
+      </View>
+    );
+  }
+
+  return (
+    <Modal
+      visible={isOpen}
+      transparent
+      animationType="fade"
+      onRequestClose={close}
+    >
+      <Pressable style={styles.backdrop} onPress={close}>
+        <Pressable onPress={(e) => e.stopPropagation()} style={styles.sheet}>
+          {cardEl}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.6)",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 16,
+  },
+  sheet: {
+    width: "90%",
+    maxWidth: 360,
+    alignItems: "center",
+  },
+  webOverlay: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: "rgba(0,0,0,0.6)",
+    zIndex: 9999,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  webCenter: {
+    width: "90%",
+    maxWidth: 360,
+  },
+});

--- a/src/components/Profile/ProfileTrigger.tsx
+++ b/src/components/Profile/ProfileTrigger.tsx
@@ -1,0 +1,82 @@
+/**
+ * ProfileTrigger - wrapper qui declenche l'ouverture de la mini-card profil.
+ *
+ * Comportement :
+ * - Touch (PWA mobile + iOS/Android natifs) : appui long 500ms ouvre la card.
+ *   Un tap court ne fait rien au niveau du trigger : il propage donc au
+ *   parent, ce qui preserve d'eventuels onPress existants (ex: navigation).
+ * - Mouse (web desktop) : clic gauche court ouvre la card. Le trigger
+ *   stoppe la propagation pour eviter qu'un onPress parent navigate aussi.
+ *
+ * On detecte le mode via Platform.OS et l'event source : sur web, on attache
+ * un listener click DOM tandis que sur natif on utilise Pressable + delayLongPress.
+ */
+import React, { useCallback, useRef } from "react";
+import { Pressable, Platform, View, GestureResponderEvent } from "react-native";
+import { useMiniProfileCard } from "../../store/miniProfileCardStore";
+
+interface ProfileTriggerProps {
+  userId: string;
+  /**
+   * Si true, sur web le clic ouvre la card et la propagation est stoppee
+   * (utile quand un parent gere un autre onPress conflictuel). Default true.
+   */
+  stopPropagationOnWeb?: boolean;
+  children: React.ReactNode;
+}
+
+const LONG_PRESS_MS = 500;
+
+export const ProfileTrigger: React.FC<ProfileTriggerProps> = ({
+  userId,
+  stopPropagationOnWeb = true,
+  children,
+}) => {
+  const { open, close, isOpen, currentUserId } = useMiniProfileCard();
+  const ref = useRef<View>(null);
+
+  const triggerOpen = useCallback(() => {
+    // ouvrir B alors que A est ouverte = close A puis open B
+    if (isOpen && currentUserId !== userId) {
+      close();
+    }
+    open(userId, ref);
+  }, [open, close, isOpen, currentUserId, userId]);
+
+  // ---- web : on intercepte le clic DOM ----
+  if (Platform.OS === "web") {
+    const handleClick = (e: any) => {
+      if (stopPropagationOnWeb) {
+        e.stopPropagation?.();
+        e.preventDefault?.();
+      }
+      triggerOpen();
+    };
+    return (
+      <View
+        ref={ref}
+        // @ts-expect-error react-native-web accepte onClick
+        onClick={handleClick}
+        accessibilityRole="button"
+      >
+        {children}
+      </View>
+    );
+  }
+
+  // ---- natif : long-press 500ms ----
+  const handleLongPress = (_e: GestureResponderEvent) => {
+    triggerOpen();
+  };
+
+  return (
+    <Pressable
+      ref={ref as never}
+      onLongPress={handleLongPress}
+      delayLongPress={LONG_PRESS_MS}
+      accessibilityRole="button"
+    >
+      {children}
+    </Pressable>
+  );
+};

--- a/src/components/Profile/index.ts
+++ b/src/components/Profile/index.ts
@@ -2,3 +2,6 @@ export { ProfileHeader } from "./ProfileHeader";
 export { ProfilePictureBlock } from "./ProfilePictureBlock";
 export { ProfileFieldRow } from "./ProfileFieldRow";
 export { StatusChip } from "./StatusChip";
+export { MiniProfileCard } from "./MiniProfileCard";
+export { MiniProfileCardHost } from "./MiniProfileCardHost";
+export { ProfileTrigger } from "./ProfileTrigger";

--- a/src/screens/Groups/GroupDetailsScreen.tsx
+++ b/src/screens/Groups/GroupDetailsScreen.tsx
@@ -47,6 +47,7 @@ import { useAuth } from "../../context/AuthContext";
 import { colors, withOpacity } from "../../theme/colors";
 import { typography } from "../../theme/typography";
 import { Avatar } from "../../components/Chat/Avatar";
+import { ProfileTrigger } from "../../components/Profile/ProfileTrigger";
 import { logger } from "../../utils/logger";
 import {
   groupsAPI,
@@ -1013,12 +1014,14 @@ export const GroupDetailsScreen: React.FC = () => {
             }`}
             entering={FadeInDown.delay(150 + index * 50).springify()}
           >
-            <Avatar
-              uri={member.avatar_url}
-              name={member.display_name}
-              size={48}
-              showOnlineBadge={false}
-            />
+            <ProfileTrigger userId={member.user_id}>
+              <Avatar
+                uri={member.avatar_url}
+                name={member.display_name}
+                size={48}
+                showOnlineBadge={false}
+              />
+            </ProfileTrigger>
             <View style={styles.memberInfo}>
               <View style={styles.memberNameRow}>
                 <Text style={[styles.memberName, { color: colors.text.light }]}>

--- a/src/services/profile/miniProfileCache.ts
+++ b/src/services/profile/miniProfileCache.ts
@@ -1,0 +1,52 @@
+/**
+ * Cache LRU en memoire pour les profils utilisateurs charges via la mini-card.
+ * - taille max 50 entries (eviction LRU)
+ * - TTL implicite 5 min : au-dela, l'entry est consideree stale et le caller
+ *   est libre de refetch en background tout en affichant la version cachee.
+ */
+import { UserProfile } from "../UserService";
+
+interface CacheEntry {
+  profile: UserProfile;
+  fetchedAt: number;
+}
+
+const MAX_ENTRIES = 50;
+const STALE_AFTER_MS = 5 * 60 * 1000;
+
+const store = new Map<string, CacheEntry>();
+
+export function getCached(userId: string): {
+  profile: UserProfile;
+  isStale: boolean;
+} | null {
+  const entry = store.get(userId);
+  if (!entry) return null;
+  // refresh LRU position (delete + reinsert)
+  store.delete(userId);
+  store.set(userId, entry);
+  return {
+    profile: entry.profile,
+    isStale: Date.now() - entry.fetchedAt > STALE_AFTER_MS,
+  };
+}
+
+export function setCached(userId: string, profile: UserProfile): void {
+  if (store.has(userId)) {
+    store.delete(userId);
+  } else if (store.size >= MAX_ENTRIES) {
+    // eviction du moins recemment utilise (premiere clef de l'iter)
+    const oldestKey = store.keys().next().value;
+    if (oldestKey !== undefined) store.delete(oldestKey);
+  }
+  store.set(userId, { profile, fetchedAt: Date.now() });
+}
+
+export function clearCache(): void {
+  store.clear();
+}
+
+// helper test-only : on l'expose pour pouvoir verifier la taille / contenu
+export function _internalSize(): number {
+  return store.size;
+}

--- a/src/store/miniProfileCardStore.ts
+++ b/src/store/miniProfileCardStore.ts
@@ -1,0 +1,37 @@
+/**
+ * Store Zustand singleton qui maintient au plus une mini-card profil visible.
+ * Ouvrir une card alors qu'une autre est deja affichee = close A puis open B.
+ */
+import { RefObject } from "react";
+import { create } from "zustand";
+
+interface MiniProfileCardState {
+  isOpen: boolean;
+  userId: string | null;
+  /** ref du composant declencheur, sert a positionner le popover sur web */
+  anchorRef: RefObject<unknown> | null;
+}
+
+interface MiniProfileCardActions {
+  open: (userId: string, anchorRef: RefObject<unknown> | null) => void;
+  close: () => void;
+}
+
+export const useMiniProfileCardStore = create<
+  MiniProfileCardState & MiniProfileCardActions
+>((set) => ({
+  isOpen: false,
+  userId: null,
+  anchorRef: null,
+  open: (userId, anchorRef) => set({ isOpen: true, userId, anchorRef }),
+  close: () => set({ isOpen: false, userId: null, anchorRef: null }),
+}));
+
+/** API hook orientee usage cote composants (open/close raccourcis). */
+export function useMiniProfileCard() {
+  const open = useMiniProfileCardStore((s) => s.open);
+  const close = useMiniProfileCardStore((s) => s.close);
+  const isOpen = useMiniProfileCardStore((s) => s.isOpen);
+  const userId = useMiniProfileCardStore((s) => s.userId);
+  return { open, close, isOpen, currentUserId: userId };
+}


### PR DESCRIPTION
## Summary

Mini-card profil legere ouvrable au clic gauche (web desktop) ou appui long 500ms (touch) sur les avatars dans la liste conversations, contacts, members groupe et bulles de message en groupe. Reutilise GET /profile/:userId existant et applique deja les privacy gates cote backend.

- nouveau composant `MiniProfileCard` (4 states : loading, loaded, error, notFound) + bouton blocked badge
- store Zustand singleton `useMiniProfileCardStore` pour qu'une seule card soit visible
- wrapper `ProfileTrigger` qui detecte device (long-press touch / clic mouse)
- cache LRU in-memory taille 50, TTL 5 min, refresh background sur stale
- host monte au niveau App pour gerer Modal mobile / overlay web + Echap close
- branche sur `ConversationItem`, `ContactItem`, `MessageBubble` (groupe), `GroupDetailsScreen` members

## Test plan

- [x] Unit tests verts (`npm test` 896 / 94 suites)
- [x] Lint clean (0 errors)
- [x] TypeScript clean (`tsc --noEmit`)
- [ ] Tested on iOS simulator
- [ ] Tested on Android emulator
- [ ] Tested on web (preprod)

Closes WHISPR-1309