### PR TITLE
[WHISPR-1311] refactor(services): wrap console.log into conditional logger

### DIFF
--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -3,6 +3,7 @@ import { DeviceService } from "./DeviceService";
 import { SignalKeyService } from "./SignalKeyService";
 import { getApiBaseUrl } from "./apiBase";
 import { emitSessionExpired } from "./sessionEvents";
+import { logger } from "../utils/logger";
 
 // NotificationService.handle401 appelle AuthService.refreshTokens : un
 // import statique réciproque crée un cycle module qui, sous Hermes /
@@ -211,8 +212,9 @@ export const AuthService = {
             sessionDead = true;
             await TokenService.clearTokens();
             emitSessionExpired("refresh_failed");
-            console.warn(
-              "[AuthService] tokens cleared, sessionExpired event emitted",
+            logger.warn(
+              "AuthService",
+              "tokens cleared, sessionExpired event emitted",
             );
           } else if (isTransientFailure(status)) {
             // 5xx or network — auth-service is unreachable, not refusing.
@@ -221,10 +223,10 @@ export const AuthService = {
               // Stop hammering — declare unreachable and bounce the user.
               sessionDead = true;
               emitSessionExpired("auth_unreachable");
-              console.warn(
-                "[AuthService] auth-service unreachable after",
-                consecutiveTransientFailures,
-                "attempts; sessionExpired emitted",
+              logger.warn(
+                "AuthService",
+                "auth-service unreachable; sessionExpired emitted",
+                { attempts: consecutiveTransientFailures },
               );
             } else {
               // Exponential backoff: 1 s, 2 s, 4 s.
@@ -284,7 +286,7 @@ export const AuthService = {
         ),
       ]);
     } catch (err) {
-      console.warn("[AuthService] unregisterDevice failed:", err);
+      logger.warn("AuthService", "unregisterDevice failed", err);
     }
     notif.tearDownPushRegistration();
 

--- a/src/services/MediaService.ts
+++ b/src/services/MediaService.ts
@@ -3,6 +3,7 @@ import { TokenService } from "./TokenService";
 import { getApiBaseUrl } from "./apiBase";
 import { Platform } from "react-native";
 import * as FileSystem from "expo-file-system/legacy";
+import { logger } from "../utils/logger";
 
 type ApiError = Error & { status?: number; body?: unknown };
 
@@ -320,9 +321,9 @@ export const MediaService = {
       });
     }
 
-    console.log(
-      "[PDP-DEBUG][MediaService] uploadMedia → POST",
-      `${getMediaBaseUrl()}/upload`,
+    logger.debug(
+      "PDP-MediaService",
+      `uploadMedia → POST ${getMediaBaseUrl()}/upload`,
       {
         context: meta?.context,
         ownerId: meta?.ownerId,
@@ -338,11 +339,10 @@ export const MediaService = {
 
     if (!response.ok) {
       const body = await response.json().catch(() => ({}));
-      console.log(
-        "[PDP-DEBUG][MediaService] uploadMedia ← HTTP",
-        response.status,
+      logger.debug("PDP-MediaService", "uploadMedia ← HTTP", {
+        status: response.status,
         body,
-      );
+      });
       const error = new Error(
         (body as { message?: string })?.message ??
           `Upload failed: HTTP ${response.status}`,
@@ -352,9 +352,9 @@ export const MediaService = {
     }
 
     const raw = await response.json();
-    console.log("[PDP-DEBUG][MediaService] uploadMedia ← 200 raw:", raw);
+    logger.debug("PDP-MediaService", "uploadMedia ← 200 raw", raw);
     const normalised = normaliseUpload(raw);
-    console.log("[PDP-DEBUG][MediaService] uploadMedia normalised:", {
+    logger.debug("PDP-MediaService", "uploadMedia normalised", {
       id: normalised.id,
       url: normalised.url,
       thumbnail_url: normalised.thumbnail_url,

--- a/src/services/TokenRefreshScheduler.ts
+++ b/src/services/TokenRefreshScheduler.ts
@@ -5,6 +5,7 @@ import {
 } from "react-native";
 import { AuthService } from "./AuthService";
 import { TokenService } from "./TokenService";
+import { logger } from "../utils/logger";
 
 // Lead time (seconds) before JWT `exp` at which we fire a proactive refresh.
 // Must be strictly greater than the 60s buffer used by TokenService.isTokenExpired
@@ -84,7 +85,7 @@ export class TokenRefreshScheduler {
       // refreshTokens already handles session-expired emission; swallow here
       // so the scheduler doesn't crash. If the session died, stop() will be
       // called by AuthContext via the sessionExpired event.
-      console.warn("[TokenRefreshScheduler] refresh failed", err);
+      logger.warn("TokenRefreshScheduler", "refresh failed", err);
       return;
     }
 

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -7,6 +7,7 @@ import { TokenService } from "./TokenService";
 import { AuthService } from "./AuthService";
 import { getApiBaseUrl } from "./apiBase";
 import { normalizeUsername } from "../utils";
+import { logger } from "../utils/logger";
 
 // Types
 export interface UserVisualPreferences {
@@ -254,7 +255,7 @@ export class UserService {
       }
       return { success: true };
     } catch (error) {
-      console.warn("[UserService] bootstrapAccount failed:", error);
+      logger.warn("UserService", "bootstrapAccount failed", error);
       return { success: false, message: "bootstrap failed" };
     }
   }
@@ -270,29 +271,23 @@ export class UserService {
     message?: string;
   }> {
     try {
-      console.log("[PDP-DEBUG][UserService] getProfile → GET /profile/me");
+      logger.debug("PDP-UserService", "getProfile → GET /profile/me");
       const response = await this.authFetch("/profile/me");
 
       if (!response.ok) {
-        console.log(
-          "[PDP-DEBUG][UserService] getProfile ← HTTP",
-          response.status,
-        );
+        logger.debug("PDP-UserService", "getProfile ← HTTP", response.status);
         return { success: false, message: `Erreur ${response.status}` };
       }
 
       const data = await response.json().catch(() => null);
-      console.log(
-        "[PDP-DEBUG][UserService] getProfile ← 200 profilePictureUrl:",
-        data?.profilePictureUrl,
-        "raw keys:",
-        data ? Object.keys(data) : null,
-      );
+      logger.debug("PDP-UserService", "getProfile ← 200", {
+        profilePictureUrl: data?.profilePictureUrl,
+        rawKeys: data ? Object.keys(data) : null,
+      });
       const profile = this.normalizeProfile(data);
-      console.log(
-        "[PDP-DEBUG][UserService] getProfile normalized.profilePicture:",
-        profile?.profilePicture,
-      );
+      logger.debug("PDP-UserService", "getProfile normalized", {
+        profilePicture: profile?.profilePicture,
+      });
       return profile
         ? { success: true, profile }
         : { success: false, message: "Profil invalide reçu du serveur" };
@@ -316,26 +311,25 @@ export class UserService {
       if (!token) return { success: false, message: "Non authentifié" };
 
       const url = `${this.baseUrl}/profile/${encodeURIComponent(userId)}`;
-      console.log("[PDP-DEBUG][UserService] getUserProfile → GET", url);
+      logger.debug("PDP-UserService", "getUserProfile → GET", url);
       const response = await fetch(url, {
         headers: { Authorization: `Bearer ${token}` },
       });
 
       if (!response.ok) {
-        console.log(
-          "[PDP-DEBUG][UserService] getUserProfile ← HTTP",
+        logger.debug(
+          "PDP-UserService",
+          "getUserProfile ← HTTP",
           response.status,
         );
         return { success: false, message: `Erreur ${response.status}` };
       }
 
       const data = await response.json().catch(() => null);
-      console.log(
-        "[PDP-DEBUG][UserService] getUserProfile ← 200 id:",
-        data?.id,
-        "profilePictureUrl:",
-        data?.profilePictureUrl,
-      );
+      logger.debug("PDP-UserService", "getUserProfile ← 200", {
+        id: data?.id,
+        profilePictureUrl: data?.profilePictureUrl,
+      });
       if (data && data.profilePictureUrl && !data.profilePicture) {
         data.profilePicture = data.profilePictureUrl;
       }
@@ -358,8 +352,9 @@ export class UserService {
         return { success: false, message: validation.error };
       }
 
-      console.log(
-        "[PDP-DEBUG][UserService] updateProfile → PATCH /profile/{userId} payload:",
+      logger.debug(
+        "PDP-UserService",
+        "updateProfile → PATCH /profile/{userId} payload",
         profileData,
       );
       const response = await this.authFetch("/profile/{userId}", {
@@ -373,26 +368,22 @@ export class UserService {
           response,
           `Erreur ${response.status}`,
         );
-        console.log(
-          "[PDP-DEBUG][UserService] updateProfile ← HTTP",
-          response.status,
+        logger.debug("PDP-UserService", "updateProfile ← HTTP", {
+          status: response.status,
           msg,
-        );
+        });
         return { success: false, message: msg };
       }
 
       const data = await response.json().catch(() => null);
-      console.log(
-        "[PDP-DEBUG][UserService] updateProfile ← 200 raw:",
-        data,
-        "profilePictureUrl:",
-        data?.profilePictureUrl,
-      );
+      logger.debug("PDP-UserService", "updateProfile ← 200", {
+        raw: data,
+        profilePictureUrl: data?.profilePictureUrl,
+      });
       const normalized = this.normalizeProfile(data);
-      console.log(
-        "[PDP-DEBUG][UserService] updateProfile normalized.profilePicture:",
-        normalized?.profilePicture,
-      );
+      logger.debug("PDP-UserService", "updateProfile normalized", {
+        profilePicture: normalized?.profilePicture,
+      });
       return {
         success: true,
         message: "Profil mis à jour avec succès",

--- a/src/services/calls/bootstrap.native.ts
+++ b/src/services/calls/bootstrap.native.ts
@@ -1,4 +1,5 @@
 import { getCallsAvailability } from "../../hooks/useCallsAvailable";
+import { logger } from "../../utils/logger";
 
 declare const require: (path: string) => any;
 
@@ -17,13 +18,15 @@ if (available) {
       require("@livekit/react-native") as typeof import("@livekit/react-native");
     livekit.registerGlobals();
   } catch (error) {
-    console.warn(
-      "[calls/bootstrap] registerGlobals failed — continuing without LiveKit globals:",
+    logger.warn(
+      "calls/bootstrap",
+      "registerGlobals failed - continuing without LiveKit globals",
       error,
     );
   }
 } else if (reason === "no-webrtc") {
-  console.warn(
-    "[calls/bootstrap] WebRTC native module missing — skipping LiveKit registerGlobals. Rebuild the iOS/Android dev client (e.g. `npx expo run:ios`) after adding @livekit/react-native-webrtc.",
+  logger.warn(
+    "calls/bootstrap",
+    "WebRTC native module missing - skipping LiveKit registerGlobals. Rebuild the iOS/Android dev client (e.g. `npx expo run:ios`) after adding @livekit/react-native-webrtc.",
   );
 }

--- a/src/services/calls/systemCallProvider.ts
+++ b/src/services/calls/systemCallProvider.ts
@@ -3,6 +3,7 @@ import { PermissionsAndroid, Platform } from "react-native";
 import { navigate, navigationRef } from "../../navigation/navigationRef";
 import { useCallsStore, type IncomingCallInfo } from "../../store/callsStore";
 import { isCallsAvailable } from "../../hooks/useCallsAvailable";
+import { logger } from "../../utils/logger";
 
 type CallKeepModule = typeof import("react-native-call-keeper").default;
 
@@ -241,8 +242,9 @@ class SystemCallProvider {
       !nativeState.connected &&
       Date.now() - nativeState.startedAt < OUTGOING_END_EVENT_GRACE_MS
     ) {
-      console.warn(
-        "[systemCallProvider] Ignoring early endCall for outgoing call",
+      logger.warn(
+        "systemCallProvider",
+        "Ignoring early endCall for outgoing call",
         callUUID,
       );
       return;


### PR DESCRIPTION
## Summary
- Replace ~23 `console.log/.warn/.debug` calls in `src/services/` by the existing conditional `logger` (in `src/utils/logger.ts`)
- Touches `UserService` (12 PDP-DEBUG traces), `AuthService` (3 warns), `MediaService` (4 PDP traces), `TokenRefreshScheduler`, `calls/bootstrap.native`, `calls/systemCallProvider`
- `console.error` calls left untouched (always-on critical errors)
- No behaviour change: dev/preprod still see logs, prod builds drop them

## Test plan
- [x] `npm test` green (94 suites, 896 tests)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint:fix` no new errors
- [ ] Smoke-test on web preprod: check console clean of PDP-DEBUG traces in prod build

Closes WHISPR-1311