### PR TITLE
[WHISPR-1313] fix(screens): apply web scroll pattern (WHISPR-1254) to 5 screens

### DIFF
--- a/src/screens/Auth/ProfileSetupScreen.tsx
+++ b/src/screens/Auth/ProfileSetupScreen.tsx
@@ -434,8 +434,18 @@ export const ProfileSetupScreen: React.FC = () => {
 };
 
 const styles = StyleSheet.create({
-  container: { flex: 1 },
-  flex: { flex: 1 },
+  container: {
+    flex: 1,
+    // WHISPR-1254 - sur react-native-web, le wrapper racine doit borner la
+    // hauteur du viewport sinon flex:1 ne propage pas aux enfants.
+    ...(Platform.OS === "web" ? { height: "100%" } : {}),
+  },
+  flex: {
+    flex: 1,
+    // WHISPR-1254 - minHeight:0 permet a la ScrollView enfant d'overflow
+    // verticalement au lieu de pousser le parent.
+    ...(Platform.OS === "web" ? { minHeight: 0 } : {}),
+  },
   scroll: { flexGrow: 1 },
   content: {
     flex: 1,

--- a/src/screens/Moderation/MySanctionsScreen.tsx
+++ b/src/screens/Moderation/MySanctionsScreen.tsx
@@ -12,6 +12,7 @@ import {
   TouchableOpacity,
   ActivityIndicator,
   RefreshControl,
+  Platform,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { LinearGradient } from "expo-linear-gradient";
@@ -213,8 +214,18 @@ export const MySanctionsScreen: React.FC = () => {
 };
 
 const styles = StyleSheet.create({
-  gradientContainer: { flex: 1 },
-  container: { flex: 1 },
+  gradientContainer: {
+    flex: 1,
+    // WHISPR-1254 - sur react-native-web, le wrapper racine doit borner la
+    // hauteur du viewport sinon flex:1 ne propage pas aux enfants.
+    ...(Platform.OS === "web" ? { height: "100%" } : {}),
+  },
+  container: {
+    flex: 1,
+    // WHISPR-1254 - minHeight:0 permet a la FlatList enfant d'overflow
+    // verticalement au lieu de pousser le parent.
+    ...(Platform.OS === "web" ? { minHeight: 0 } : {}),
+  },
   header: {
     flexDirection: "row",
     alignItems: "center",

--- a/src/screens/Profile/UserProfileScreen.tsx
+++ b/src/screens/Profile/UserProfileScreen.tsx
@@ -12,6 +12,7 @@ import {
   Animated,
   ActivityIndicator,
   TouchableOpacity,
+  Platform,
 } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
 import {
@@ -213,12 +214,24 @@ export const UserProfileScreen: React.FC = () => {
 };
 
 const styles = StyleSheet.create({
-  container: { flex: 1 },
-  content: { flex: 1 },
+  container: {
+    flex: 1,
+    // WHISPR-1254 - sur react-native-web, le wrapper racine doit borner la
+    // hauteur du viewport sinon flex:1 ne propage pas aux enfants.
+    ...(Platform.OS === "web" ? { height: "100%" } : {}),
+  },
+  content: {
+    flex: 1,
+    // WHISPR-1254 - minHeight:0 permet a la ScrollView enfant d'overflow
+    // verticalement au lieu de pousser le parent.
+    ...(Platform.OS === "web" ? { minHeight: 0 } : {}),
+  },
   iconButton: { padding: spacing.sm },
   scrollView: {
     flex: 1,
     paddingHorizontal: spacing.lg,
+    // WHISPR-1254 - meme raison que .content : autoriser l'overflow.
+    ...(Platform.OS === "web" ? { minHeight: 0 } : {}),
   },
   profileInfo: {
     paddingBottom: spacing.xl,

--- a/src/screens/Security/TwoFactorAuthScreen.tsx
+++ b/src/screens/Security/TwoFactorAuthScreen.tsx
@@ -685,9 +685,23 @@ export const TwoFactorAuthScreen: React.FC = () => {
 };
 
 const styles = StyleSheet.create({
-  container: { flex: 1 },
-  animatedContainer: { flex: 1 },
-  scrollView: { flex: 1 },
+  container: {
+    flex: 1,
+    // WHISPR-1254 - sur react-native-web, le wrapper racine doit borner la
+    // hauteur du viewport sinon flex:1 ne propage pas aux enfants.
+    ...(Platform.OS === "web" ? { height: "100%" } : {}),
+  },
+  animatedContainer: {
+    flex: 1,
+    // WHISPR-1254 - minHeight:0 permet a la ScrollView enfant d'overflow
+    // verticalement au lieu de pousser le parent.
+    ...(Platform.OS === "web" ? { minHeight: 0 } : {}),
+  },
+  scrollView: {
+    flex: 1,
+    // WHISPR-1254 - meme raison : autoriser l'overflow vertical.
+    ...(Platform.OS === "web" ? { minHeight: 0 } : {}),
+  },
   scrollContent: { paddingBottom: 40 },
   header: {
     flexDirection: "row",

--- a/src/screens/Security/TwoFactorSetupScreen.tsx
+++ b/src/screens/Security/TwoFactorSetupScreen.tsx
@@ -483,9 +483,23 @@ export const TwoFactorSetupScreen: React.FC = () => {
 };
 
 const styles = StyleSheet.create({
-  container: { flex: 1 },
-  animatedContainer: { flex: 1 },
-  scrollView: { flex: 1 },
+  container: {
+    flex: 1,
+    // WHISPR-1254 - sur react-native-web, le wrapper racine doit borner la
+    // hauteur du viewport sinon flex:1 ne propage pas aux enfants.
+    ...(Platform.OS === "web" ? { height: "100%" } : {}),
+  },
+  animatedContainer: {
+    flex: 1,
+    // WHISPR-1254 - minHeight:0 permet a la ScrollView enfant d'overflow
+    // verticalement au lieu de pousser le parent.
+    ...(Platform.OS === "web" ? { minHeight: 0 } : {}),
+  },
+  scrollView: {
+    flex: 1,
+    // WHISPR-1254 - meme raison : autoriser l'overflow vertical.
+    ...(Platform.OS === "web" ? { minHeight: 0 } : {}),
+  },
   scrollContent: { paddingBottom: 40 },
   header: {
     flexDirection: "row",


### PR DESCRIPTION
## Summary
- Apply the WHISPR-1254 web scroll fix pattern to 5 screens that had the same flex:1-without-minHeight:0 bug as ContactsScreen
- Touched: `UserProfileScreen`, `MySanctionsScreen`, `ProfileSetupScreen`, `TwoFactorSetupScreen`, `TwoFactorAuthScreen`
- Each screen now wraps its root container with `height: '100%'` on web and adds `minHeight: 0` to intermediate flex containers so child ScrollView/FlatList can overflow vertically
- Native (iOS/Android) behaviour unchanged: styles only apply when `Platform.OS === 'web'`

## Test plan
- [x] `npm test` green (94 suites, 896 tests)
- [x] `npx tsc --noEmit` clean
- [x] `npx prettier --write` clean
- [ ] Manual test web preprod: scroll all 5 screens (UserProfile, MySanctions, ProfileSetup, 2FA Setup/Auth) on small viewport heights

Closes WHISPR-1313