### PR TITLE
[WHISPR-1314] fix: post-deploy audit findings (mini-card + read receipts)

### DIFF
--- a/MiniProfileCache.test.ts
+++ b/MiniProfileCache.test.ts
@@ -64,4 +64,17 @@ describe("miniProfileCache", () => {
     expect(getCached("u0")).not.toBeNull();
     expect(getCached("u1")).toBeNull();
   });
+
+  it("never exceeds the max size even with rapid burst inserts", () => {
+    for (let i = 0; i < 200; i++) setCached(`u${i}`, baseProfile(`u${i}`));
+    expect(_internalSize()).toBeLessThanOrEqual(50);
+  });
+
+  it("keeps store bounded when updating an existing key", () => {
+    for (let i = 0; i < 50; i++) setCached(`u${i}`, baseProfile(`u${i}`));
+    expect(_internalSize()).toBe(50);
+    // update d'une cle existante : le size doit rester a 50
+    setCached("u10", baseProfile("u10"));
+    expect(_internalSize()).toBe(50);
+  });
 });

--- a/MiniProfileCard.test.tsx
+++ b/MiniProfileCard.test.tsx
@@ -181,6 +181,26 @@ describe("MiniProfileCard", () => {
     expect(onMessage).toHaveBeenCalled();
   });
 
+  it("hides the last seen line when backend returns no value", async () => {
+    mockGetUserProfile.mockResolvedValue({
+      success: true,
+      profile: buildProfile({ isOnline: false, lastSeen: undefined }),
+    });
+    const { queryByText, getByTestId } = render(
+      <MiniProfileCard
+        userId="u1"
+        currentUserId="me"
+        onClose={() => {}}
+        onOpenFullProfile={() => {}}
+        onOpenSelfProfile={() => {}}
+        onMessage={() => {}}
+      />,
+    );
+    await waitFor(() => getByTestId("mini-profile-card-loaded"));
+    expect(queryByText("en ligne")).toBeNull();
+    expect(queryByText(/vu /)).toBeNull();
+  });
+
   it("does not warn when unmounted before fetch resolves", async () => {
     let resolveProfile: (v: unknown) => void = () => {};
     mockGetUserProfile.mockReturnValue(

--- a/MiniProfileCard.test.tsx
+++ b/MiniProfileCard.test.tsx
@@ -181,6 +181,49 @@ describe("MiniProfileCard", () => {
     expect(onMessage).toHaveBeenCalled();
   });
 
+  it("renders the stale banner when refresh fails but cache exists", async () => {
+    const realNow = Date.now;
+    Date.now = jest.fn(() => 1_000_000_000_000);
+
+    // 1er fetch reussi -> remplit le cache
+    mockGetUserProfile.mockResolvedValueOnce({
+      success: true,
+      profile: buildProfile(),
+    });
+    const first = render(
+      <MiniProfileCard
+        userId="u1"
+        currentUserId="me"
+        onClose={() => {}}
+        onOpenFullProfile={() => {}}
+        onOpenSelfProfile={() => {}}
+        onMessage={() => {}}
+      />,
+    );
+    await waitFor(() => first.getByTestId("mini-profile-card-loaded"));
+    first.unmount();
+
+    // avance le temps de 6 minutes : le cache devient stale
+    Date.now = jest.fn(() => 1_000_000_000_000 + 6 * 60 * 1000);
+
+    // 2eme rendu : cache hit stale + refresh echoue -> banner stale visible
+    mockGetUserProfile.mockRejectedValueOnce(new Error("network down"));
+    const view = render(
+      <MiniProfileCard
+        userId="u1"
+        currentUserId="me"
+        onClose={() => {}}
+        onOpenFullProfile={() => {}}
+        onOpenSelfProfile={() => {}}
+        onMessage={() => {}}
+      />,
+    );
+    await waitFor(() => view.getByTestId("mini-profile-card-stale"));
+    expect(view.getByText("Donnees possiblement obsoletes")).toBeTruthy();
+    expect(view.getByText("Reessayer")).toBeTruthy();
+    Date.now = realNow;
+  });
+
   it("hides the last seen line when backend returns no value", async () => {
     mockGetUserProfile.mockResolvedValue({
       success: true,

--- a/MiniProfileCard.test.tsx
+++ b/MiniProfileCard.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, waitFor, act, fireEvent } from "@testing-library/react-native";
 import { MiniProfileCard } from "./src/components/Profile/MiniProfileCard";
 import { clearCache } from "./src/services/profile/miniProfileCache";
+import { clearRelationCache } from "./src/services/profile/miniRelationCache";
 
 const mockGetUserProfile = jest.fn();
 jest.mock("./src/services/UserService", () => ({
@@ -40,6 +41,7 @@ const buildProfile = (overrides = {}) => ({
 
 beforeEach(() => {
   clearCache();
+  clearRelationCache();
   mockGetUserProfile.mockReset();
   mockGetBlockedUsers.mockReset().mockResolvedValue({ blocked: [], total: 0 });
   mockGetContacts.mockReset().mockResolvedValue({ contacts: [], total: 0 });

--- a/MiniProfileCard.test.tsx
+++ b/MiniProfileCard.test.tsx
@@ -178,4 +178,34 @@ describe("MiniProfileCard", () => {
     });
     expect(onMessage).toHaveBeenCalled();
   });
+
+  it("does not warn when unmounted before fetch resolves", async () => {
+    let resolveProfile: (v: unknown) => void = () => {};
+    mockGetUserProfile.mockReturnValue(
+      new Promise((res) => {
+        resolveProfile = res;
+      }),
+    );
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const { unmount } = render(
+      <MiniProfileCard
+        userId="u1"
+        currentUserId="me"
+        onClose={() => {}}
+        onOpenFullProfile={() => {}}
+        onOpenSelfProfile={() => {}}
+        onMessage={() => {}}
+      />,
+    );
+    unmount();
+    await act(async () => {
+      resolveProfile({ success: true, profile: buildProfile() });
+      await Promise.resolve();
+    });
+    const calls = errorSpy.mock.calls.map((c) => String(c[0]));
+    expect(
+      calls.some((m) => m.includes("unmounted") || m.includes("memory leak")),
+    ).toBe(false);
+    errorSpy.mockRestore();
+  });
 });

--- a/src/components/Profile/MiniProfileCard.tsx
+++ b/src/components/Profile/MiniProfileCard.tsx
@@ -299,9 +299,16 @@ export const MiniProfileCard: React.FC<MiniProfileCardProps> = ({
   if (!profile) return null;
 
   const displayName = buildDisplayName(profile);
-  const lastSeenText = profile.isOnline
-    ? "en ligne"
-    : formatLastSeen(profile.lastSeen);
+  // privacy gate cote client : si le backend a deja masque, on ne ressuscite
+  // PAS la valeur. lastSeen falsy => masque par parametres user. isOnline
+  // doit etre strictement true pour afficher "en ligne". Pas de fallback
+  // "vu il y a longtemps" invente cote client.
+  const lastSeenText =
+    profile.isOnline === true
+      ? "en ligne"
+      : profile.lastSeen
+        ? formatLastSeen(profile.lastSeen)
+        : null;
 
   return (
     <View style={styles.card} testID="mini-profile-card-loaded">

--- a/src/components/Profile/MiniProfileCard.tsx
+++ b/src/components/Profile/MiniProfileCard.tsx
@@ -185,6 +185,7 @@ export const MiniProfileCard: React.FC<MiniProfileCardProps> = ({
         setCached(userId, result.profile);
         if (!mounted.current) return;
         setProfile(result.profile);
+        setError(null);
         setState("loaded");
         const rel = await computeRelation(userId);
         if (!mounted.current) return;
@@ -196,8 +197,10 @@ export const MiniProfileCard: React.FC<MiniProfileCardProps> = ({
           kind: isTimeout ? "timeout" : "network",
           retriable: true,
         });
-        // si on a deja une version cachee on reste en loaded, sinon error
-        if (!cached) setState("error");
+        // on bascule en error meme si on a du stale : la card va l'afficher
+        // avec un banner "donnees possiblement obsoletes" plutot que
+        // renvoyer null silencieusement.
+        setState("error");
       }
     },
     [userId, computeRelation],
@@ -299,6 +302,7 @@ export const MiniProfileCard: React.FC<MiniProfileCardProps> = ({
   if (!profile) return null;
 
   const displayName = buildDisplayName(profile);
+  const isStale = state === "error" && !!profile;
   // privacy gate cote client : si le backend a deja masque, on ne ressuscite
   // PAS la valeur. lastSeen falsy => masque par parametres user. isOnline
   // doit etre strictement true pour afficher "en ligne". Pas de fallback
@@ -312,6 +316,25 @@ export const MiniProfileCard: React.FC<MiniProfileCardProps> = ({
 
   return (
     <View style={styles.card} testID="mini-profile-card-loaded">
+      {isStale ? (
+        <View style={styles.staleBanner} testID="mini-profile-card-stale">
+          <Ionicons
+            name="cloud-offline-outline"
+            size={14}
+            color={colors.ui.error}
+          />
+          <Text style={styles.staleBannerText}>
+            Donnees possiblement obsoletes
+          </Text>
+          <Pressable
+            onPress={() => void load({ forceRefresh: true })}
+            accessibilityRole="button"
+            hitSlop={8}
+          >
+            <Text style={styles.staleBannerLink}>Reessayer</Text>
+          </Pressable>
+        </View>
+      ) : null}
       {profile.profilePicture ? (
         <Image
           source={{ uri: profile.profilePicture }}
@@ -466,6 +489,30 @@ const styles = StyleSheet.create({
     fontSize: 13,
     marginTop: 6,
     textAlign: "center",
+  },
+  staleBanner: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    backgroundColor: withOpacity(colors.ui.error, 0.12),
+    borderWidth: 1,
+    borderColor: withOpacity(colors.ui.error, 0.3),
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 10,
+    width: "100%",
+    justifyContent: "center",
+    marginBottom: 6,
+  },
+  staleBannerText: {
+    color: withOpacity("#FFFFFF", 0.85),
+    fontSize: 12,
+  },
+  staleBannerLink: {
+    color: colors.ui.error,
+    fontSize: 12,
+    fontWeight: "700",
+    textDecorationLine: "underline",
   },
   blockedBadge: {
     flexDirection: "row",

--- a/src/components/Profile/MiniProfileCard.tsx
+++ b/src/components/Profile/MiniProfileCard.tsx
@@ -6,7 +6,7 @@
  * Le composant ne gere PAS le positionnement : il rend uniquement le contenu
  * de la card. Le wrapping (Modal mobile / Popover web) est dans le host.
  */
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   View,
   Text,
@@ -92,6 +92,15 @@ export const MiniProfileCard: React.FC<MiniProfileCardProps> = ({
   const [busyAction, setBusyAction] = useState<null | "block" | "unblock">(
     null,
   );
+  // mounted ref pour eviter les setState apres demontage (memory leak si l'user
+  // ferme la card pendant un fetch en cours).
+  const mounted = useRef(true);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
 
   const isSelf = !!currentUserId && currentUserId === userId;
 
@@ -120,15 +129,20 @@ export const MiniProfileCard: React.FC<MiniProfileCardProps> = ({
       // 1. cache hit
       const cached = getCached(userId);
       if (cached && !opts.forceRefresh) {
+        if (!mounted.current) return;
         setProfile(cached.profile);
         setState("loaded");
         // si stale, on continue jusqu'au fetch en background
         if (!cached.isStale) {
           // on resoud quand meme la relation
-          computeRelation(userId).then(setRelation);
+          computeRelation(userId).then((rel) => {
+            if (!mounted.current) return;
+            setRelation(rel);
+          });
           return;
         }
       } else if (!cached) {
+        if (!mounted.current) return;
         setState("loading");
       }
 
@@ -136,6 +150,7 @@ export const MiniProfileCard: React.FC<MiniProfileCardProps> = ({
         const result = await fetchWithTimeout(
           UserService.getInstance().getUserProfile(userId),
         );
+        if (!mounted.current) return;
         if (!result.success || !result.profile) {
           // 404 -> on l'identifie par message contenant "404"
           if (result.message?.includes("404")) {
@@ -152,11 +167,14 @@ export const MiniProfileCard: React.FC<MiniProfileCardProps> = ({
           return;
         }
         setCached(userId, result.profile);
+        if (!mounted.current) return;
         setProfile(result.profile);
         setState("loaded");
         const rel = await computeRelation(userId);
+        if (!mounted.current) return;
         setRelation(rel);
       } catch (e) {
+        if (!mounted.current) return;
         const isTimeout = (e as Error)?.message === "timeout";
         setError({
           kind: isTimeout ? "timeout" : "network",
@@ -178,11 +196,12 @@ export const MiniProfileCard: React.FC<MiniProfileCardProps> = ({
     setBusyAction("block");
     try {
       await contactsAPI.blockUser(userId);
+      if (!mounted.current) return;
       setRelation("blocked");
     } catch {
       // si l'appel rate, on garde le relation precedent
     } finally {
-      setBusyAction(null);
+      if (mounted.current) setBusyAction(null);
     }
   }, [userId, busyAction]);
 
@@ -191,11 +210,12 @@ export const MiniProfileCard: React.FC<MiniProfileCardProps> = ({
     setBusyAction("unblock");
     try {
       await contactsAPI.unblockUser(userId);
+      if (!mounted.current) return;
       setRelation("contact");
     } catch {
       // idem
     } finally {
-      setBusyAction(null);
+      if (mounted.current) setBusyAction(null);
     }
   }, [userId, busyAction]);
 

--- a/src/components/Profile/MiniProfileCard.tsx
+++ b/src/components/Profile/MiniProfileCard.tsx
@@ -20,8 +20,13 @@ import { colors, withOpacity } from "../../theme/colors";
 import { UserService, UserProfile } from "../../services/UserService";
 import { contactsAPI } from "../../services/contacts/api";
 import { getCached, setCached } from "../../services/profile/miniProfileCache";
+import {
+  getCachedRelation,
+  invalidateCachedRelation,
+  setCachedRelation,
+  type Relation,
+} from "../../services/profile/miniRelationCache";
 
-type Relation = "self" | "blocked" | "contact" | "unknown";
 type CardState = "loading" | "loaded" | "error" | "notFound";
 
 interface ErrorInfo {
@@ -107,19 +112,30 @@ export const MiniProfileCard: React.FC<MiniProfileCardProps> = ({
   const computeRelation = useCallback(
     async (id: string): Promise<Relation> => {
       if (currentUserId && currentUserId === id) return "self";
+      // hit cache TTL 60s pour eviter 2 appels reseau a chaque ouverture de card
+      const cachedRel = getCachedRelation(id);
+      if (cachedRel !== null) return cachedRel;
+      let result: Relation = "unknown";
       try {
         const { blocked } = await contactsAPI.getBlockedUsers();
-        if (blocked.some((b) => b.blocked_user_id === id)) return "blocked";
+        if (blocked.some((b) => b.blocked_user_id === id)) {
+          result = "blocked";
+        }
       } catch {
         // ne pas bloquer le rendu si la liste blocked echoue
       }
-      try {
-        const { contacts } = await contactsAPI.getContacts();
-        if (contacts.some((c) => c.contact_id === id)) return "contact";
-      } catch {
-        // idem
+      if (result === "unknown") {
+        try {
+          const { contacts } = await contactsAPI.getContacts();
+          if (contacts.some((c) => c.contact_id === id)) {
+            result = "contact";
+          }
+        } catch {
+          // idem
+        }
       }
-      return "unknown";
+      setCachedRelation(id, result);
+      return result;
     },
     [currentUserId],
   );
@@ -197,6 +213,8 @@ export const MiniProfileCard: React.FC<MiniProfileCardProps> = ({
     try {
       await contactsAPI.blockUser(userId);
       if (!mounted.current) return;
+      invalidateCachedRelation(userId);
+      setCachedRelation(userId, "blocked");
       setRelation("blocked");
     } catch {
       // si l'appel rate, on garde le relation precedent
@@ -211,6 +229,8 @@ export const MiniProfileCard: React.FC<MiniProfileCardProps> = ({
     try {
       await contactsAPI.unblockUser(userId);
       if (!mounted.current) return;
+      invalidateCachedRelation(userId);
+      setCachedRelation(userId, "contact");
       setRelation("contact");
     } catch {
       // idem

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -3,7 +3,7 @@
  * WHISPR-133: Implement SettingsScreen with app configuration
  */
 
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import {
   View,
   Text,
@@ -127,6 +127,11 @@ export const SettingsScreen: React.FC = () => {
     readReceipts: true,
     typingIndicator: true,
   });
+
+  // compteur de requestId pour le toggle des accuses de lecture. Si l'user
+  // toggle plusieurs fois avant que le backend reponde, seule la derniere
+  // requete a le droit de rollback - les precedentes deviennent obsoletes.
+  const readReceiptsRequestIdRef = useRef(0);
 
   // Application settings
   const [appSettings, setAppSettings] = useState({
@@ -389,16 +394,23 @@ export const SettingsScreen: React.FC = () => {
           if (key === "readReceipts") {
             setReadReceiptsEnabled(value);
             const userService = UserService.getInstance();
+            // increment + capture du requestId : si l'user re-toggle avant que
+            // l'API reponde, ce requestId ne correspondra plus au courant et
+            // on ignore le rollback (l'user a deja change d'avis).
+            readReceiptsRequestIdRef.current += 1;
+            const requestId = readReceiptsRequestIdRef.current;
+            const previousValue = prev.readReceipts;
             userService
               .updatePrivacySettings({ readReceipts: value })
               .then((result) => {
+                if (requestId !== readReceiptsRequestIdRef.current) return;
                 if (!result.success) {
                   // rollback en memoire et en state
-                  setReadReceiptsEnabled(prev.readReceipts);
+                  setReadReceiptsEnabled(previousValue);
                   setMessagingSettings((curr) => {
                     const reverted = {
                       ...curr,
-                      readReceipts: prev.readReceipts,
+                      readReceipts: previousValue,
                     };
                     persistSettings(STORAGE_KEYS.messaging, reverted);
                     return reverted;
@@ -410,9 +422,10 @@ export const SettingsScreen: React.FC = () => {
                 }
               })
               .catch(() => {
-                setReadReceiptsEnabled(prev.readReceipts);
+                if (requestId !== readReceiptsRequestIdRef.current) return;
+                setReadReceiptsEnabled(previousValue);
                 setMessagingSettings((curr) => {
-                  const reverted = { ...curr, readReceipts: prev.readReceipts };
+                  const reverted = { ...curr, readReceipts: previousValue };
                   persistSettings(STORAGE_KEYS.messaging, reverted);
                   return reverted;
                 });

--- a/src/services/profile/miniProfileCache.ts
+++ b/src/services/profile/miniProfileCache.ts
@@ -32,14 +32,19 @@ export function getCached(userId: string): {
 }
 
 export function setCached(userId: string, profile: UserProfile): void {
+  // refresh LRU position si la cle existe deja (delete + reinsert)
   if (store.has(userId)) {
     store.delete(userId);
-  } else if (store.size >= MAX_ENTRIES) {
-    // eviction du moins recemment utilise (premiere clef de l'iter)
-    const oldestKey = store.keys().next().value;
-    if (oldestKey !== undefined) store.delete(oldestKey);
   }
   store.set(userId, { profile, fetchedAt: Date.now() });
+  // eviction du moins recemment utilise tant qu'on depasse la taille
+  // bornee. Trigger meme sur update de cle existante au cas ou la
+  // limite a ete depassee dans une session anterieure.
+  while (store.size > MAX_ENTRIES) {
+    const oldestKey = store.keys().next().value;
+    if (oldestKey === undefined) break;
+    store.delete(oldestKey);
+  }
 }
 
 export function clearCache(): void {

--- a/src/services/profile/miniRelationCache.ts
+++ b/src/services/profile/miniRelationCache.ts
@@ -1,0 +1,59 @@
+/**
+ * Cache LRU memoire pour les relations user (self / blocked / contact / unknown)
+ * resolues lors de l'ouverture de la mini-card.
+ * - taille max 50 entries
+ * - TTL 60s : au-dela on recompute pour ne pas garder une relation stale apres
+ *   un block / unblock recent.
+ *
+ * Le cache est invalide explicitement par les actions block/unblock pour
+ * ne pas afficher l'ancienne valeur a l'utilisateur.
+ */
+export type Relation = "self" | "blocked" | "contact" | "unknown";
+
+interface CacheEntry {
+  relation: Relation;
+  fetchedAt: number;
+}
+
+const MAX_ENTRIES = 50;
+const TTL_MS = 60 * 1000;
+
+const store = new Map<string, CacheEntry>();
+
+export function getCachedRelation(userId: string): Relation | null {
+  const entry = store.get(userId);
+  if (!entry) return null;
+  if (Date.now() - entry.fetchedAt > TTL_MS) {
+    store.delete(userId);
+    return null;
+  }
+  // refresh LRU position
+  store.delete(userId);
+  store.set(userId, entry);
+  return entry.relation;
+}
+
+export function setCachedRelation(userId: string, relation: Relation): void {
+  if (store.has(userId)) {
+    store.delete(userId);
+  }
+  store.set(userId, { relation, fetchedAt: Date.now() });
+  while (store.size > MAX_ENTRIES) {
+    const oldestKey = store.keys().next().value;
+    if (oldestKey === undefined) break;
+    store.delete(oldestKey);
+  }
+}
+
+export function invalidateCachedRelation(userId: string): void {
+  store.delete(userId);
+}
+
+export function clearRelationCache(): void {
+  store.clear();
+}
+
+// helper test-only
+export function _internalRelationSize(): number {
+  return store.size;
+}


### PR DESCRIPTION
## Summary

Fix de 6 findings de l'audit defensif post-deploy sur la mini-card profil et le toggle read receipts dans Settings.

- **memory leak (HIGH)** : ajout d'un `mounted` ref dans `MiniProfileCard` pour eviter les setState apres demontage si l'utilisateur ferme la card pendant un fetch en cours.
- **privacy gates (HIGH)** : `lastSeen` et `isOnline` sont desormais affiches uniquement si le backend renvoie une valeur explicite. Pas de fallback "vu il y a longtemps" invente cote client.
- **relation cache (MEDIUM)** : nouveau cache LRU dedie (50 entries / TTL 60s) pour eviter 2 appels reseau (`getBlockedUsers` + `getContacts`) a chaque ouverture de card. Invalidation explicite sur block/unblock.
- **LRU eviction bug (MEDIUM)** : `miniProfileCache.setCached` triggerait pas l'eviction sur update d'une cle existante, le store pouvait depasser 50 entrees temporairement. Fix : check `store.size > MAX_ENTRIES` apres chaque set.
- **stale data banner (MEDIUM)** : si le profile est en cache mais le refresh echoue, on affiche desormais la card avec un banner "Donnees possiblement obsoletes" + bouton "Reessayer" plutot que retourner null.
- **read receipts race (MEDIUM)** : compteur de `requestId` dans `SettingsScreen` pour ignorer les rollbacks issus de toggles obsoletes (l'user a toggle plusieurs fois avant que la 1ere requete API n'ait repondu).

## Test plan

- [x] `npm test -- --watchAll=false` : 901/901 passing
- [x] `npx tsc --noEmit` : 0 erreur
- [x] `npm run lint:fix` : 0 erreur
- [x] Tests ajoutes : memory leak unmount, privacy gate hide, stale banner refresh, LRU eviction on update
- [ ] Smoke test mini-card sur iOS / Android / web
- [ ] Smoke test toggle read receipts en double-tap rapide

Closes WHISPR-1314