### PR TITLE
[WHISPR-1328] fix(mobile): security audit HIGH+MEDIUM findings

### DIFF
--- a/LinkPreviewCard.test.tsx
+++ b/LinkPreviewCard.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Tests for LinkPreviewCard - on doit refuser d'ouvrir une URL avec un
+ * schema autre que http/https, sinon un backend compromis pourrait pousser
+ * `javascript:` ou `intent:` dans un message et obtenir de l'execution
+ * arbitraire cote client (WHISPR-1328).
+ */
+
+import React from "react";
+import { Linking } from "react-native";
+import { render, fireEvent } from "@testing-library/react-native";
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock("./src/context/ThemeContext", () => ({
+  useTheme: () => ({
+    getThemeColors: () => ({
+      text: { primary: "#000", secondary: "#444", tertiary: "#888" },
+    }),
+  }),
+}));
+
+import { LinkPreviewCard } from "./src/components/Chat/LinkPreviewCard";
+import type { MessageLinkPreview } from "./src/types/messaging";
+
+const basePreview = (url: string): MessageLinkPreview => ({
+  url,
+  canonicalUrl: url,
+  title: "Title",
+  description: "desc",
+  domain: "example.com",
+  siteName: "Example",
+  imageUrl: undefined,
+});
+
+const flush = async () => {
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+};
+
+describe("LinkPreviewCard URL scheme guard", () => {
+  let openSpy: jest.SpyInstance;
+  let canOpenSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    openSpy = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
+    canOpenSpy = jest.spyOn(Linking, "canOpenURL").mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    openSpy.mockRestore();
+    canOpenSpy.mockRestore();
+  });
+
+  it("opens https URLs through Linking.openURL", async () => {
+    const { getByRole } = render(
+      <LinkPreviewCard
+        preview={basePreview("https://example.com")}
+        isSent={false}
+      />,
+    );
+    fireEvent.press(getByRole("link"));
+    await flush();
+    expect(openSpy).toHaveBeenCalledWith("https://example.com");
+  });
+
+  it("opens http URLs through Linking.openURL", async () => {
+    const { getByRole } = render(
+      <LinkPreviewCard
+        preview={basePreview("http://example.com")}
+        isSent={false}
+      />,
+    );
+    fireEvent.press(getByRole("link"));
+    await flush();
+    expect(openSpy).toHaveBeenCalledWith("http://example.com");
+  });
+
+  it("never calls Linking.openURL for javascript: scheme", async () => {
+    const { getByRole } = render(
+      <LinkPreviewCard
+        preview={basePreview("javascript:alert(1)")}
+        isSent={false}
+      />,
+    );
+    fireEvent.press(getByRole("link"));
+    await flush();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it("never calls Linking.openURL for intent: scheme", async () => {
+    const { getByRole } = render(
+      <LinkPreviewCard
+        preview={basePreview("intent://attacker#Intent;scheme=http;end")}
+        isSent={false}
+      />,
+    );
+    fireEvent.press(getByRole("link"));
+    await flush();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it("never calls Linking.openURL for file: scheme", async () => {
+    const { getByRole } = render(
+      <LinkPreviewCard
+        preview={basePreview("file:///etc/passwd")}
+        isSent={false}
+      />,
+    );
+    fireEvent.press(getByRole("link"));
+    await flush();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+});

--- a/app.config.js
+++ b/app.config.js
@@ -44,8 +44,6 @@ module.exports = () => ({
   extra: {
     ...base.expo.extra,
     apiBaseUrl: process.env.API_BASE_URL || 'https://whispr.devzeyu.com',
-    devAuthApiUrl: 'http://10.0.2.2:3010',
-    devUserApiUrl: 'http://10.0.2.2:3011',
     legalPrivacyUrl:
       process.env.EXPO_PUBLIC_LEGAL_PRIVACY_URL || 'https://whispr.example/privacy',
     legalTermsUrl:

--- a/app.json
+++ b/app.json
@@ -33,6 +33,7 @@
         },
         "NSMicrophoneUsageDescription": "Whispr a besoin du micro pour les appels voix et video.",
         "NSCameraUsageDescription": "Whispr a besoin de la camera pour les appels video.",
+        "NSContactsUsageDescription": "Whispr accede aux contacts pour trouver vos amis sur l'application.",
         "UIBackgroundModes": ["voip", "audio"]
       }
     },
@@ -48,7 +49,8 @@
         "RECORD_AUDIO",
         "CAMERA",
         "MODIFY_AUDIO_SETTINGS",
-        "INTERNET"
+        "INTERNET",
+        "READ_CONTACTS"
       ]
     },
     "web": {

--- a/app.json
+++ b/app.json
@@ -6,8 +6,6 @@
     "version": "1.0.0",
     "extra": {
       "apiBaseUrl": "https://whispr.devzeyu.com",
-      "devAuthApiUrl": "http://10.0.2.2:3010",
-      "devUserApiUrl": "http://10.0.2.2:3011",
       "legalPrivacyUrl": "https://whispr.example/privacy",
       "legalTermsUrl": "https://whispr.example/terms",
       "appVersion": "1.0.0",

--- a/src/components/Chat/LinkPreviewCard.tsx
+++ b/src/components/Chat/LinkPreviewCard.tsx
@@ -11,7 +11,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "../../context/ThemeContext";
 import { colors, withOpacity } from "../../theme/colors";
 import type { MessageLinkPreview } from "../../types/messaging";
-import { isReachableUrl } from "../../utils";
+import { isHttpUrl, isReachableUrl } from "../../utils";
 
 interface LinkPreviewCardProps {
   preview: MessageLinkPreview;
@@ -26,11 +26,18 @@ export const LinkPreviewCard: React.FC<LinkPreviewCardProps> = ({
   const themeColors = getThemeColors();
 
   const handleOpen = useCallback(async () => {
+    const url = preview.canonicalUrl || preview.url;
+    // ne jamais faire confiance au backend sur l'URL : un schema autre
+    // que http(s) (ex: javascript:, intent:, file:) ouvrirait un vecteur
+    // d'execution arbitraire cote client.
+    if (!isHttpUrl(url)) return;
     try {
-      await Linking.openURL(preview.canonicalUrl || preview.url);
+      const supported = await Linking.canOpenURL(url);
+      if (!supported) return;
+      await Linking.openURL(url);
     } catch {
-      // Ignore open failures — keeping the chat interaction resilient matters
-      // more than surfacing a noisy warning.
+      // URL invalide ou ouverture impossible : on garde le chat utilisable
+      // plutot que de remonter un warning bruyant.
     }
   }, [preview.canonicalUrl, preview.url]);
 

--- a/src/components/Chat/MediaMessage.tsx
+++ b/src/components/Chat/MediaMessage.tsx
@@ -25,6 +25,8 @@ import {
   useResolvedMediaUrl,
   uriNeedsAuthResolution,
 } from "../../hooks/useResolvedMediaUrl";
+import { isHttpUrl } from "../../utils/urlFilters";
+import { logger } from "../../utils/logger";
 
 let Video: any = null;
 let ResizeMode: any = null;
@@ -37,12 +39,9 @@ function ensureExpoAvVideoLoaded(): void {
     const expoAv = require("expo-av");
     Video = expoAv.Video;
     ResizeMode = expoAv.ResizeMode;
-    console.log("[MediaMessage] expo-av loaded successfully");
+    logger.debug("MediaMessage", "expo-av loaded successfully");
   } catch (error) {
-    console.warn(
-      "[MediaMessage] expo-av not available, using fallback:",
-      error,
-    );
+    logger.warn("MediaMessage", "expo-av not available, using fallback", error);
   }
 }
 
@@ -164,27 +163,31 @@ export const MediaMessage: React.FC<MediaMessageProps> = ({
             const loadResult = await playerVideoRef.current.loadAsync({
               uri: resolvedMainUri,
             });
-            console.log(
-              "[MediaMessage] Video preloaded",
+            logger.debug(
+              "MediaMessage",
+              "Video preloaded",
               loadResult ? "with status" : "no status",
             );
 
             // Play immediately after load
             const playResult = await playerVideoRef.current.playAsync();
-            console.log(
-              "[MediaMessage] Video playing",
+            logger.debug(
+              "MediaMessage",
+              "Video playing",
               playResult ? "with status" : "no status",
             );
           } catch (loadError: any) {
-            console.error(
-              "[MediaMessage] Error in loadAsync/playAsync:",
+            logger.error(
+              "MediaMessage",
+              "Error in loadAsync/playAsync",
               loadError?.message || loadError,
             );
             // Don't rethrow, let the component handle it
           }
         } catch (error: any) {
-          console.error(
-            "[MediaMessage] Error loading/playing video:",
+          logger.error(
+            "MediaMessage",
+            "Error loading/playing video",
             error?.message || error,
           );
           // Don't show alert here, let onError handle it
@@ -312,21 +315,31 @@ export const MediaMessage: React.FC<MediaMessageProps> = ({
 
   // Video with thumbnail and player
   const handleVideoPress = async () => {
-    console.log("[MediaMessage] Video pressed, opening player");
+    logger.debug("MediaMessage", "Video pressed, opening player");
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
 
     if (!Video) {
-      // Fallback: ouvrir dans le lecteur natif
-      console.log("[MediaMessage] expo-av not available, opening with Linking");
+      // Fallback: ouvrir dans le lecteur natif. On valide le scheme avant
+      // d'appeler Linking pour eviter qu'une URL backend compromise (ex:
+      // javascript:, intent:) ne devienne un vecteur d'execution.
+      logger.debug(
+        "MediaMessage",
+        "expo-av not available, opening with Linking",
+      );
+      const target = resolvedMainUri || uri;
+      if (!isHttpUrl(target)) {
+        Alert.alert("Erreur", "Impossible d'ouvrir la vidéo.");
+        return;
+      }
       try {
-        const supported = await Linking.canOpenURL(resolvedMainUri || uri);
+        const supported = await Linking.canOpenURL(target);
         if (supported) {
-          await Linking.openURL(resolvedMainUri || uri);
+          await Linking.openURL(target);
         } else {
           Alert.alert("Erreur", "Impossible d'ouvrir la vidéo.");
         }
       } catch (error) {
-        console.error("[MediaMessage] Error opening video:", error);
+        logger.error("MediaMessage", "Error opening video", error);
         Alert.alert("Erreur", "Impossible d'ouvrir la vidéo.");
       }
       return;
@@ -336,17 +349,17 @@ export const MediaMessage: React.FC<MediaMessageProps> = ({
   };
 
   const handleCloseVideo = () => {
-    console.log("[MediaMessage] Closing video player");
+    logger.debug("MediaMessage", "Closing video player");
     if (playerVideoRef.current && Video) {
       try {
         playerVideoRef.current
           .pauseAsync()
           .then(() => playerVideoRef.current?.unloadAsync?.())
           .catch((error: any) => {
-            console.error("[MediaMessage] Error stopping video:", error);
+            logger.error("MediaMessage", "Error stopping video", error);
           });
       } catch (error) {
-        console.error("[MediaMessage] Error pausing video:", error);
+        logger.error("MediaMessage", "Error pausing video", error);
       }
     }
     setShowVideoPlayer(false);
@@ -378,26 +391,30 @@ export const MediaMessage: React.FC<MediaMessageProps> = ({
             onLoad={(status: any) => {
               // Silently ignore null or invalid status to prevent crashes
               if (!status || typeof status !== "object" || status === null) {
-                console.log(
-                  "[MediaMessage] Video thumbnail loaded (null status, ignoring)",
+                logger.debug(
+                  "MediaMessage",
+                  "Video thumbnail loaded (null status, ignoring)",
                 );
                 return;
               }
               try {
-                console.log(
-                  "[MediaMessage] Video thumbnail loaded successfully",
+                logger.debug(
+                  "MediaMessage",
+                  "Video thumbnail loaded successfully",
                 );
                 setThumbnailError(false);
               } catch (error: any) {
                 // Silently ignore errors
-                console.log(
-                  "[MediaMessage] Thumbnail load completed (status may be null, ignoring)",
+                logger.debug(
+                  "MediaMessage",
+                  "Thumbnail load completed (status may be null, ignoring)",
                 );
               }
             }}
             onError={(error: any) => {
-              console.error(
-                "[MediaMessage] Video thumbnail error, using placeholder:",
+              logger.error(
+                "MediaMessage",
+                "Video thumbnail error, using placeholder",
                 error?.message || error,
               );
               setThumbnailError(true);
@@ -499,36 +516,40 @@ export const MediaMessage: React.FC<MediaMessageProps> = ({
                       if (isLoaded && !isPlaying && playerVideoRef.current) {
                         // Auto-play if loaded but not playing
                         playerVideoRef.current.playAsync().catch((err: any) => {
-                          console.error(
-                            "[MediaMessage] Error auto-playing:",
+                          logger.error(
+                            "MediaMessage",
+                            "Error auto-playing",
                             err?.message || err,
                           );
                         });
                       }
                     } catch (error: any) {
                       // Silently catch all errors to prevent crashes
-                      console.error(
-                        "[MediaMessage] Error in onPlaybackStatusUpdate:",
+                      logger.error(
+                        "MediaMessage",
+                        "Error in onPlaybackStatusUpdate",
                         error?.message || error,
                       );
                     }
                   }}
                   onLoadStart={() => {
-                    console.log("[MediaMessage] Video load started");
+                    logger.debug("MediaMessage", "Video load started");
                   }}
                   onLoad={(status: any) => {
                     // Completely ignore null/undefined status to prevent crashes
                     if (status == null || typeof status !== "object") {
-                      console.log(
-                        "[MediaMessage] Video loaded (null/undefined status, ignoring)",
+                      logger.debug(
+                        "MediaMessage",
+                        "Video loaded (null/undefined status, ignoring)",
                       );
                       return;
                     }
                     try {
                       // Safely access properties with optional chaining
                       const isLoaded = status?.isLoaded === true;
-                      console.log(
-                        "[MediaMessage] Video loaded, auto-playing",
+                      logger.debug(
+                        "MediaMessage",
+                        "Video loaded, auto-playing",
                         isLoaded,
                       );
                       if (status) {
@@ -537,24 +558,27 @@ export const MediaMessage: React.FC<MediaMessageProps> = ({
                       // Auto-play immediately when loaded
                       if (playerVideoRef.current && isLoaded) {
                         playerVideoRef.current.playAsync().catch((err: any) => {
-                          console.error(
-                            "[MediaMessage] Error playing after load:",
+                          logger.error(
+                            "MediaMessage",
+                            "Error playing after load",
                             err?.message || err,
                           );
                         });
                       }
                     } catch (error: any) {
                       // Silently catch all errors to prevent crashes
-                      console.error(
-                        "[MediaMessage] Error in onLoad:",
+                      logger.error(
+                        "MediaMessage",
+                        "Error in onLoad",
                         error?.message || error,
                       );
                     }
                   }}
                   onError={(error: any) => {
                     // Catch error but don't show alert to avoid interrupting user
-                    console.error(
-                      "[MediaMessage] Video error:",
+                    logger.error(
+                      "MediaMessage",
+                      "Video error",
                       error?.message || error,
                     );
                   }}
@@ -573,6 +597,10 @@ export const MediaMessage: React.FC<MediaMessageProps> = ({
                 <TouchableOpacity
                   style={styles.videoFallbackButton}
                   onPress={async () => {
+                    if (!isHttpUrl(uri)) {
+                      Alert.alert("Erreur", "Impossible d'ouvrir la vidéo.");
+                      return;
+                    }
                     try {
                       const supported = await Linking.canOpenURL(uri);
                       if (supported) {
@@ -582,7 +610,11 @@ export const MediaMessage: React.FC<MediaMessageProps> = ({
                         Alert.alert("Erreur", "Impossible d'ouvrir la vidéo.");
                       }
                     } catch (error) {
-                      console.error("[MediaMessage] Error:", error);
+                      logger.error(
+                        "MediaMessage",
+                        "Error opening video",
+                        error,
+                      );
                       Alert.alert("Erreur", "Impossible d'ouvrir la vidéo.");
                     }
                   }}

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -201,11 +201,9 @@ export const AuthService = {
           cooldownUntil = 0;
         } catch (err) {
           const status = (err as { status?: number })?.status;
-          console.error(
-            "[AuthService] refreshTokens failed, status=",
-            status,
-            err,
-          );
+          // ne pas logger `err` brut : le body peut contenir le refresh_token
+          // ou un autre secret renvoye par auth-service en cas d'erreur.
+          logger.warn("AuthService", "refreshTokens failed", { status });
 
           if (status === 401 || status === 403) {
             // Auth said "no" — session genuinely dead.

--- a/src/services/moderation/appealApi.ts
+++ b/src/services/moderation/appealApi.ts
@@ -3,10 +3,11 @@ import { TokenService } from "../TokenService";
 import { getApiBaseUrl } from "../apiBase";
 
 /**
- * Données fictives — flux contestation sans appel API réel.
- * TODO(retirer): passer à `false` ou supprimer ce bloc quand POST /moderation/appeal est OK en preprod.
+ * Donnees fictives - flux contestation sans appel API reel quand on tourne
+ * en dev local sans backend moderation up. En preprod / prod, __DEV__ est
+ * false, on tape donc directement le vrai endpoint.
  */
-export const MOCK_MODERATION_APPEAL_SUCCESS = __DEV__ && true;
+export const MOCK_MODERATION_APPEAL_SUCCESS = __DEV__;
 
 const mockDelayMs = 600;
 

--- a/src/services/storage.web.ts
+++ b/src/services/storage.web.ts
@@ -1,9 +1,13 @@
 import { isWrapped, unwrap, wrap } from "./webCryptoVault.web";
 
-// Keys whose values must never sit in localStorage as plaintext. Anything
-// not in this set is stored as-is (short-lived auth tokens are out of scope
-// for this fix — see WHISPR-1212).
-const SECURE_KEYS = new Set<string>(["whispr.signal.identityKeyPrivate"]);
+// Cles dont les valeurs ne doivent jamais finir en clair dans localStorage.
+// On y inclut la cle d'identite Signal (WHISPR-1212) et les tokens d'auth
+// (WHISPR-1328) pour limiter l'exposition en cas de XSS sur le PWA web.
+const SECURE_KEYS = new Set<string>([
+  "whispr.signal.identityKeyPrivate",
+  "whispr.auth.accessToken",
+  "whispr.auth.refreshToken",
+]);
 
 function isSecure(key: string): boolean {
   return SECURE_KEYS.has(key);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,7 +3,7 @@ export { FormattedText } from "./textFormatter";
 export { logger } from "./logger";
 export { copyToClipboard } from "./clipboard";
 export { toSnakeCase, snakecaseKeys } from "./caseTransform";
-export { isReachableUrl } from "./urlFilters";
+export { isReachableUrl, isHttpUrl } from "./urlFilters";
 
 /**
  * Format a username for display with a single "@" prefix.

--- a/src/utils/urlFilters.ts
+++ b/src/utils/urlFilters.ts
@@ -10,3 +10,19 @@ export const isReachableUrl = (url?: string | null): boolean => {
   if (/^http:\/\/(minio|[\d.]+:)/i.test(url)) return false;
   return true;
 };
+
+/**
+ * Verifie qu'une URL utilise un schema http(s) avant de la passer a
+ * Linking.openURL. Empeche un backend compromis ou un payload malveillant
+ * d'injecter `javascript:`, `intent:`, `file:` ou tout autre schema qui
+ * ouvrirait un vecteur d'execution arbitraire cote client.
+ */
+export const isHttpUrl = (url?: string | null): boolean => {
+  if (typeof url !== "string" || url.length === 0) return false;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" || parsed.protocol === "http:";
+  } catch {
+    return false;
+  }
+};

--- a/storage.web.test.ts
+++ b/storage.web.test.ts
@@ -65,11 +65,34 @@ describe("storage.web (secure key handling)", () => {
     expect(localStorage.getItem(IDENTITY_KEY)).toBeNull();
   });
 
-  it("leaves non-secure keys untouched (no wrapping for tokens)", async () => {
+  it("wraps auth tokens just like the identity key (WHISPR-1328)", async () => {
     const accessToken = "header.payload.signature";
     await storage.setItem("whispr.auth.accessToken", accessToken);
-    expect(localStorage.getItem("whispr.auth.accessToken")).toBe(accessToken);
+
+    const stored = localStorage.getItem("whispr.auth.accessToken");
+    expect(stored).not.toBeNull();
+    expect(stored).not.toBe(accessToken);
+    expect(stored!.startsWith(WEB_VAULT_PREFIX)).toBe(true);
     expect(await storage.getItem("whispr.auth.accessToken")).toBe(accessToken);
+  });
+
+  it("wraps the refresh token alongside the access token", async () => {
+    const refreshToken = "refresh-token-secret";
+    await storage.setItem("whispr.auth.refreshToken", refreshToken);
+
+    const stored = localStorage.getItem("whispr.auth.refreshToken");
+    expect(stored).not.toBeNull();
+    expect(stored).not.toBe(refreshToken);
+    expect(stored!.startsWith(WEB_VAULT_PREFIX)).toBe(true);
+    expect(await storage.getItem("whispr.auth.refreshToken")).toBe(
+      refreshToken,
+    );
+  });
+
+  it("leaves arbitrary non-secure keys untouched", async () => {
+    await storage.setItem("whispr.misc.flag", "1");
+    expect(localStorage.getItem("whispr.misc.flag")).toBe("1");
+    expect(await storage.getItem("whispr.misc.flag")).toBe("1");
   });
 
   it("deleteItem removes the stored value", async () => {

--- a/urlFilters.test.ts
+++ b/urlFilters.test.ts
@@ -1,4 +1,4 @@
-import { isReachableUrl } from "./src/utils/urlFilters";
+import { isHttpUrl, isReachableUrl } from "./src/utils/urlFilters";
 
 describe("isReachableUrl", () => {
   it("returns false for undefined", () => {
@@ -49,5 +49,44 @@ describe("isReachableUrl", () => {
 
   it("accepts http URLs that do not match the blocked patterns", () => {
     expect(isReachableUrl("http://cdn.example.com/avatar.png")).toBe(true);
+  });
+});
+
+describe("isHttpUrl", () => {
+  it("accepts https URLs", () => {
+    expect(isHttpUrl("https://example.com")).toBe(true);
+  });
+
+  it("accepts http URLs", () => {
+    expect(isHttpUrl("http://example.com")).toBe(true);
+  });
+
+  it("rejects javascript: scheme", () => {
+    expect(isHttpUrl("javascript:alert(1)")).toBe(false);
+  });
+
+  it("rejects intent: scheme used by Android attacks", () => {
+    expect(isHttpUrl("intent://example#Intent;scheme=http;end")).toBe(false);
+  });
+
+  it("rejects file: scheme", () => {
+    expect(isHttpUrl("file:///etc/passwd")).toBe(false);
+  });
+
+  it("rejects data: scheme", () => {
+    expect(isHttpUrl("data:text/html,<script>alert(1)</script>")).toBe(false);
+  });
+
+  it("rejects malformed input", () => {
+    expect(isHttpUrl("not a url")).toBe(false);
+  });
+
+  it("rejects null and undefined", () => {
+    expect(isHttpUrl(null)).toBe(false);
+    expect(isHttpUrl(undefined)).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(isHttpUrl("")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Sept fixes ciblant les findings auto-fixables de l'audit securite mobile-app :

- **HIGH-1** `fix(auth)` : `console.error` -> `logger.warn` dans `AuthService.refreshTokens` ; on ne logge plus l'objet d'erreur brut qui pouvait leak le `refresh_token` ou un autre secret renvoye par auth-service.
- **HIGH-2** `fix(chat)` : validation du schema URL avant `Linking.openURL` dans `LinkPreviewCard` (et meme garde dans `MediaMessage`). Un backend compromis ne peut plus pousser `javascript:`, `intent:`, `file:` ou `data:` via la link preview pour obtenir de l'execution arbitraire client.
- **HIGH-3** `fix(mobile)` : declaration des permissions Contacts manquantes (`NSContactsUsageDescription` iOS + `READ_CONTACTS` Android). `expo-contacts` ne crashera plus au runtime sur iOS et le prompt Android sera correct.
- **MEDIUM-1** `fix(security)` : `whispr.auth.accessToken` et `whispr.auth.refreshToken` rejoignent `SECURE_KEYS` dans `storage.web.ts`, donc les tokens sont desormais wrappes via `webCryptoVault` au lieu d'etre stockes en clair dans `localStorage` (mitigation XSS sur la PWA).
- **MEDIUM-4** `fix(chat)` : tous les `console.log/error/warn` de `MediaMessage` passent par `logger.debug/error/warn`, gates derriere `__DEV__`. Plus de logs verbeux en prod.
- **LOW-1** `chore(config)` : suppression de `devAuthApiUrl` / `devUserApiUrl` (`http://10.0.2.2:3010`) dans `app.json` et `app.config.js`. Ces hosts dev locaux n'ont jamais ete consommes mais polluaient les metadata du bundle.
- **LOW-2** `chore(moderation)` : suppression du `&& true` et du `TODO(retirer)` sur `MOCK_MODERATION_APPEAL_SUCCESS`. Le flag reste gate par `__DEV__` seul.

## Test plan

- [x] `npm test -- --watchAll=false` -> 95 suites / 917 tests verts (5 nouveaux tests sur `LinkPreviewCard URL scheme guard` + 9 sur `isHttpUrl`, plus 2 maj sur `storage.web` pour les tokens wrappes)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint:fix` -> 0 errors (warnings preexistants uniquement)
- [ ] Smoke test sur preprod apres merge : ouverture de link preview, sync de contacts iOS/Android, refresh token round-trip web

Closes WHISPR-1328