### PR TITLE
fix(mobile): restore scroll and layout on MyProfile + Calls screens (web+iOS)

### DIFF
--- a/src/components/Chat/Avatar.tsx
+++ b/src/components/Chat/Avatar.tsx
@@ -72,7 +72,15 @@ export const Avatar: React.FC<AvatarProps> = ({
     const raw = typeof uri === "string" ? uri.trim() : "";
     if (!raw) return { uri: undefined, mediaId: undefined };
 
-    if (raw.startsWith("file://") || raw.startsWith("data:")) {
+    // WHISPR-1335 - sur web, le selecteur d'image fallback expose un
+    // URL.createObjectURL() qui produit un URI "blob:". On doit le
+    // passer tel quel a <Image> pour afficher la preview, sinon la photo
+    // fraichement choisie ne s'affiche pas avant l'upload.
+    if (
+      raw.startsWith("file://") ||
+      raw.startsWith("data:") ||
+      raw.startsWith("blob:")
+    ) {
       return { uri: raw, mediaId: undefined };
     }
 

--- a/src/screens/Calls/CallsScreen.tsx
+++ b/src/screens/Calls/CallsScreen.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { StyleSheet, View } from "react-native";
+import { Platform, StyleSheet, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { LinearGradient } from "expo-linear-gradient";
 import { CallHistoryScreen } from "./CallHistoryScreen";
@@ -25,12 +25,18 @@ export const CallsScreen: React.FC = () => {
 const styles = StyleSheet.create({
   gradient: {
     flex: 1,
+    // WHISPR-1254 / WHISPR-1335 - sur react-native-web le wrapper racine
+    // doit borner la hauteur du viewport sinon flex:1 ne propage pas et
+    // la FlatList des appels n'est ni visible ni scrollable.
+    ...(Platform.OS === "web" ? { height: "100%" } : {}),
   },
   container: {
     flex: 1,
+    ...(Platform.OS === "web" ? { minHeight: 0 } : {}),
   },
   content: {
     flex: 1,
+    ...(Platform.OS === "web" ? { minHeight: 0 } : {}),
   },
 });
 

--- a/src/screens/Profile/MyProfileScreen.tsx
+++ b/src/screens/Profile/MyProfileScreen.tsx
@@ -611,7 +611,25 @@ export const MyProfileScreen: React.FC = () => {
   const handleHomePress = () => navigation.navigate("ConversationsList");
 
   const handleBackPress = () => {
+    // WHISPR-1335 - Alert.alert sur react-native-web ne rend pas le menu
+    // d'actions; le bouton Retour parait inactif. On retombe sur
+    // window.confirm (single-action) sur web pour ne pas bloquer.
+    const confirmWeb = (msg: string) =>
+      typeof window !== "undefined" &&
+      typeof window.confirm === "function" &&
+      window.confirm(msg);
+
     if (loading) {
+      if (Platform.OS === "web") {
+        if (
+          confirmWeb("Sauvegarde en cours. Annuler la sauvegarde et quitter ?")
+        ) {
+          cancelSave();
+          setIsEditing(false);
+          navigation.goBack();
+        }
+        return;
+      }
       Alert.alert(
         "Sauvegarde en cours",
         "Voulez-vous annuler la sauvegarde et quitter ?",
@@ -629,6 +647,17 @@ export const MyProfileScreen: React.FC = () => {
         ],
       );
     } else if (isEditing) {
+      if (Platform.OS === "web") {
+        if (
+          confirmWeb(
+            "Modifications non sauvegardees. Quitter sans sauvegarder ?",
+          )
+        ) {
+          setIsEditing(false);
+          navigation.goBack();
+        }
+        return;
+      }
       Alert.alert(
         "Modifications non sauvegardées",
         "Voulez-vous vraiment quitter sans sauvegarder ?",
@@ -702,7 +731,8 @@ export const MyProfileScreen: React.FC = () => {
 
           <ScrollView
             style={styles.scrollView}
-            showsVerticalScrollIndicator={false}
+            contentContainerStyle={styles.scrollContent}
+            showsVerticalScrollIndicator={Platform.OS === "web"}
           >
             <ProfilePictureBlock
               uri={profile.profilePicture}
@@ -910,9 +940,22 @@ export const MyProfileScreen: React.FC = () => {
 };
 
 const styles = StyleSheet.create({
-  container: { flex: 1 },
-  keyboardView: { flex: 1 },
-  content: { flex: 1 },
+  container: {
+    flex: 1,
+    // WHISPR-1254 / WHISPR-1335 - sur react-native-web le wrapper racine
+    // doit borner la hauteur du viewport sinon flex:1 ne propage pas aux
+    // enfants et la ScrollView ne peut pas scroller (bouton Sauvegarder
+    // hors ecran).
+    ...(Platform.OS === "web" ? { height: "100%" } : {}),
+  },
+  keyboardView: {
+    flex: 1,
+    ...(Platform.OS === "web" ? { minHeight: 0 } : {}),
+  },
+  content: {
+    flex: 1,
+    ...(Platform.OS === "web" ? { minHeight: 0 } : {}),
+  },
   iconButton: { padding: spacing.sm },
   cancelButtonText: {
     fontSize: typography.fontSize.base,
@@ -922,6 +965,14 @@ const styles = StyleSheet.create({
   scrollView: {
     flex: 1,
     paddingHorizontal: spacing.lg,
+    // WHISPR-1254 / WHISPR-1335 - minHeight:0 autorise la ScrollView a
+    // overflow verticalement au lieu de pousser ses parents.
+    ...(Platform.OS === "web" ? { minHeight: 0 } : {}),
+  },
+  scrollContent: {
+    // garantir un padding bas suffisant pour que le bouton Sauvegarder
+    // ne soit pas masque par la BottomTabBar flottante sur web et iOS.
+    paddingBottom: spacing.xxxl,
   },
   profileInfo: {
     paddingBottom: spacing.sm,
@@ -953,6 +1004,10 @@ const styles = StyleSheet.create({
   nameInputsContainer: {
     flexDirection: "row",
     gap: spacing.sm,
+    // WHISPR-1335 - Safari iOS web: sans minWidth:0 sur le container, les
+    // flex items conservent leur min-width:auto et debordent du parent
+    // (le second input "Nom" sort a droite de l'ecran).
+    ...(Platform.OS === "web" ? { width: "100%" } : {}),
   },
   input: {
     borderWidth: 1,
@@ -970,7 +1025,13 @@ const styles = StyleSheet.create({
     shadowRadius: 4,
     elevation: 2,
   },
-  nameInput: { flex: 1 },
+  nameInput: {
+    flex: 1,
+    // WHISPR-1335 - en CSS flexbox, min-width:auto fait que l'input garde
+    // sa taille intrinseque et peut depasser du parent. minWidth:0 force
+    // les deux inputs a partager equitablement la largeur disponible.
+    ...(Platform.OS === "web" ? { minWidth: 0 } : {}),
+  },
   biographyInput: {
     height: 100,
     textAlignVertical: "top",


### PR DESCRIPTION
## Summary

Fixes a UI regression on Safari iOS PWA and native iOS reported on preprod:

- **MyProfileScreen** : ScrollView ne scrollait plus sur web (bouton Sauvegarder hors ecran), le second input du champ Nom complet sortait a droite de l'ecran sur Safari iOS, le bouton Retour en mode edition restait inactif (Alert.alert ne rend pas correctement sur web), pas de preview de la photo apres selection (URI blob: non geree dans Avatar).
- **CallsScreen** : la liste d'appels n'etait pas visible / pas scrollable sur web car le wrapper ne portait pas la chaine flex WHISPR-1254 (height:100% / minHeight:0).

ConversationsListScreen et ContactsScreen ont deja le pattern WHISPR-1254 et n'ont pas ete touches dans cette PR.

## Changes

- 'src/screens/Profile/MyProfileScreen.tsx' : applique le pattern WHISPR-1254 (height:100% / minHeight:0 web), ajoute minWidth:0 sur les inputs du nom complet, fallback window.confirm a la place de Alert.alert sur web pour le retour en mode edition, contentContainerStyle pour reserver la place du bouton Sauvegarder.
- 'src/components/Chat/Avatar.tsx' : autorise les URI 'blob:' (en plus de file:/ et data:) pour preview avatar avant upload.
- 'src/screens/Calls/CallsScreen.tsx' : applique height:100% / minHeight:0 au gradient et aux containers internes.

## Test plan

- [x] 'npm test -- --watchAll=false' : 95 suites / 917 tests verts
- [x] 'tsc --noEmit' clean
- [x] 'lint:fix' : 0 erreurs (warnings preexistants no-explicit-any uniquement)
- [ ] Tester sur Safari iOS preprod (whispr-preprod.roadmvn.com) : scroll MyProfile, layout des inputs Prenom/Nom, preview photo, bouton Retour
- [ ] Tester sur natif iOS dev build : MyProfile scroll + layout
- [ ] Tester ecran Appels sur web preprod

Closes WHISPR-1335
Refs WHISPR-1254 / WHISPR-1291 / WHISPR-1313