### PR TITLE
[WHISPR-1336] docs(mobile): DANGER ZONE comments on layout-sensitive screens

### DIFF
--- a/src/components/Chat/Avatar.tsx
+++ b/src/components/Chat/Avatar.tsx
@@ -8,6 +8,25 @@
  * le chargement, on affiche les initiales plutot que l'URL non auth.
  */
 
+/**
+ * @danger-zone-mobile-layout
+ *
+ * DANGER ZONE - Avatar URI parsing critique
+ *
+ * Bug historique : `extractMediaIdFromUri` doit reconnaitre `blob:` URIs (creees
+ * par URL.createObjectURL cote web) en plus de `file://` et `data:`. Sans ca,
+ * preview photo cassee apres upload sur PWA web.
+ *
+ * AVANT TOUTE MODIF :
+ * 1. Tester live upload photo profil sur Safari iOS PWA (whispr-preprod.roadmvn.com).
+ * 2. Verifier que preview s'affiche apres selection (avant upload).
+ * 3. Preserver le support des 3 schemes : file:, data:, blob:.
+ *
+ * Tickets historiques : WHISPR-1335
+ *
+ * Tag parsable : @danger-zone-mobile-layout
+ */
+
 import React from "react";
 import { View, Text, StyleSheet, Image } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";

--- a/src/screens/Auth/ProfileSetupScreen.tsx
+++ b/src/screens/Auth/ProfileSetupScreen.tsx
@@ -1,3 +1,21 @@
+/**
+ * @danger-zone-mobile-layout
+ *
+ * DANGER ZONE - Layout web/iOS critique
+ *
+ * Bug historique : scroll bottom inaccessible sur Safari iOS PWA si la chaine flex
+ * ne porte pas le pattern WHISPR-1254 (height:100% + minHeight:0 web).
+ *
+ * AVANT TOUTE MODIF :
+ * 1. Tester live sur Safari iOS PWA (whispr-preprod.roadmvn.com).
+ * 2. Verifier scroll vers le bas + boutons visibles + retour fonctionnel.
+ * 3. Preserver les Platform.OS === 'web' ? minHeight:0 sur containers/scroll.
+ *
+ * Tickets historiques : WHISPR-1254, WHISPR-1291, WHISPR-1313, WHISPR-1335
+ *
+ * Tag parsable : @danger-zone-mobile-layout (utilise par script CI grep pour detection).
+ */
+
 import React, { useRef, useState } from "react";
 import {
   ActivityIndicator,

--- a/src/screens/Calls/CallsScreen.tsx
+++ b/src/screens/Calls/CallsScreen.tsx
@@ -1,3 +1,21 @@
+/**
+ * @danger-zone-mobile-layout
+ *
+ * DANGER ZONE - Layout web/iOS critique
+ *
+ * Bug historique : scroll bottom inaccessible sur Safari iOS PWA si la chaine flex
+ * ne porte pas le pattern WHISPR-1254 (height:100% + minHeight:0 web).
+ *
+ * AVANT TOUTE MODIF :
+ * 1. Tester live sur Safari iOS PWA (whispr-preprod.roadmvn.com).
+ * 2. Verifier scroll vers le bas + boutons visibles + retour fonctionnel.
+ * 3. Preserver les Platform.OS === 'web' ? minHeight:0 sur containers/scroll.
+ *
+ * Tickets historiques : WHISPR-1254, WHISPR-1291, WHISPR-1313, WHISPR-1335
+ *
+ * Tag parsable : @danger-zone-mobile-layout (utilise par script CI grep pour detection).
+ */
+
 import React from "react";
 import { Platform, StyleSheet, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";

--- a/src/screens/Chat/ConversationsListScreen.tsx
+++ b/src/screens/Chat/ConversationsListScreen.tsx
@@ -3,6 +3,24 @@
  * Displays list of conversations with real-time updates
  */
 
+/**
+ * @danger-zone-mobile-layout
+ *
+ * DANGER ZONE - Layout web/iOS critique
+ *
+ * Bug historique : scroll bottom inaccessible sur Safari iOS PWA si la chaine flex
+ * ne porte pas le pattern WHISPR-1254 (height:100% + minHeight:0 web).
+ *
+ * AVANT TOUTE MODIF :
+ * 1. Tester live sur Safari iOS PWA (whispr-preprod.roadmvn.com).
+ * 2. Verifier scroll vers le bas + boutons visibles + retour fonctionnel.
+ * 3. Preserver les Platform.OS === 'web' ? minHeight:0 sur containers/scroll.
+ *
+ * Tickets historiques : WHISPR-1254, WHISPR-1291, WHISPR-1313, WHISPR-1335
+ *
+ * Tag parsable : @danger-zone-mobile-layout (utilise par script CI grep pour detection).
+ */
+
 import React, { useState, useEffect, useCallback, useMemo } from "react";
 import {
   View,

--- a/src/screens/Contacts/ContactsScreen.tsx
+++ b/src/screens/Contacts/ContactsScreen.tsx
@@ -1,3 +1,21 @@
+/**
+ * @danger-zone-mobile-layout
+ *
+ * DANGER ZONE - Layout web/iOS critique
+ *
+ * Bug historique : scroll bottom inaccessible sur Safari iOS PWA si la chaine flex
+ * ne porte pas le pattern WHISPR-1254 (height:100% + minHeight:0 web).
+ *
+ * AVANT TOUTE MODIF :
+ * 1. Tester live sur Safari iOS PWA (whispr-preprod.roadmvn.com).
+ * 2. Verifier scroll vers le bas + boutons visibles + retour fonctionnel.
+ * 3. Preserver les Platform.OS === 'web' ? minHeight:0 sur containers/scroll.
+ *
+ * Tickets historiques : WHISPR-1254, WHISPR-1291, WHISPR-1313, WHISPR-1335
+ *
+ * Tag parsable : @danger-zone-mobile-layout (utilise par script CI grep pour detection).
+ */
+
 import React, {
   useState,
   useEffect,

--- a/src/screens/Moderation/MySanctionsScreen.tsx
+++ b/src/screens/Moderation/MySanctionsScreen.tsx
@@ -3,6 +3,24 @@
  * WHISPR-1043
  */
 
+/**
+ * @danger-zone-mobile-layout
+ *
+ * DANGER ZONE - Layout web/iOS critique
+ *
+ * Bug historique : scroll bottom inaccessible sur Safari iOS PWA si la chaine flex
+ * ne porte pas le pattern WHISPR-1254 (height:100% + minHeight:0 web).
+ *
+ * AVANT TOUTE MODIF :
+ * 1. Tester live sur Safari iOS PWA (whispr-preprod.roadmvn.com).
+ * 2. Verifier scroll vers le bas + boutons visibles + retour fonctionnel.
+ * 3. Preserver les Platform.OS === 'web' ? minHeight:0 sur containers/scroll.
+ *
+ * Tickets historiques : WHISPR-1254, WHISPR-1291, WHISPR-1313, WHISPR-1335
+ *
+ * Tag parsable : @danger-zone-mobile-layout (utilise par script CI grep pour detection).
+ */
+
 import React, { useEffect, useCallback } from "react";
 import {
   View,

--- a/src/screens/Profile/MyProfileScreen.tsx
+++ b/src/screens/Profile/MyProfileScreen.tsx
@@ -3,6 +3,24 @@
  * Séparé de UserProfileScreen (consultation d'un profil tiers) — WHISPR-1189.
  */
 
+/**
+ * @danger-zone-mobile-layout
+ *
+ * DANGER ZONE - Layout web/iOS critique
+ *
+ * Bug historique : scroll bottom inaccessible sur Safari iOS PWA si la chaine flex
+ * ne porte pas le pattern WHISPR-1254 (height:100% + minHeight:0 web).
+ *
+ * AVANT TOUTE MODIF :
+ * 1. Tester live sur Safari iOS PWA (whispr-preprod.roadmvn.com).
+ * 2. Verifier scroll vers le bas + boutons visibles + retour fonctionnel.
+ * 3. Preserver les Platform.OS === 'web' ? minHeight:0 sur containers/scroll.
+ *
+ * Tickets historiques : WHISPR-1254, WHISPR-1291, WHISPR-1313, WHISPR-1335
+ *
+ * Tag parsable : @danger-zone-mobile-layout (utilise par script CI grep pour detection).
+ */
+
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import {
   View,

--- a/src/screens/Profile/UserProfileScreen.tsx
+++ b/src/screens/Profile/UserProfileScreen.tsx
@@ -3,6 +3,24 @@
  * Séparé de MyProfileScreen (édition du profil personnel) — WHISPR-1189.
  */
 
+/**
+ * @danger-zone-mobile-layout
+ *
+ * DANGER ZONE - Layout web/iOS critique
+ *
+ * Bug historique : scroll bottom inaccessible sur Safari iOS PWA si la chaine flex
+ * ne porte pas le pattern WHISPR-1254 (height:100% + minHeight:0 web).
+ *
+ * AVANT TOUTE MODIF :
+ * 1. Tester live sur Safari iOS PWA (whispr-preprod.roadmvn.com).
+ * 2. Verifier scroll vers le bas + boutons visibles + retour fonctionnel.
+ * 3. Preserver les Platform.OS === 'web' ? minHeight:0 sur containers/scroll.
+ *
+ * Tickets historiques : WHISPR-1254, WHISPR-1291, WHISPR-1313, WHISPR-1335
+ *
+ * Tag parsable : @danger-zone-mobile-layout (utilise par script CI grep pour detection).
+ */
+
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   View,

--- a/src/screens/Security/TwoFactorAuthScreen.tsx
+++ b/src/screens/Security/TwoFactorAuthScreen.tsx
@@ -3,6 +3,24 @@
  * Two-factor authentication management screen
  */
 
+/**
+ * @danger-zone-mobile-layout
+ *
+ * DANGER ZONE - Layout web/iOS critique
+ *
+ * Bug historique : scroll bottom inaccessible sur Safari iOS PWA si la chaine flex
+ * ne porte pas le pattern WHISPR-1254 (height:100% + minHeight:0 web).
+ *
+ * AVANT TOUTE MODIF :
+ * 1. Tester live sur Safari iOS PWA (whispr-preprod.roadmvn.com).
+ * 2. Verifier scroll vers le bas + boutons visibles + retour fonctionnel.
+ * 3. Preserver les Platform.OS === 'web' ? minHeight:0 sur containers/scroll.
+ *
+ * Tickets historiques : WHISPR-1254, WHISPR-1291, WHISPR-1313, WHISPR-1335
+ *
+ * Tag parsable : @danger-zone-mobile-layout (utilise par script CI grep pour detection).
+ */
+
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import {
   View,

--- a/src/screens/Security/TwoFactorSetupScreen.tsx
+++ b/src/screens/Security/TwoFactorSetupScreen.tsx
@@ -1,3 +1,21 @@
+/**
+ * @danger-zone-mobile-layout
+ *
+ * DANGER ZONE - Layout web/iOS critique
+ *
+ * Bug historique : scroll bottom inaccessible sur Safari iOS PWA si la chaine flex
+ * ne porte pas le pattern WHISPR-1254 (height:100% + minHeight:0 web).
+ *
+ * AVANT TOUTE MODIF :
+ * 1. Tester live sur Safari iOS PWA (whispr-preprod.roadmvn.com).
+ * 2. Verifier scroll vers le bas + boutons visibles + retour fonctionnel.
+ * 3. Preserver les Platform.OS === 'web' ? minHeight:0 sur containers/scroll.
+ *
+ * Tickets historiques : WHISPR-1254, WHISPR-1291, WHISPR-1313, WHISPR-1335
+ *
+ * Tag parsable : @danger-zone-mobile-layout (utilise par script CI grep pour detection).
+ */
+
 import React, {
   useState,
   useRef,


### PR DESCRIPTION
## Summary

Add `@danger-zone-mobile-layout` JSDoc blocks at the head of 10 layout-sensitive mobile-app files (Wave 21 part 2). Each block lists the historic regression tickets, the verification steps to follow before any modification, and a parsable tag for a future CI grep check.

Conforming to global rule § 34 (audit visuel UI obligatoire avant merge mobile/frontend) which calls for `// DANGER ZONE` markers on the listed files.

## Files annotated (10/10)

- `src/screens/Chat/ConversationsListScreen.tsx` (cf WHISPR-1254)
- `src/screens/Contacts/ContactsScreen.tsx` (cf WHISPR-1291)
- `src/screens/Profile/UserProfileScreen.tsx` (cf WHISPR-1313)
- `src/screens/Profile/MyProfileScreen.tsx` (cf WHISPR-1335)
- `src/screens/Moderation/MySanctionsScreen.tsx` (cf WHISPR-1313)
- `src/screens/Auth/ProfileSetupScreen.tsx` (cf WHISPR-1313)
- `src/screens/Security/TwoFactorSetupScreen.tsx` (cf WHISPR-1313)
- `src/screens/Security/TwoFactorAuthScreen.tsx` (cf WHISPR-1313)
- `src/screens/Calls/CallsScreen.tsx` (cf WHISPR-1335)
- `src/components/Chat/Avatar.tsx` (cf WHISPR-1335 - URI parsing variant)

## Test plan

- [x] `npm test -- --watchAll=false` green (917/917)
- [x] `npm run lint:fix` 0 errors
- [x] `npx prettier --write` clean
- [x] `npx tsc --noEmit` clean
- [x] `grep '@danger-zone-mobile-layout'` present in each of the 10 files
- [ ] All bot reviews green before merge (Copilot, Sonar, Codecov, GitGuardian, CodeQL, Trivy)

Closes WHISPR-1336