### PR TITLE
test(e2e): Playwright multi-platform foundation for web scroll regression

### DIFF
--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -1,0 +1,55 @@
+name: E2E Web Scroll
+
+on:
+  pull_request:
+    branches:
+      - main
+      - deploy/preprod
+    paths-ignore:
+      - "**.md"
+      - "documentation/**"
+  push:
+    branches:
+      - deploy/preprod
+    paths-ignore:
+      - "**.md"
+      - "documentation/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  playwright:
+    name: Playwright multi-platform
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      E2E_BASE_URL: ${{ vars.E2E_BASE_URL || 'https://whispr-preprod.roadmvn.com' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium webkit
+
+      - name: Run Playwright tests
+        run: npx playwright test
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: playwright-report-${{ github.sha }}
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,11 @@ Thumbs.db
 # Test artifacts
 test-results/
 
+# Playwright artifacts
+playwright-report/
+playwright/.cache/
+e2e-results/
+
 # Build
 build/
 CLAUDE.local.md

--- a/e2e/web-scroll/README.md
+++ b/e2e/web-scroll/README.md
@@ -1,0 +1,39 @@
+# E2E web scroll — Whispr PWA
+
+Tests Playwright multi-platform pour valider que la PWA Whispr
+(`https://whispr-preprod.roadmvn.com` par defaut) charge correctement et
+que le layout reste fonctionnel sur les 3 viewports cibles :
+
+- desktop-chrome (Chromium 1280x720)
+- iphone-safari (WebKit, iPhone 14 Pro)
+- android-pixel (Chromium, Pixel 7)
+
+## Lancer en local
+
+```bash
+# Installer les browsers (premiere fois uniquement)
+npx playwright install chromium webkit
+
+# Lancer toute la suite contre preprod
+npm run e2e:web
+
+# Lancer un seul project
+npx playwright test --project=desktop-chrome
+
+# Lancer contre une autre URL (preview locale par exemple)
+E2E_BASE_URL=http://localhost:8081 npm run e2e:web
+```
+
+## Structure
+
+- `smoke.spec.ts` : la PWA charge et expose un titre, un manifest et
+  un splash sans crash console.
+- `pwa-shell.spec.ts` : verifie que la coquille rendue ne deborde pas
+  du viewport (pas de scroll horizontal parasite, body height >= viewport
+  height pour les screens connus).
+
+Les specs login + scroll deep (9 screens : ConversationsList, Contacts,
+MyProfile, UserProfile, MySanctions, ProfileSetup, TwoFactorSetup,
+TwoFactorAuth, Calls) sont reportees aux follow-ups WHISPR-1338 / 1339
+qui ajouteront d'abord les `testID="screen-<name>-bottom"` necessaires
+sur chaque screen, puis l'helper login OTP avec `OTP_BYPASS_CODE=123456`.

--- a/e2e/web-scroll/pwa-shell.spec.ts
+++ b/e2e/web-scroll/pwa-shell.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "@playwright/test";
+
+// Verifie que la coquille PWA rendue dans chaque viewport ne deborde
+// pas horizontalement (cause typique de regressions layout vues sur
+// preprod : flexDirection 'row' avec width fixe au lieu de flex:1).
+//
+// Ces assertions sont volontairement legeres : on ne se logge pas et
+// on n'interagit pas avec les ecrans authentifies. Les tests scroll
+// deep par screen (ConversationsList, Contacts, MyProfile, ...) sont
+// dans les follow-ups WHISPR-1338 / 1339, qui necessitent d'ajouter
+// d'abord les testID "screen-<name>-bottom" sur chaque ecran cible.
+test.describe("PWA layout", () => {
+  test("no horizontal overflow on first paint", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const overflow = await page.evaluate(() => {
+      return {
+        scrollWidth: document.documentElement.scrollWidth,
+        clientWidth: document.documentElement.clientWidth,
+      };
+    });
+    // Tolerance 1px pour les sub-pixel rounding en webkit / chromium.
+    expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth + 1);
+  });
+
+  test("body fills the viewport vertically", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const sizes = await page.evaluate(() => {
+      return {
+        bodyHeight: document.body.getBoundingClientRect().height,
+        innerHeight: window.innerHeight,
+      };
+    });
+    // L'app expo-rendered doit remplir au moins la totalite du viewport
+    // (SafeAreaView + flex:1 racine). Si bodyHeight < innerHeight, c'est
+    // un bug layout connu (cf WHISPR-1313 / WHISPR-1335).
+    expect(sizes.bodyHeight).toBeGreaterThanOrEqual(sizes.innerHeight - 4);
+  });
+});

--- a/e2e/web-scroll/smoke.spec.ts
+++ b/e2e/web-scroll/smoke.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "@playwright/test";
+
+// Smoke test : la PWA charge sur les 3 viewports sans crash JS.
+// Sert de garde-fou contre les regressions web build (bundle Metro casse,
+// asset 404, hydration error).
+test.describe("PWA shell", () => {
+  test("loads without console errors", async ({ page }) => {
+    const consoleErrors: string[] = [];
+    page.on("pageerror", (err) => {
+      consoleErrors.push(err.message);
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        const text = msg.text();
+        // Filtrer les erreurs de chargement asset attendues
+        // (favicons, fonts) qui ne cassent pas l'app.
+        if (!/favicon|font|woff|sw\.js/i.test(text)) {
+          consoleErrors.push(text);
+        }
+      }
+    });
+
+    await page.goto("/");
+    // On attend que React hydrate. La presence d'un root non-vide est
+    // un signal suffisant ici, l'app etant une SPA single-page.
+    await page.waitForLoadState("networkidle");
+
+    // Le root expo-rendered doit exister.
+    const root = page.locator("#root, #__expo-root, body > div").first();
+    await expect(root).toBeVisible();
+
+    expect(
+      consoleErrors,
+      `Console errors detected: ${consoleErrors.join(" | ")}`,
+    ).toHaveLength(0);
+  });
+
+  test("has a non-empty title", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("domcontentloaded");
+    const title = await page.title();
+    expect(title.length).toBeGreaterThan(0);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
       "devDependencies": {
         "@babel/core": "^7.20.0",
         "@expo/ngrok": "^4.1.3",
+        "@playwright/test": "^1.59.1",
         "@testing-library/react-native": "^13.3.3",
         "@types/jest": "^29.5.0",
         "@types/react": "~19.1.0",
@@ -3200,6 +3201,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@react-native-async-storage/async-storage": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
@@ -3948,13 +3965,6 @@
         "@types/responselike": "^1.0.0"
       }
     },
-    "node_modules/@types/dom-mediacapture-record": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz",
-      "integrity": "sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@types/emscripten": {
       "version": "1.41.5",
       "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
@@ -4135,7 +4145,7 @@
       "version": "19.1.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -6153,7 +6163,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -13728,6 +13738,53 @@
         "node": ">=8"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/plist": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
@@ -16699,7 +16756,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "type-check": "tsc --noEmit",
+    "e2e:web": "playwright test",
+    "e2e:web:install": "playwright install --with-deps chromium webkit",
     "prepare": "husky"
   },
   "dependencies": {
@@ -74,6 +76,7 @@
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "@expo/ngrok": "^4.1.3",
+    "@playwright/test": "^1.59.1",
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^29.5.0",
     "@types/react": "~19.1.0",
@@ -107,6 +110,10 @@
   "jest": {
     "preset": "jest-expo",
     "coverageProvider": "v8",
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/e2e/"
+    ],
     "setupFiles": [
       "<rootDir>/jest.setup.js"
     ],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Config Playwright pour la PWA Whispr (preprod par defaut).
+// On teste sur 3 viewports : desktop chrome, iPhone Safari (webkit),
+// Android Pixel (chromium emulation). Ces 3 couvrent les regressions
+// scroll/layout vues sur whispr-preprod.roadmvn.com.
+export default defineConfig({
+  testDir: "./e2e/web-scroll",
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI
+    ? [["html", { outputFolder: "playwright-report", open: "never" }], ["list"]]
+    : [["list"]],
+  use: {
+    baseURL: process.env.E2E_BASE_URL || "https://whispr-preprod.roadmvn.com",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+    // La PWA peut etre lente a hydrater au premier chargement.
+    navigationTimeout: 20_000,
+  },
+  projects: [
+    {
+      name: "desktop-chrome",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "iphone-safari",
+      use: { ...devices["iPhone 14 Pro"] },
+    },
+    {
+      name: "android-pixel",
+      use: { ...devices["Pixel 7"] },
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

- Setup `@playwright/test` v1.59.1 + scripts npm `e2e:web` / `e2e:web:install`.
- Config Playwright multi-platform : desktop chrome, iPhone Safari (webkit), Android Pixel (chromium emulation Pixel 7).
- Specs initiales : smoke (PWA charge, pas d'erreurs console, titre non vide) et shell layout (pas de scroll horizontal parasite, body remplit le viewport).
- Workflow CI dedie `e2e-web.yml` qui tourne sur PR et push deploy/preprod, avec upload du report html en artefact.
- Jest exclut `e2e/` via `testPathIgnorePatterns` pour ne pas tomber sur les specs Playwright.
- `.gitignore` couvre `playwright-report/`, `playwright/.cache/`, `e2e-results/`.

## Scope

C'est la **fondation** Wave 21 (1/3). Les follow-ups :

- **Wave 21 (2/3)** : ajouter `testID="screen-<name>-bottom"` sur les 9 screens critiques (ConversationsList, Contacts, MyProfile, UserProfile, MySanctions, ProfileSetup, TwoFactorSetup, TwoFactorAuth, Calls) + spec scroll-screens qui visite chaque screen et assert que le bottom marker est atteignable.
- **Wave 21 (3/3)** : helper login OTP (user test 0769828164 / `OTP_BYPASS_CODE=123456`) + spec back-navigation + buttons-visible.

Faire la fondation seule garde la PR review-friendly et permet de cabler la CI avant que les tests deep arrivent.

## Test plan

- [x] `npx playwright test --list` retourne 12 tests (4 specs x 3 platforms).
- [x] `npm run type-check` clean.
- [x] `npm run lint` 0 erreurs.
- [x] `npm test -- --watchAll=false` 917 tests verts (e2e exclu).
- [ ] CI Playwright job tourne et passe sur preprod (`https://whispr-preprod.roadmvn.com`).
- [ ] Tous les bots (Sonar, Codecov, GitGuardian, Trivy, CodeQL, Copilot) verts ou justifies avant merge.

Closes WHISPR-1337