### PR TITLE
[WHISPR-1342] fix(web): borne tous les ecrans Stack.Screen au viewport

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -105,6 +105,19 @@ export default function App() {
       html.style.height = "100%";
       body.style.height = "100%";
       body.style.overflow = "hidden";
+
+      // WHISPR-1342 - le wrapper `Card` du Stack.Navigator (react-navigation/stack
+      // sans react-native-screens) compile en `min-height: 100%` + `flex: 0 0 auto`
+      // sur web. Du coup tout ecran avec FlatList/ScrollView grandit a la hauteur
+      // de son contenu au lieu d'etre borne au viewport, et le scroll interne ne
+      // se declenche jamais. Le combo de classes `.r-2llsf.r-12vffkv` (min-height:
+      // 100% + pointer-events: none !important) est unique a ce wrapper, on peut
+      // donc le rebrancher en `min-height: 0; flex: 1` sans casser le reste.
+      const stackFix = document.createElement("style");
+      stackFix.id = "whispr-stack-card-fix";
+      stackFix.textContent =
+        ".r-2llsf.r-12vffkv{min-height:0!important;flex:1 1 0%!important;}";
+      document.head.appendChild(stackFix);
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- Bug user-reported: scroll cassé sur ConversationsList, Contacts, ChatScreen, MyProfile en PWA web (Safari iOS et Chrome desktop).
- Root cause confirmée live via Playwright: le wrapper Card de react-navigation/stack (sans react-native-screens car `enableScreens(false)` au boot) compile en `min-height: 100%` + `flex: 0 0 auto` sur web. Chaque ecran grandit a la hauteur de son contenu (1380px pour 16 conversations) au lieu d'etre borne au viewport (852px). FlatList interne se voit attribuer toute la hauteur, donc scrollHeight == clientHeight, donc canScroll = false.
- Le pattern WHISPR-1254 (`minHeight: 0` sur containers du screen) ne suffit pas parce qu'il s'applique sous le wrapper Card, pas dessus.

## Fix
Injection d'un style global au boot web dans `App.jsx` qui rebranche le combo de classes specifique au wrapper Stack.Screen :

```css
.r-2llsf.r-12vffkv {
  min-height: 0 !important;
  flex: 1 1 0% !important;
}
```

- `.r-2llsf` = `min-height: 100%` (RN-Web class)
- `.r-12vffkv` = `pointer-events: none !important` (RN-Web class)
- Le combo des deux est UNIQUE au Card wrapper Stack — on ne casse pas les autres composants qui ont juste `min-height: 100%` (ScrollView contentContainer notamment).

## Test plan (effectue live preprod)
- [x] ConversationsList : avant culpritH=1380, FlatList sH=cH=1260 → apres culpritH=852, FlatList sH=1112 cH=402 (canScroll: true)
- [x] Contacts : avant culpritH=1562 → apres 852, scroll restaure
- [x] ChatScreen : FlatList interne canScroll=true (sH=812, cH=731)
- [ ] MyProfile : a verifier post-deploy
- [x] tsc --noEmit clean
- [x] Pas d'impact sur natif (Platform.OS === "web" gate)

## Refs
Closes WHISPR-1342
Suit WHISPR-1254 (containers minHeight:0), WHISPR-1313 (5 screens scroll), WHISPR-1336 (DANGER ZONE comments)