### PR TITLE
[WHISPR-1343] perf(profiles): reduce burst concurrency to 5 + short TTL on 429

### DIFF
--- a/messagingApi.test.ts
+++ b/messagingApi.test.ts
@@ -624,6 +624,50 @@ describe("messagingAPI.getUserInfo cache", () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
+
+  it("caches null with a short TTL on 429 (refetches after 30s)", async () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-05-09T12:00:00Z"));
+    try {
+      mockFetch
+        .mockResolvedValueOnce(mockResponse({ status: 429 }))
+        .mockResolvedValueOnce(
+          mockResponse({ body: { id: "u-1", username: "ada" } }),
+        );
+
+      const first = await messagingAPI.getUserInfo("u-1");
+      expect(first).toBeNull();
+      // dans la fenetre 30s : sert le cache, pas de retry storm
+      const cached = await messagingAPI.getUserInfo("u-1");
+      expect(cached).toBeNull();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      // apres 30s + 1s, le cache short-TTL expire et on refetch
+      jest.setSystemTime(new Date("2026-05-09T12:00:31Z"));
+      const second = await messagingAPI.getUserInfo("u-1");
+      expect(second).toMatchObject({ id: "u-1" });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("keeps the standard 5-min TTL for non-429 errors (e.g. 500)", async () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-05-09T12:00:00Z"));
+    try {
+      mockFetch.mockResolvedValueOnce(mockResponse({ status: 500 }));
+
+      const first = await messagingAPI.getUserInfo("u-1");
+      expect(first).toBeNull();
+
+      // a 31s, le cache 5min tient toujours, pas de refetch
+      jest.setSystemTime(new Date("2026-05-09T12:00:31Z"));
+      const stillCached = await messagingAPI.getUserInfo("u-1");
+      expect(stillCached).toBeNull();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/services/groups/api.ts
+++ b/src/services/groups/api.ts
@@ -117,7 +117,10 @@ async function batchedMap<T, R>(
   return results;
 }
 
-const MEMBER_PROFILE_FETCH_CONCURRENCY = 20;
+// le user-service throttle court est a ~10 req/s; on garde 5 in-flight
+// max pour laisser de la marge et eviter le burst 429 au load de la
+// ConversationsList (enrichissement profile en parallele).
+const MEMBER_PROFILE_FETCH_CONCURRENCY = 5;
 
 interface ConversationPayload {
   memberUserIds?: string[];

--- a/src/services/messaging/api.ts
+++ b/src/services/messaging/api.ts
@@ -178,7 +178,10 @@ async function batchedMap<T, R>(
   return results;
 }
 
-const MEMBER_PROFILE_FETCH_CONCURRENCY = 20;
+// le user-service throttle court est a ~10 req/s; on garde 5 in-flight
+// max pour laisser de la marge et eviter le burst 429 au load de la
+// ConversationsList (enrichissement profile en parallele).
+const MEMBER_PROFILE_FETCH_CONCURRENCY = 5;
 
 // --- User profile cache ------------------------------------------------------
 // Avoid re-fetching the same /user/v1/profile/{id} on every render cycle. A
@@ -193,6 +196,10 @@ type CachedUserInfo = {
 };
 
 const USER_INFO_TTL_MS = 5 * 60 * 1000; // 5 minutes
+// TTL court pour les 429 : on attend juste que la fenetre throttle se
+// reouvre, sinon le user reste sans nom/avatar pendant 5 min apres un
+// simple burst.
+const USER_INFO_RATE_LIMIT_TTL_MS = 30 * 1000; // 30 seconds
 const userInfoCache = new Map<
   string,
   { value: CachedUserInfo | null; expiresAt: number }
@@ -705,15 +712,27 @@ export const messagingAPI = {
         );
 
         if (!response.ok) {
-          logger.warn(
-            "getUserInfo",
-            `HTTP ${response.status} for user ${userId}`,
-          );
-          // Cache negative result briefly to prevent a retry storm when the
-          // backend returns 429 — TTL keeps it from being permanently stuck.
+          // 429 = throttler user-service (court 10 req/s). Cas attendu sous
+          // charge (load ConversationsList), pas une erreur. On cache null
+          // avec un TTL court pour laisser la fenetre se reouvrir, sinon le
+          // membre reste sans nom/avatar pendant 5 min apres un simple burst.
+          const isRateLimited = response.status === 429;
+          if (isRateLimited) {
+            logger.info(
+              "getUserInfo",
+              `Rate limited (429) for user ${userId}, retry after short TTL`,
+            );
+          } else {
+            logger.warn(
+              "getUserInfo",
+              `HTTP ${response.status} for user ${userId}`,
+            );
+          }
           userInfoCache.set(userId, {
             value: null,
-            expiresAt: Date.now() + USER_INFO_TTL_MS,
+            expiresAt:
+              Date.now() +
+              (isRateLimited ? USER_INFO_RATE_LIMIT_TTL_MS : USER_INFO_TTL_MS),
           });
           return null;
         }


### PR DESCRIPTION
## Summary
- Reduce `MEMBER_PROFILE_FETCH_CONCURRENCY` from 20 to 5 in both `src/services/messaging/api.ts` and `src/services/groups/api.ts`. The user-service throttle short window is ~10 req/s — 20 in-flight saturates it and triggers a wave of 429 at the start of every ConversationsList load.
- In `getUserInfo`, differentiate HTTP 429 from other failures: cache null with a short 30s TTL on 429 (the throttle window reopens fast) instead of the standard 5 min. Members no longer stay nameless/avatarless for 5 minutes after a single burst.
- 429 logged at `info` level (expected under load), other errors stay at `warn`.
- Negative cache TTL kept at 5 min for true errors (500, 404, etc.) — no behavioural change there.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/services/messaging/api.ts src/services/groups/api.ts` clean (preexisting `any` warnings only)
- [x] Unit tests added: `429 caches null with short TTL (30s)` + `non-429 keeps the 5-min TTL`
- [x] `npx jest --watchAll=false --testPathPattern="messaging|user|conversations|groups"` -> 919 tests green
- [ ] Smoke test live on whispr-preprod.roadmvn.com after CD: 0 console 429 at ConversationsList load

Closes WHISPR-1343