### PR TITLE
[WHISPR-1345] feat(security): typed confirm modal for destructive actions

### DIFF
--- a/DangerConfirmModal.test.tsx
+++ b/DangerConfirmModal.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Tests for DangerConfirmModal — typed-confirm pour actions destructives
+ */
+
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+
+jest.mock("./src/theme/colors", () => ({
+  colors: {
+    background: { dark: "#000" },
+    text: { light: "#fff" },
+    ui: { error: "#FF3B30", warning: "#F04882" },
+  },
+  withOpacity: (c: string) => c,
+}));
+
+const mockGetLocalizedText = jest.fn((key: string) => {
+  const dict: Record<string, string> = {
+    "confirm.typeToConfirm": "Tape {{text}} pour confirmer",
+    "confirm.actionIrreversible": "Cette action est irréversible.",
+    "confirm.cancel": "Annuler",
+  };
+  return dict[key] ?? key;
+});
+
+jest.mock("./src/context/ThemeContext", () => ({
+  useTheme: () => ({
+    getThemeColors: () => ({
+      text: { primary: "#fff", secondary: "#aaa", tertiary: "#888" },
+    }),
+    getLocalizedText: mockGetLocalizedText,
+  }),
+}));
+
+import { DangerConfirmModal } from "./src/components/Common/DangerConfirmModal";
+
+const baseProps = {
+  visible: true,
+  title: "Supprimer ?",
+  description: "Action destructive.",
+  expectedText: "SUPPRIMER",
+  actionLabel: "Supprimer",
+  onCancel: jest.fn(),
+  onConfirm: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("DangerConfirmModal", () => {
+  it("rend le titre et la description", () => {
+    const { getByText } = render(<DangerConfirmModal {...baseProps} />);
+    expect(getByText("Supprimer ?")).toBeTruthy();
+    expect(getByText("Action destructive.")).toBeTruthy();
+  });
+
+  it("interpole expectedText dans le label tape-pour-confirmer", () => {
+    const { getByText } = render(<DangerConfirmModal {...baseProps} />);
+    expect(getByText("Tape SUPPRIMER pour confirmer")).toBeTruthy();
+  });
+
+  it("desactive le bouton confirm si l'input est vide", () => {
+    const onConfirm = jest.fn();
+    const { getByTestId } = render(
+      <DangerConfirmModal {...baseProps} onConfirm={onConfirm} />,
+    );
+    fireEvent.press(getByTestId("danger-confirm-action"));
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("desactive le bouton confirm si le texte ne match qu'a moitie", () => {
+    const onConfirm = jest.fn();
+    const { getByTestId } = render(
+      <DangerConfirmModal {...baseProps} onConfirm={onConfirm} />,
+    );
+    fireEvent.changeText(getByTestId("danger-confirm-input"), "SUPP");
+    fireEvent.press(getByTestId("danger-confirm-action"));
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("active le bouton confirm sur match exact (case-insensitive par defaut)", () => {
+    const onConfirm = jest.fn();
+    const { getByTestId } = render(
+      <DangerConfirmModal {...baseProps} onConfirm={onConfirm} />,
+    );
+    fireEvent.changeText(getByTestId("danger-confirm-input"), "supprimer");
+    fireEvent.press(getByTestId("danger-confirm-action"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("respecte caseInsensitive=false : 'supprimer' ne match pas 'SUPPRIMER'", () => {
+    const onConfirm = jest.fn();
+    const { getByTestId } = render(
+      <DangerConfirmModal
+        {...baseProps}
+        caseInsensitive={false}
+        onConfirm={onConfirm}
+      />,
+    );
+    fireEvent.changeText(getByTestId("danger-confirm-input"), "supprimer");
+    fireEvent.press(getByTestId("danger-confirm-action"));
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    fireEvent.changeText(getByTestId("danger-confirm-input"), "SUPPRIMER");
+    fireEvent.press(getByTestId("danger-confirm-action"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("appelle onCancel au clic sur Annuler", () => {
+    const onCancel = jest.fn();
+    const { getByTestId } = render(
+      <DangerConfirmModal {...baseProps} onCancel={onCancel} />,
+    );
+    fireEvent.press(getByTestId("danger-confirm-cancel"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("submit via Enter dans l'input quand match", () => {
+    const onConfirm = jest.fn();
+    const { getByTestId } = render(
+      <DangerConfirmModal {...baseProps} onConfirm={onConfirm} />,
+    );
+    const input = getByTestId("danger-confirm-input");
+    fireEvent.changeText(input, "SUPPRIMER");
+    fireEvent(input, "submitEditing");
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("loading=true : input non editable, bouton confirm bloque, spinner visible", () => {
+    const onConfirm = jest.fn();
+    const onCancel = jest.fn();
+    const { getByTestId, queryByText } = render(
+      <DangerConfirmModal
+        {...baseProps}
+        loading
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    );
+    const input = getByTestId("danger-confirm-input");
+    expect(input.props.editable).toBe(false);
+
+    // bouton action ne declenche pas onConfirm meme avec match
+    fireEvent.changeText(input, "SUPPRIMER");
+    fireEvent.press(getByTestId("danger-confirm-action"));
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    // bouton cancel bloque aussi pendant loading
+    fireEvent.press(getByTestId("danger-confirm-cancel"));
+    expect(onCancel).not.toHaveBeenCalled();
+
+    // le label texte est remplace par un ActivityIndicator
+    expect(queryByText("Supprimer")).toBeNull();
+  });
+
+  it("snapshot stable", () => {
+    const tree = render(<DangerConfirmModal {...baseProps} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/DeleteContactModal.test.tsx
+++ b/DeleteContactModal.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * Tests for DeleteContactModal — wrapper autour de DangerConfirmModal
+ */
+
+import React from "react";
+import { render, fireEvent, waitFor } from "@testing-library/react-native";
+
+const mockDeleteContact = jest.fn();
+
+jest.mock("./src/services/contacts/api", () => ({
+  contactsAPI: {
+    deleteContact: (...args: unknown[]) => mockDeleteContact(...args),
+  },
+}));
+
+jest.mock("./src/theme/colors", () => ({
+  colors: {
+    background: { dark: "#000" },
+    text: { light: "#fff" },
+    ui: { error: "#FF3B30", warning: "#F04882" },
+  },
+  withOpacity: (c: string) => c,
+}));
+
+jest.mock("./src/context/ThemeContext", () => ({
+  useTheme: () => ({
+    getThemeColors: () => ({
+      text: { primary: "#fff", secondary: "#aaa", tertiary: "#888" },
+    }),
+    getLocalizedText: (key: string) => {
+      const dict: Record<string, string> = {
+        "confirm.deleteContact.title": "Supprimer ce contact ?",
+        "confirm.deleteContact.description":
+          "Le contact sera retiré de votre liste.",
+        "confirm.deleteContact.action": "Supprimer",
+        "confirm.expectedDelete": "SUPPRIMER",
+        "confirm.typeToConfirm": "Tape {{text}} pour confirmer",
+        "confirm.cancel": "Annuler",
+      };
+      return dict[key] ?? key;
+    },
+  }),
+}));
+
+import { DeleteContactModal } from "./src/components/Contacts/DeleteContactModal";
+
+const baseContact = {
+  id: "rel-1",
+  contact_id: "user-42",
+  nickname: "Bob",
+  is_favorite: false,
+  contact_user: {
+    id: "user-42",
+    first_name: "Bobby",
+    username: "bob",
+    avatar_url: null,
+  },
+} as any;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("DeleteContactModal", () => {
+  it("ne rend rien si contact est null", () => {
+    const { toJSON } = render(
+      <DeleteContactModal
+        visible={true}
+        contact={null}
+        onClose={jest.fn()}
+        onContactDeleted={jest.fn()}
+      />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it("appelle deleteContact + onContactDeleted + onClose au confirm", async () => {
+    mockDeleteContact.mockResolvedValueOnce(undefined);
+    const onClose = jest.fn();
+    const onContactDeleted = jest.fn();
+    const { getByTestId } = render(
+      <DeleteContactModal
+        visible={true}
+        contact={baseContact}
+        onClose={onClose}
+        onContactDeleted={onContactDeleted}
+      />,
+    );
+    fireEvent.changeText(getByTestId("danger-confirm-input"), "SUPPRIMER");
+    fireEvent.press(getByTestId("danger-confirm-action"));
+
+    await waitFor(() => {
+      expect(mockDeleteContact).toHaveBeenCalledWith("user-42");
+      expect(onContactDeleted).toHaveBeenCalledTimes(1);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("ne ferme pas la modal si l'API echoue", async () => {
+    mockDeleteContact.mockRejectedValueOnce(new Error("network"));
+    const onClose = jest.fn();
+    const onContactDeleted = jest.fn();
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const { getByTestId } = render(
+      <DeleteContactModal
+        visible={true}
+        contact={baseContact}
+        onClose={onClose}
+        onContactDeleted={onContactDeleted}
+      />,
+    );
+    fireEvent.changeText(getByTestId("danger-confirm-input"), "SUPPRIMER");
+    fireEvent.press(getByTestId("danger-confirm-action"));
+
+    await waitFor(() => {
+      expect(mockDeleteContact).toHaveBeenCalled();
+    });
+    expect(onContactDeleted).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it("annulation : appelle onClose sans toucher l'API", () => {
+    const onClose = jest.fn();
+    const onContactDeleted = jest.fn();
+    const { getByTestId } = render(
+      <DeleteContactModal
+        visible={true}
+        contact={baseContact}
+        onClose={onClose}
+        onContactDeleted={onContactDeleted}
+      />,
+    );
+    fireEvent.press(getByTestId("danger-confirm-cancel"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockDeleteContact).not.toHaveBeenCalled();
+    expect(onContactDeleted).not.toHaveBeenCalled();
+  });
+
+  it("fallback contact_id : utilise contact.id si contact_id manquant", async () => {
+    mockDeleteContact.mockResolvedValueOnce(undefined);
+    const { getByTestId } = render(
+      <DeleteContactModal
+        visible={true}
+        contact={{ ...baseContact, contact_id: undefined }}
+        onClose={jest.fn()}
+        onContactDeleted={jest.fn()}
+      />,
+    );
+    fireEvent.changeText(getByTestId("danger-confirm-input"), "SUPPRIMER");
+    fireEvent.press(getByTestId("danger-confirm-action"));
+    await waitFor(() => {
+      expect(mockDeleteContact).toHaveBeenCalledWith("rel-1");
+    });
+  });
+});

--- a/EditContactModalDelete.test.tsx
+++ b/EditContactModalDelete.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * Tests for EditContactModal — focus sur le flow "Supprimer le contact"
+ * (typed-confirm via DangerConfirmModal). Le reste du modal (Save, Block,
+ * favorite toggle) reste couvert par d'autres tests/QA manuelle.
+ */
+
+import React from "react";
+import { Alert } from "react-native";
+import { render, fireEvent, waitFor } from "@testing-library/react-native";
+
+const mockDeleteContact = jest.fn();
+const mockUpdateContact = jest.fn();
+const mockBlockUser = jest.fn();
+
+jest.mock("./src/services/contacts/api", () => ({
+  contactsAPI: {
+    deleteContact: (...args: unknown[]) => mockDeleteContact(...args),
+    updateContact: (...args: unknown[]) => mockUpdateContact(...args),
+    blockUser: (...args: unknown[]) => mockBlockUser(...args),
+  },
+}));
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({ navigate: jest.fn(), goBack: jest.fn() }),
+}));
+
+jest.mock("expo-linear-gradient", () => {
+  const { View } = require("react-native");
+  return { LinearGradient: View };
+});
+
+jest.mock("react-native-safe-area-context", () => {
+  const { View } = require("react-native");
+  return { SafeAreaView: View };
+});
+
+jest.mock("./src/components/Chat/Avatar", () => {
+  const { View } = require("react-native");
+  return { Avatar: View };
+});
+
+jest.mock("./src/theme/colors", () => ({
+  colors: {
+    background: { dark: "#000", gradient: { app: ["#000", "#111"] } },
+    text: { light: "#fff" },
+    primary: { main: "#FF7A5C", dark: "#F96645" },
+    ui: { error: "#FF3B30", warning: "#F04882" },
+  },
+  withOpacity: (c: string) => c,
+}));
+
+jest.mock("./src/context/ThemeContext", () => ({
+  useTheme: () => ({
+    getThemeColors: () => ({
+      text: { primary: "#fff", secondary: "#aaa", tertiary: "#888" },
+    }),
+    getLocalizedText: (key: string) => {
+      const dict: Record<string, string> = {
+        "confirm.deleteContact.title": "Supprimer ce contact ?",
+        "confirm.deleteContact.description":
+          "Le contact sera retiré de votre liste.",
+        "confirm.deleteContact.action": "Supprimer",
+        "confirm.expectedDelete": "SUPPRIMER",
+        "confirm.typeToConfirm": "Tape {{text}} pour confirmer",
+        "confirm.cancel": "Annuler",
+      };
+      return dict[key] ?? key;
+    },
+  }),
+}));
+
+import { EditContactModal } from "./src/components/Contacts/EditContactModal";
+
+const baseContact = {
+  id: "rel-1",
+  contact_id: "user-42",
+  nickname: "Bob",
+  is_favorite: false,
+  contact_user: {
+    id: "user-42",
+    first_name: "Bobby",
+    username: "bob",
+    avatar_url: null,
+  },
+} as any;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(Alert, "alert").mockImplementation(() => {});
+});
+
+describe("EditContactModal — typed-confirm delete", () => {
+  it("le DangerConfirmModal est cache au depart", () => {
+    const { queryByTestId } = render(
+      <EditContactModal
+        visible={true}
+        contact={baseContact}
+        onClose={jest.fn()}
+        onContactUpdated={jest.fn()}
+      />,
+    );
+    expect(queryByTestId("danger-confirm-input")).toBeNull();
+  });
+
+  it("clic sur 'Supprimer le contact' ouvre la modal typed-confirm", () => {
+    const { getByText, getByTestId } = render(
+      <EditContactModal
+        visible={true}
+        contact={baseContact}
+        onClose={jest.fn()}
+        onContactUpdated={jest.fn()}
+      />,
+    );
+    fireEvent.press(getByText("Supprimer le contact"));
+    expect(getByTestId("danger-confirm-input")).toBeTruthy();
+  });
+
+  it("apres typed-confirm, deleteContact est appele puis onContactUpdated", async () => {
+    mockDeleteContact.mockResolvedValueOnce(undefined);
+    const onContactUpdated = jest.fn();
+    const onClose = jest.fn();
+    const { getByText, getByTestId } = render(
+      <EditContactModal
+        visible={true}
+        contact={baseContact}
+        onClose={onClose}
+        onContactUpdated={onContactUpdated}
+      />,
+    );
+    fireEvent.press(getByText("Supprimer le contact"));
+    fireEvent.changeText(getByTestId("danger-confirm-input"), "SUPPRIMER");
+    fireEvent.press(getByTestId("danger-confirm-action"));
+
+    await waitFor(() => {
+      expect(mockDeleteContact).toHaveBeenCalledWith("user-42");
+      expect(onContactUpdated).toHaveBeenCalledTimes(1);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("erreur API : Alert affiche le message + modal se ferme", async () => {
+    mockDeleteContact.mockRejectedValueOnce(new Error("boom"));
+    const { getByText, getByTestId } = render(
+      <EditContactModal
+        visible={true}
+        contact={baseContact}
+        onClose={jest.fn()}
+        onContactUpdated={jest.fn()}
+      />,
+    );
+    fireEvent.press(getByText("Supprimer le contact"));
+    fireEvent.changeText(getByTestId("danger-confirm-input"), "SUPPRIMER");
+    fireEvent.press(getByTestId("danger-confirm-action"));
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith("Erreur", "boom");
+    });
+  });
+
+  it("annulation : ferme la typed-confirm sans appeler l'API", () => {
+    const { getByText, getByTestId, queryByTestId } = render(
+      <EditContactModal
+        visible={true}
+        contact={baseContact}
+        onClose={jest.fn()}
+        onContactUpdated={jest.fn()}
+      />,
+    );
+    fireEvent.press(getByText("Supprimer le contact"));
+    fireEvent.press(getByTestId("danger-confirm-cancel"));
+    expect(mockDeleteContact).not.toHaveBeenCalled();
+    expect(queryByTestId("danger-confirm-input")).toBeNull();
+  });
+});

--- a/__snapshots__/DangerConfirmModal.test.tsx.snap
+++ b/__snapshots__/DangerConfirmModal.test.tsx.snap
@@ -1,0 +1,277 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DangerConfirmModal snapshot stable 1`] = `
+<Modal
+  animationType="fade"
+  onRequestClose={[MockFunction]}
+  transparent={true}
+  visible={true}
+>
+  <View
+    style={
+      {
+        "alignItems": "center",
+        "backgroundColor": "rgba(0, 0, 0, 0.6)",
+        "flex": 1,
+        "justifyContent": "center",
+        "paddingHorizontal": 32,
+      }
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "borderRadius": 20,
+            "maxWidth": 420,
+            "paddingHorizontal": 24,
+            "paddingVertical": 28,
+            "width": "100%",
+          },
+          {
+            "backgroundColor": "#000",
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          {
+            "marginBottom": 16,
+          }
+        }
+      >
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "borderRadius": 32,
+                "height": 64,
+                "justifyContent": "center",
+                "width": 64,
+              },
+              {
+                "backgroundColor": "#FF3B30",
+              },
+            ]
+          }
+        />
+      </View>
+      <Text
+        style={
+          [
+            {
+              "fontSize": 18,
+              "fontWeight": "700",
+              "marginBottom": 12,
+              "textAlign": "center",
+            },
+            {
+              "color": "#fff",
+            },
+          ]
+        }
+      >
+        Supprimer ?
+      </Text>
+      <Text
+        style={
+          [
+            {
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 16,
+              "textAlign": "center",
+            },
+            {
+              "color": "#aaa",
+            },
+          ]
+        }
+      >
+        Action destructive.
+      </Text>
+      <Text
+        style={
+          [
+            {
+              "alignSelf": "stretch",
+              "fontSize": 13,
+              "marginBottom": 8,
+              "textAlign": "center",
+            },
+            {
+              "color": "#aaa",
+            },
+          ]
+        }
+      >
+        Tape SUPPRIMER pour confirmer
+      </Text>
+      <TextInput
+        accessibilityHint="Cette action est irréversible."
+        accessibilityLabel="Tape SUPPRIMER pour confirmer"
+        autoCapitalize="characters"
+        autoCorrect={false}
+        editable={true}
+        onChangeText={[Function]}
+        onSubmitEditing={[Function]}
+        placeholder="SUPPRIMER"
+        placeholderTextColor="#fff"
+        returnKeyType="done"
+        style={
+          [
+            {
+              "borderRadius": 12,
+              "borderWidth": 1,
+              "fontSize": 16,
+              "marginBottom": 24,
+              "paddingHorizontal": 16,
+              "paddingVertical": 14,
+              "textAlign": "center",
+              "width": "100%",
+            },
+            {
+              "backgroundColor": "rgba(255, 255, 255, 0.05)",
+              "borderColor": "#fff",
+              "color": "#fff",
+              "opacity": 1,
+            },
+          ]
+        }
+        testID="danger-confirm-input"
+        value=""
+      />
+      <View
+        style={
+          {
+            "flexDirection": "row",
+            "gap": 12,
+            "width": "100%",
+          }
+        }
+      >
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": false,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "borderColor": "#fff",
+              "borderRadius": 12,
+              "borderWidth": 1,
+              "flex": 1,
+              "justifyContent": "center",
+              "opacity": 1,
+              "paddingVertical": 14,
+            }
+          }
+          testID="danger-confirm-cancel"
+        >
+          <Text
+            style={
+              [
+                {
+                  "fontSize": 16,
+                  "fontWeight": "600",
+                },
+                {
+                  "color": "#fff",
+                },
+              ]
+            }
+          >
+            Annuler
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": true,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={false}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "backgroundColor": "#FF3B30",
+              "borderRadius": 12,
+              "flex": 1,
+              "justifyContent": "center",
+              "opacity": 0.4,
+              "paddingVertical": 14,
+            }
+          }
+          testID="danger-confirm-action"
+        >
+          <Text
+            style={
+              [
+                {
+                  "fontSize": 16,
+                  "fontWeight": "600",
+                },
+                {
+                  "color": "#fff",
+                },
+              ]
+            }
+          >
+            Supprimer
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>
+</Modal>
+`;

--- a/src/components/Common/DangerConfirmModal.tsx
+++ b/src/components/Common/DangerConfirmModal.tsx
@@ -1,0 +1,291 @@
+/**
+ * DangerConfirmModal - confirmation forte pour actions destructives
+ *
+ * L'user doit taper un mot de validation (ex: "SUPPRIMER") avant que le
+ * bouton de confirmation devienne actif. Empêche les déclenchements
+ * accidentels (un simple tap sur "Confirmer" ne suffit plus).
+ */
+
+import React, { useEffect, useState } from "react";
+import {
+  ActivityIndicator,
+  Modal,
+  Platform,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "../../context/ThemeContext";
+import { colors, withOpacity } from "../../theme/colors";
+
+export type DangerConfirmActionVariant = "destructive" | "warning";
+
+export interface DangerConfirmModalProps {
+  visible: boolean;
+  title: string;
+  description: string;
+  expectedText: string;
+  caseInsensitive?: boolean;
+  actionLabel: string;
+  actionVariant?: DangerConfirmActionVariant;
+  onCancel: () => void;
+  onConfirm: () => void | Promise<void>;
+  loading?: boolean;
+}
+
+export const DangerConfirmModal: React.FC<DangerConfirmModalProps> = ({
+  visible,
+  title,
+  description,
+  expectedText,
+  caseInsensitive = true,
+  actionLabel,
+  actionVariant = "destructive",
+  onCancel,
+  onConfirm,
+  loading = false,
+}) => {
+  const [input, setInput] = useState("");
+  const { getThemeColors, getLocalizedText } = useTheme();
+  const themeColors = getThemeColors();
+
+  // reset l'input a chaque ouverture pour ne pas garder l'ancien match
+  useEffect(() => {
+    if (visible) {
+      setInput("");
+    }
+  }, [visible]);
+
+  const normalize = (value: string): string =>
+    caseInsensitive ? value.trim().toLowerCase() : value.trim();
+
+  const isMatch = normalize(input) === normalize(expectedText);
+  const canConfirm = isMatch && !loading;
+
+  const variantColor =
+    actionVariant === "warning" ? colors.ui.warning : colors.ui.error;
+
+  const handleConfirm = () => {
+    if (!canConfirm) return;
+    void onConfirm();
+  };
+
+  const handleSubmitEditing = () => {
+    if (canConfirm) handleConfirm();
+  };
+
+  const typeToConfirmLabel = getLocalizedText("confirm.typeToConfirm").replace(
+    "{{text}}",
+    expectedText,
+  );
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onCancel}
+    >
+      <View style={styles.overlay}>
+        <View
+          style={[
+            styles.container,
+            { backgroundColor: colors.background.dark },
+          ]}
+        >
+          <View style={styles.iconContainer}>
+            <View
+              style={[
+                styles.iconCircle,
+                { backgroundColor: withOpacity(variantColor, 0.15) },
+              ]}
+            >
+              <Ionicons name="warning-outline" size={32} color={variantColor} />
+            </View>
+          </View>
+
+          <Text style={[styles.title, { color: themeColors.text.primary }]}>
+            {title}
+          </Text>
+
+          <Text style={[styles.message, { color: themeColors.text.secondary }]}>
+            {description}
+          </Text>
+
+          <Text
+            style={[styles.typeLabel, { color: themeColors.text.secondary }]}
+          >
+            {typeToConfirmLabel}
+          </Text>
+
+          <TextInput
+            style={[
+              styles.input,
+              {
+                color: themeColors.text.primary,
+                borderColor: isMatch
+                  ? variantColor
+                  : withOpacity(colors.text.light, 0.2),
+                backgroundColor: "rgba(255, 255, 255, 0.05)",
+                opacity: loading ? 0.5 : 1,
+              },
+            ]}
+            value={input}
+            onChangeText={setInput}
+            placeholder={expectedText}
+            placeholderTextColor={withOpacity(colors.text.light, 0.4)}
+            autoCapitalize="characters"
+            autoCorrect={false}
+            editable={!loading}
+            onSubmitEditing={handleSubmitEditing}
+            returnKeyType="done"
+            // accessibilite : decrit l'effet attendu
+            accessibilityLabel={typeToConfirmLabel}
+            accessibilityHint={
+              isMatch
+                ? actionLabel
+                : getLocalizedText("confirm.actionIrreversible")
+            }
+            testID="danger-confirm-input"
+          />
+
+          <View style={styles.actions}>
+            <TouchableOpacity
+              style={[
+                styles.button,
+                styles.cancelButton,
+                { borderColor: withOpacity(colors.text.light, 0.2) },
+              ]}
+              onPress={onCancel}
+              disabled={loading}
+              activeOpacity={0.7}
+              accessibilityRole="button"
+              testID="danger-confirm-cancel"
+            >
+              <Text
+                style={[
+                  styles.cancelButtonText,
+                  { color: themeColors.text.primary },
+                ]}
+              >
+                {getLocalizedText("confirm.cancel")}
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[
+                styles.button,
+                styles.confirmButton,
+                {
+                  backgroundColor: variantColor,
+                  opacity: canConfirm ? 1 : 0.4,
+                },
+              ]}
+              onPress={handleConfirm}
+              disabled={!canConfirm}
+              activeOpacity={0.7}
+              accessibilityRole="button"
+              accessibilityState={{ disabled: !canConfirm }}
+              testID="danger-confirm-action"
+            >
+              {loading ? (
+                <ActivityIndicator size="small" color={colors.text.light} />
+              ) : (
+                <Text
+                  style={[
+                    styles.confirmButtonText,
+                    { color: colors.text.light },
+                  ]}
+                >
+                  {actionLabel}
+                </Text>
+              )}
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: "rgba(0, 0, 0, 0.6)",
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 32,
+  },
+  container: {
+    width: "100%",
+    maxWidth: 420,
+    borderRadius: 20,
+    paddingVertical: 28,
+    paddingHorizontal: 24,
+    alignItems: "center",
+  },
+  iconContainer: {
+    marginBottom: 16,
+  },
+  iconCircle: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "700",
+    marginBottom: 12,
+    textAlign: "center",
+  },
+  message: {
+    fontSize: 14,
+    textAlign: "center",
+    lineHeight: 20,
+    marginBottom: 16,
+  },
+  typeLabel: {
+    fontSize: 13,
+    textAlign: "center",
+    marginBottom: 8,
+    alignSelf: "stretch",
+  },
+  input: {
+    width: "100%",
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: Platform.OS === "ios" ? 14 : 10,
+    fontSize: 16,
+    marginBottom: 24,
+    textAlign: "center",
+  },
+  actions: {
+    flexDirection: "row",
+    gap: 12,
+    width: "100%",
+  },
+  button: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  cancelButton: {
+    borderWidth: 1,
+  },
+  confirmButton: {},
+  cancelButtonText: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  confirmButtonText: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+});

--- a/src/components/Contacts/DeleteContactModal.tsx
+++ b/src/components/Contacts/DeleteContactModal.tsx
@@ -1,23 +1,15 @@
 /**
- * DeleteContactModal - Modal de confirmation de suppression d'un contact
- * Affiche une popup avec les options Confirmer et Annuler
+ * DeleteContactModal - confirmation de suppression d'un contact
+ *
+ * Utilise DangerConfirmModal : l'user doit taper "SUPPRIMER" pour activer
+ * le bouton, ce qui evite les suppressions accidentelles.
  */
 
 import React, { useState } from "react";
-import {
-  View,
-  Text,
-  StyleSheet,
-  Modal,
-  TouchableOpacity,
-  ActivityIndicator,
-} from "react-native";
-import { Ionicons } from "@expo/vector-icons";
 import { Contact } from "../../types/contact";
-import { Avatar } from "../Chat/Avatar";
 import { useTheme } from "../../context/ThemeContext";
-import { colors, withOpacity } from "../../theme/colors";
 import { contactsAPI } from "../../services/contacts/api";
+import { DangerConfirmModal } from "../Common/DangerConfirmModal";
 
 interface DeleteContactModalProps {
   visible: boolean;
@@ -33,8 +25,7 @@ export const DeleteContactModal: React.FC<DeleteContactModalProps> = ({
   onContactDeleted,
 }) => {
   const [deleting, setDeleting] = useState(false);
-  const { getThemeColors } = useTheme();
-  const themeColors = getThemeColors();
+  const { getLocalizedText } = useTheme();
 
   if (!contact) return null;
 
@@ -55,189 +46,19 @@ export const DeleteContactModal: React.FC<DeleteContactModalProps> = ({
     }
   };
 
-  const handleCancel = () => {
-    onClose();
-  };
-
   return (
-    <Modal
+    <DangerConfirmModal
       visible={visible}
-      transparent
-      animationType="fade"
-      onRequestClose={handleCancel}
-    >
-      <View style={styles.overlay}>
-        <View
-          style={[
-            styles.container,
-            { backgroundColor: colors.background.dark },
-          ]}
-        >
-          <View style={styles.iconContainer}>
-            <View
-              style={[
-                styles.iconCircle,
-                { backgroundColor: withOpacity(colors.ui.error, 0.15) },
-              ]}
-            >
-              <Ionicons
-                name="trash-outline"
-                size={32}
-                color={colors.ui.error}
-              />
-            </View>
-          </View>
-
-          <Text style={[styles.title, { color: themeColors.text.primary }]}>
-            Supprimer le contact
-          </Text>
-
-          <View style={styles.contactPreview}>
-            <Avatar
-              uri={user?.avatar_url}
-              name={displayName}
-              size={40}
-              showOnlineBadge={false}
-            />
-            <Text
-              style={[styles.contactName, { color: themeColors.text.primary }]}
-              numberOfLines={1}
-            >
-              {displayName}
-            </Text>
-          </View>
-
-          <Text style={[styles.message, { color: themeColors.text.secondary }]}>
-            {
-              "Êtes-vous sûr de vouloir supprimer ce contact ? Cette action est irréversible."
-            }
-          </Text>
-
-          <View style={styles.actions}>
-            <TouchableOpacity
-              style={[
-                styles.button,
-                styles.cancelButton,
-                { borderColor: withOpacity(colors.text.light, 0.2) },
-              ]}
-              onPress={handleCancel}
-              disabled={deleting}
-              activeOpacity={0.7}
-            >
-              <Text
-                style={[
-                  styles.cancelButtonText,
-                  { color: themeColors.text.primary },
-                ]}
-              >
-                Annuler
-              </Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={[
-                styles.button,
-                styles.confirmButton,
-                { backgroundColor: colors.ui.error },
-              ]}
-              onPress={handleConfirm}
-              disabled={deleting}
-              activeOpacity={0.7}
-            >
-              {deleting ? (
-                <ActivityIndicator size="small" color={colors.text.light} />
-              ) : (
-                <Text
-                  style={[
-                    styles.confirmButtonText,
-                    { color: colors.text.light },
-                  ]}
-                >
-                  Confirmer
-                </Text>
-              )}
-            </TouchableOpacity>
-          </View>
-        </View>
-      </View>
-    </Modal>
+      title={getLocalizedText("confirm.deleteContact.title")}
+      description={`${displayName} — ${getLocalizedText(
+        "confirm.deleteContact.description",
+      )}`}
+      expectedText={getLocalizedText("confirm.expectedDelete")}
+      actionLabel={getLocalizedText("confirm.deleteContact.action")}
+      actionVariant="destructive"
+      loading={deleting}
+      onCancel={onClose}
+      onConfirm={handleConfirm}
+    />
   );
 };
-
-const styles = StyleSheet.create({
-  overlay: {
-    flex: 1,
-    backgroundColor: "rgba(0, 0, 0, 0.6)",
-    justifyContent: "center",
-    alignItems: "center",
-    paddingHorizontal: 32,
-  },
-  container: {
-    width: "100%",
-    borderRadius: 20,
-    paddingVertical: 28,
-    paddingHorizontal: 24,
-    alignItems: "center",
-  },
-  iconContainer: {
-    marginBottom: 16,
-  },
-  iconCircle: {
-    width: 64,
-    height: 64,
-    borderRadius: 32,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  title: {
-    fontSize: 18,
-    fontWeight: "700",
-    marginBottom: 16,
-    textAlign: "center",
-  },
-  contactPreview: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 12,
-    marginBottom: 12,
-    paddingHorizontal: 16,
-    paddingVertical: 10,
-    borderRadius: 12,
-    backgroundColor: "rgba(255, 255, 255, 0.05)",
-    width: "100%",
-  },
-  contactName: {
-    fontSize: 16,
-    fontWeight: "600",
-    flex: 1,
-  },
-  message: {
-    fontSize: 14,
-    textAlign: "center",
-    lineHeight: 20,
-    marginBottom: 24,
-  },
-  actions: {
-    flexDirection: "row",
-    gap: 12,
-    width: "100%",
-  },
-  button: {
-    flex: 1,
-    paddingVertical: 14,
-    borderRadius: 12,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  cancelButton: {
-    borderWidth: 1,
-  },
-  confirmButton: {},
-  cancelButtonText: {
-    fontSize: 16,
-    fontWeight: "600",
-  },
-  confirmButtonText: {
-    fontSize: 16,
-    fontWeight: "600",
-  },
-});

--- a/src/components/Contacts/EditContactModal.tsx
+++ b/src/components/Contacts/EditContactModal.tsx
@@ -25,6 +25,7 @@ import { Avatar } from "../Chat/Avatar";
 import { useTheme } from "../../context/ThemeContext";
 import { colors } from "../../theme/colors";
 import { useNavigation } from "@react-navigation/native";
+import { DangerConfirmModal } from "../Common/DangerConfirmModal";
 
 interface EditContactModalProps {
   visible: boolean;
@@ -42,7 +43,9 @@ export const EditContactModal: React.FC<EditContactModalProps> = ({
   const [nickname, setNickname] = useState("");
   const [isFavorite, setIsFavorite] = useState(false);
   const [saving, setSaving] = useState(false);
-  const { getThemeColors } = useTheme();
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deletingContact, setDeletingContact] = useState(false);
+  const { getThemeColors, getLocalizedText } = useTheme();
   const themeColors = getThemeColors();
   const navigation = useNavigation();
 
@@ -84,41 +87,27 @@ export const EditContactModal: React.FC<EditContactModalProps> = ({
 
   const handleDelete = () => {
     if (!contact) return;
+    setShowDeleteConfirm(true);
+  };
 
-    Alert.alert(
-      "Supprimer le contact",
-      "Êtes-vous sûr de vouloir supprimer ce contact ?",
-      [
-        { text: "Annuler", style: "cancel" },
-        {
-          text: "Supprimer",
-          style: "destructive",
-          onPress: async () => {
-            try {
-              await contactsAPI.deleteContact(contact.contact_id || contact.id);
-              Alert.alert("Succès", "Contact supprimé", [
-                {
-                  text: "OK",
-                  onPress: () => {
-                    onContactUpdated();
-                    handleClose();
-                  },
-                },
-              ]);
-            } catch (error: any) {
-              console.error(
-                "[EditContactModal] Error deleting contact:",
-                error,
-              );
-              Alert.alert(
-                "Erreur",
-                error.message || "Impossible de supprimer le contact",
-              );
-            }
-          },
-        },
-      ],
-    );
+  const confirmDeleteContact = async () => {
+    if (!contact) return;
+    setDeletingContact(true);
+    try {
+      await contactsAPI.deleteContact(contact.contact_id || contact.id);
+      setShowDeleteConfirm(false);
+      onContactUpdated();
+      handleClose();
+    } catch (error: any) {
+      console.error("[EditContactModal] Error deleting contact:", error);
+      setShowDeleteConfirm(false);
+      Alert.alert(
+        "Erreur",
+        error.message || "Impossible de supprimer le contact",
+      );
+    } finally {
+      setDeletingContact(false);
+    }
   };
 
   const handleClose = () => {
@@ -347,6 +336,19 @@ export const EditContactModal: React.FC<EditContactModalProps> = ({
           </View>
         </SafeAreaView>
       </LinearGradient>
+      <DangerConfirmModal
+        visible={showDeleteConfirm}
+        title={getLocalizedText("confirm.deleteContact.title")}
+        description={`${displayName} — ${getLocalizedText(
+          "confirm.deleteContact.description",
+        )}`}
+        expectedText={getLocalizedText("confirm.expectedDelete")}
+        actionLabel={getLocalizedText("confirm.deleteContact.action")}
+        actionVariant="destructive"
+        loading={deletingContact}
+        onCancel={() => setShowDeleteConfirm(false)}
+        onConfirm={confirmDeleteContact}
+      />
     </Modal>
   );
 };

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -997,6 +997,20 @@ const localizedTexts: Record<Language, Record<string, string>> = {
     "common.retry": "Réessayer",
     "common.optional": "optionnel",
     "common.copyError": "Impossible de copier dans le presse-papiers.",
+
+    // Confirmation forte (typed-confirm)
+    "confirm.expectedDelete": "SUPPRIMER",
+    "confirm.typeToConfirm": "Tape {{text}} pour confirmer",
+    "confirm.actionIrreversible": "Cette action est irréversible.",
+    "confirm.cancel": "Annuler",
+    "confirm.deleteAccount.title": "Supprimer mon compte ?",
+    "confirm.deleteAccount.description":
+      "Cette action est irréversible. Toutes vos conversations, messages et données seront supprimés.",
+    "confirm.deleteAccount.action": "Supprimer définitivement",
+    "confirm.deleteContact.title": "Supprimer ce contact ?",
+    "confirm.deleteContact.description":
+      "Le contact sera retiré de votre liste. Cette action est irréversible.",
+    "confirm.deleteContact.action": "Supprimer",
   },
   en: {
     // Navigation
@@ -1299,6 +1313,20 @@ const localizedTexts: Record<Language, Record<string, string>> = {
     "common.retry": "Retry",
     "common.optional": "optional",
     "common.copyError": "Unable to copy to clipboard.",
+
+    // Strong confirmation (typed-confirm)
+    "confirm.expectedDelete": "DELETE",
+    "confirm.typeToConfirm": "Type {{text}} to confirm",
+    "confirm.actionIrreversible": "This action cannot be undone.",
+    "confirm.cancel": "Cancel",
+    "confirm.deleteAccount.title": "Delete my account?",
+    "confirm.deleteAccount.description":
+      "This action cannot be undone. All your conversations, messages and data will be deleted.",
+    "confirm.deleteAccount.action": "Delete permanently",
+    "confirm.deleteContact.title": "Delete this contact?",
+    "confirm.deleteContact.description":
+      "The contact will be removed from your list. This action cannot be undone.",
+    "confirm.deleteContact.action": "Delete",
   },
 };
 

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -36,6 +36,7 @@ import {
 } from "../../services/NotificationService";
 import { setReadReceiptsEnabled } from "../../services/messaging/readReceiptsPref";
 import { SettingsChoiceAlert } from "./SettingsChoiceAlert";
+import { DangerConfirmModal } from "../../components/Common/DangerConfirmModal";
 import { FLOATING_TAB_BAR_RESERVED_SPACE } from "../../components/Navigation/floatingTabBarLayout";
 import {
   DEFAULT_MODERATION_MODEL,
@@ -94,6 +95,8 @@ export const SettingsScreen: React.FC = () => {
   const [selectedPrivacyItem, setSelectedPrivacyItem] = useState<string | null>(
     null,
   );
+  const [showDeleteAccountModal, setShowDeleteAccountModal] = useState(false);
+  const [deletingAccount, setDeletingAccount] = useState(false);
 
   // AsyncStorage keys
   const STORAGE_KEYS = {
@@ -591,15 +594,27 @@ export const SettingsScreen: React.FC = () => {
   };
 
   const handleDeleteAccount = () => {
-    if (Platform.OS === "web") {
-      window.alert("Fonctionnalité à venir");
-      return;
+    setShowDeleteAccountModal(true);
+  };
+
+  const confirmDeleteAccount = async () => {
+    // l'endpoint /users/me delete cote backend n'est pas encore livre,
+    // on garde un placeholder mais l'UX du typed-confirm protege la future integration
+    setDeletingAccount(true);
+    try {
+      if (Platform.OS === "web") {
+        window.alert("Fonctionnalité à venir");
+      } else {
+        Alert.alert(
+          getLocalizedText("settings.deleteAccount"),
+          "Fonctionnalité à venir",
+          [{ text: "OK" }],
+        );
+      }
+    } finally {
+      setDeletingAccount(false);
+      setShowDeleteAccountModal(false);
     }
-    Alert.alert(
-      getLocalizedText("settings.deleteAccount"),
-      "Fonctionnalité à venir",
-      [{ text: "OK" }],
-    );
   };
 
   const backgroundPresetLabel =
@@ -1452,6 +1467,18 @@ export const SettingsScreen: React.FC = () => {
           layout="vertical"
         />
       )}
+
+      <DangerConfirmModal
+        visible={showDeleteAccountModal}
+        title={getLocalizedText("confirm.deleteAccount.title")}
+        description={getLocalizedText("confirm.deleteAccount.description")}
+        expectedText={getLocalizedText("confirm.expectedDelete")}
+        actionLabel={getLocalizedText("confirm.deleteAccount.action")}
+        actionVariant="destructive"
+        loading={deletingAccount}
+        onCancel={() => setShowDeleteAccountModal(false)}
+        onConfirm={confirmDeleteAccount}
+      />
     </LinearGradient>
   );
 };


### PR DESCRIPTION
## Summary
- Nouveau composant reutilisable `DangerConfirmModal` (`src/components/Common/`) qui force l'user a taper un mot de validation (par defaut "SUPPRIMER" / "DELETE") pour activer le bouton de confirmation. Empeche les suppressions accidentelles.
- Branche sur deux call-sites :
  - **Suppression de compte** (`SettingsScreen`) : remplace l'`Alert.alert` simple par le typed-confirm.
  - **Suppression de contact** (`DeleteContactModal` + bouton "Supprimer le contact" dans `EditContactModal`) : meme mecanisme.
- i18n FR/EN ajoutee dans `ThemeContext` (cles `confirm.expectedDelete`, `confirm.typeToConfirm`, `confirm.actionIrreversible`, `confirm.cancel`, `confirm.deleteAccount.*`, `confirm.deleteContact.*`).
- Hors scope volontairement : swipe-to-delete sur la liste contacts (UX volontaire), bouton Bloquer (reversible), actions groupe.

## Test plan
- [x] 10 nouveaux tests unitaires sur `DangerConfirmModal` (input vide / partiel / match / case-insensitive / case-sensitive / cancel / submit Enter / loading / snapshot)
- [x] `npm test -- --watchAll=false` : 929/929 passing
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` 0 errors sur les fichiers touches
- [ ] QA manuelle iOS Simulator (a faire en preprod)
- [ ] QA manuelle Android Emulator
- [ ] QA manuelle Web PWA Safari iOS

## Screenshots
A ajouter apres deploy preprod.

Closes WHISPR-1345