### PR TITLE
[WHISPR-1346] feat(security): typed confirm modal for leave/delete group actions

### DIFF
--- a/GroupDetailsScreen.test.tsx
+++ b/GroupDetailsScreen.test.tsx
@@ -65,7 +65,17 @@ jest.mock("./src/context/ThemeContext", () => ({
       primary: "#6200ee",
     }),
     getFontSize: () => 16,
-    getLocalizedText: (key: string) => key,
+    getLocalizedText: (key: string) => {
+      // mappe les cles utilisees par DangerConfirmModal vers leurs valeurs FR
+      // pour que le test puisse taper le mot exact attendu
+      const dict: Record<string, string> = {
+        "confirm.expectedDelete": "SUPPRIMER",
+        "confirm.typeToConfirm": "Tape {{text}} pour confirmer",
+        "confirm.cancel": "Annuler",
+        "confirm.actionIrreversible": "Cette action est irréversible.",
+      };
+      return dict[key] ?? key;
+    },
   }),
 }));
 jest.mock("./src/context/AuthContext", () => ({
@@ -89,6 +99,8 @@ jest.mock("./src/services/groups/api", () => ({
     getGroupStats: jest.fn(),
     getGroupLogs: jest.fn(),
     getGroupSettings: jest.fn(),
+    leaveGroup: jest.fn(),
+    deleteGroup: jest.fn(),
   },
 }));
 jest.mock("./src/theme/colors", () => ({
@@ -239,6 +251,126 @@ describe("GroupDetailsScreen", () => {
 
     await waitFor(() => {
       expect(getByText("Ajouter un membre")).toBeTruthy();
+    });
+  });
+
+  describe("typed-confirm group actions (WHISPR-1346)", () => {
+    const memberMe = {
+      id: "user1",
+      user_id: "user1",
+      display_name: "Me",
+      role: "member" as const,
+      joined_at: "2024-01-01T00:00:00Z",
+      is_active: true,
+    };
+    const adminOther = {
+      id: "user2",
+      user_id: "user2",
+      display_name: "Admin Other",
+      role: "admin" as const,
+      joined_at: "2024-01-01T00:00:00Z",
+      is_active: true,
+    };
+    const adminMe = {
+      id: "user1",
+      user_id: "user1",
+      display_name: "Me",
+      role: "admin" as const,
+      joined_at: "2024-01-01T00:00:00Z",
+      is_active: true,
+    };
+
+    it("non-last-admin: quitter ouvre la typed-confirm modal", async () => {
+      mockedGroupsAPI.getGroupMembers.mockResolvedValue({
+        members: [memberMe, adminOther],
+        total: 2,
+      } as any);
+
+      const { getByText, getByTestId, queryByTestId, getAllByText } = render(
+        <GroupDetailsScreen />,
+      );
+      await waitFor(() => {
+        expect(getAllByText("Test Group").length).toBeGreaterThan(0);
+      });
+      // bouton "Quitter le groupe" est dans le tab Parametres
+      fireEvent.press(getByText("Paramètres"));
+      await waitFor(() => {
+        expect(getByText("Quitter le groupe")).toBeTruthy();
+      });
+      expect(queryByTestId("danger-confirm-input")).toBeNull();
+
+      fireEvent.press(getByText("Quitter le groupe"));
+
+      expect(getByTestId("danger-confirm-input")).toBeTruthy();
+    });
+
+    it("leave: action desactivee tant que SUPPRIMER n'est pas tape", async () => {
+      mockedGroupsAPI.getGroupMembers.mockResolvedValue({
+        members: [memberMe, adminOther],
+        total: 2,
+      } as any);
+      (mockedGroupsAPI as any).leaveGroup.mockResolvedValueOnce(undefined);
+
+      const { getByText, getByTestId, getAllByText } = render(
+        <GroupDetailsScreen />,
+      );
+      await waitFor(() => {
+        expect(getAllByText("Test Group").length).toBeGreaterThan(0);
+      });
+      fireEvent.press(getByText("Paramètres"));
+      await waitFor(() => {
+        expect(getByText("Quitter le groupe")).toBeTruthy();
+      });
+
+      fireEvent.press(getByText("Quitter le groupe"));
+      // tap sur action sans input -> rien ne se passe
+      fireEvent.press(getByTestId("danger-confirm-action"));
+      expect((mockedGroupsAPI as any).leaveGroup).not.toHaveBeenCalled();
+
+      fireEvent.changeText(getByTestId("danger-confirm-input"), "SUPPRIMER");
+      fireEvent.press(getByTestId("danger-confirm-action"));
+
+      await waitFor(() => {
+        expect((mockedGroupsAPI as any).leaveGroup).toHaveBeenCalledWith(
+          "g1",
+          "user1",
+          "conv1",
+        );
+      });
+    });
+
+    it("admin: supprimer le groupe necessite SUPPRIMER tape", async () => {
+      mockedGroupsAPI.getGroupMembers.mockResolvedValue({
+        members: [adminMe, adminOther],
+        total: 2,
+      } as any);
+      (mockedGroupsAPI as any).deleteGroup.mockResolvedValueOnce(undefined);
+
+      const { getByText, getByTestId, getAllByText } = render(
+        <GroupDetailsScreen />,
+      );
+      await waitFor(() => {
+        expect(getAllByText("Test Group").length).toBeGreaterThan(0);
+      });
+      fireEvent.press(getByText("Paramètres"));
+      await waitFor(() => {
+        expect(getByText("Supprimer le groupe")).toBeTruthy();
+      });
+
+      fireEvent.press(getByText("Supprimer le groupe"));
+      // sans input, l'API ne doit pas etre appelee
+      fireEvent.press(getByTestId("danger-confirm-action"));
+      expect((mockedGroupsAPI as any).deleteGroup).not.toHaveBeenCalled();
+
+      fireEvent.changeText(getByTestId("danger-confirm-input"), "SUPPRIMER");
+      fireEvent.press(getByTestId("danger-confirm-action"));
+
+      await waitFor(() => {
+        expect((mockedGroupsAPI as any).deleteGroup).toHaveBeenCalledWith(
+          "g1",
+          "conv1",
+        );
+      });
     });
   });
 });

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1011,6 +1011,14 @@ const localizedTexts: Record<Language, Record<string, string>> = {
     "confirm.deleteContact.description":
       "Le contact sera retiré de votre liste. Cette action est irréversible.",
     "confirm.deleteContact.action": "Supprimer",
+    "confirm.leaveGroup.title": "Quitter ce groupe ?",
+    "confirm.leaveGroup.description":
+      "Tu ne pourras plus envoyer de messages ni voir l'historique. Tape SUPPRIMER pour confirmer.",
+    "confirm.leaveGroup.action": "Quitter",
+    "confirm.deleteGroup.title": "Supprimer ce groupe ?",
+    "confirm.deleteGroup.description":
+      "Tous les messages, médias et l'historique seront perdus. Action irréversible. Tape SUPPRIMER pour confirmer.",
+    "confirm.deleteGroup.action": "Supprimer définitivement",
   },
   en: {
     // Navigation
@@ -1327,6 +1335,14 @@ const localizedTexts: Record<Language, Record<string, string>> = {
     "confirm.deleteContact.description":
       "The contact will be removed from your list. This action cannot be undone.",
     "confirm.deleteContact.action": "Delete",
+    "confirm.leaveGroup.title": "Leave this group?",
+    "confirm.leaveGroup.description":
+      "You will no longer be able to send messages or see history. Type DELETE to confirm.",
+    "confirm.leaveGroup.action": "Leave",
+    "confirm.deleteGroup.title": "Delete this group?",
+    "confirm.deleteGroup.description":
+      "All messages, media and history will be lost. This action cannot be undone. Type DELETE to confirm.",
+    "confirm.deleteGroup.action": "Delete permanently",
   },
 };
 

--- a/src/screens/Groups/GroupDetailsScreen.tsx
+++ b/src/screens/Groups/GroupDetailsScreen.tsx
@@ -47,6 +47,7 @@ import { useAuth } from "../../context/AuthContext";
 import { colors, withOpacity } from "../../theme/colors";
 import { typography } from "../../theme/typography";
 import { Avatar } from "../../components/Chat/Avatar";
+import { DangerConfirmModal } from "../../components/Common/DangerConfirmModal";
 import { ProfileTrigger } from "../../components/Profile/ProfileTrigger";
 import { logger } from "../../utils/logger";
 import {
@@ -148,7 +149,7 @@ export const GroupDetailsScreen: React.FC = () => {
   );
   const [memberActionLoading, setMemberActionLoading] = useState(false);
 
-  const { settings: themeSettings } = useTheme();
+  const { settings: themeSettings, getLocalizedText } = useTheme();
   const hasCustomBackground =
     themeSettings?.backgroundPreset === "custom" &&
     !!themeSettings?.customBackgroundUri;
@@ -304,10 +305,10 @@ export const GroupDetailsScreen: React.FC = () => {
 
     try {
       setLeaving(true);
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
       await groupsAPI.leaveGroup(groupId, CURRENT_USER_ID, conversationId);
       removeConversationLocal(conversationKey);
       refreshConversations().catch(() => {});
+      // haptic apres succes API pour eviter le feedback positif sur un fail
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       navigation.navigate("ConversationsList");
     } catch (error: any) {
@@ -332,8 +333,8 @@ export const GroupDetailsScreen: React.FC = () => {
   const handleDeleteGroup = useCallback(async () => {
     try {
       setDeleting(true);
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
       await groupsAPI.deleteGroup(groupId, conversationId);
+      // haptic apres succes API pour eviter le feedback positif sur un fail
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       Alert.alert("Succès", "Le groupe a été supprimé");
       navigation.navigate("ConversationsList");
@@ -345,7 +346,7 @@ export const GroupDetailsScreen: React.FC = () => {
       setDeleting(false);
       setShowDeleteModal(false);
     }
-  }, [groupId, navigation]);
+  }, [groupId, conversationId, navigation]);
 
   const updateGroupSetting = useCallback(
     async (updates: Partial<GroupSettings>) => {
@@ -1537,7 +1538,12 @@ export const GroupDetailsScreen: React.FC = () => {
             style={styles.actionButton}
             onPress={() => {
               Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-              setShowLeaveModal(true);
+              // si dernier admin, on saute la typed-confirm et on force le transfert direct
+              if (isLastAdmin) {
+                setShowTransferAdminModal(true);
+              } else {
+                setShowLeaveModal(true);
+              }
             }}
             activeOpacity={0.7}
             entering={FadeInDown.delay(200).duration(300)}
@@ -1634,176 +1640,31 @@ export const GroupDetailsScreen: React.FC = () => {
   };
 
   const renderLeaveModal = () => (
-    <Modal
+    <DangerConfirmModal
       visible={showLeaveModal}
-      transparent
-      animationType="fade"
-      onRequestClose={() => setShowLeaveModal(false)}
-    >
-      <View style={styles.modalOverlay}>
-        <AnimatedView
-          style={styles.modalContainer}
-          entering={FadeInDown.duration(300).springify()}
-        >
-          <LinearGradient
-            colors={colors.background.gradient.app}
-            start={{ x: 0, y: 0 }}
-            end={{ x: 1, y: 1 }}
-            style={styles.modalGradient}
-          >
-            <View style={styles.modalHeader}>
-              <View style={styles.modalIconContainer}>
-                <LinearGradient
-                  colors={[colors.primary.main, colors.primary.dark]}
-                  style={styles.modalIconGradient}
-                >
-                  <Ionicons
-                    name="exit-outline"
-                    size={28}
-                    color={colors.text.light}
-                  />
-                </LinearGradient>
-              </View>
-              <Text style={styles.modalTitle}>Quitter le groupe</Text>
-              <Text style={styles.modalDescription}>
-                {isLastAdmin
-                  ? "Vous êtes le dernier administrateur. Vous devez transférer l'administration avant de quitter le groupe, sinon le groupe sera supprimé."
-                  : `Êtes-vous sûr de vouloir quitter "${groupDetails?.name}" ? Vous ne recevrez plus les messages de ce groupe.`}
-              </Text>
-            </View>
-            <View style={styles.modalActions}>
-              <TouchableOpacity
-                style={styles.modalButtonCancel}
-                onPress={() => {
-                  Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                  setShowLeaveModal(false);
-                }}
-                activeOpacity={0.7}
-              >
-                <Text style={styles.modalButtonCancelText}>Annuler</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={styles.modalButtonConfirm}
-                onPress={handleLeaveGroup}
-                disabled={leaving}
-                activeOpacity={0.8}
-              >
-                <LinearGradient
-                  colors={[colors.primary.main, colors.primary.dark]}
-                  start={{ x: 0, y: 0 }}
-                  end={{ x: 1, y: 0 }}
-                  style={styles.modalButtonGradient}
-                >
-                  {leaving ? (
-                    <ActivityIndicator size="small" color={colors.text.light} />
-                  ) : (
-                    <>
-                      <Ionicons
-                        name="exit-outline"
-                        size={18}
-                        color={colors.text.light}
-                        style={styles.modalButtonIcon}
-                      />
-                      <Text style={styles.modalButtonConfirmText}>Quitter</Text>
-                    </>
-                  )}
-                </LinearGradient>
-              </TouchableOpacity>
-            </View>
-          </LinearGradient>
-        </AnimatedView>
-      </View>
-    </Modal>
+      title={getLocalizedText("confirm.leaveGroup.title")}
+      description={getLocalizedText("confirm.leaveGroup.description")}
+      expectedText={getLocalizedText("confirm.expectedDelete")}
+      actionLabel={getLocalizedText("confirm.leaveGroup.action")}
+      actionVariant="destructive"
+      loading={leaving}
+      onCancel={() => setShowLeaveModal(false)}
+      onConfirm={handleLeaveGroup}
+    />
   );
 
   const renderDeleteModal = () => (
-    <Modal
+    <DangerConfirmModal
       visible={showDeleteModal}
-      transparent
-      animationType="fade"
-      onRequestClose={() => setShowDeleteModal(false)}
-    >
-      <View style={styles.modalOverlay}>
-        <AnimatedView
-          style={styles.modalContainer}
-          entering={FadeInDown.duration(300).springify()}
-        >
-          <LinearGradient
-            colors={colors.background.gradient.app}
-            start={{ x: 0, y: 0 }}
-            end={{ x: 1, y: 1 }}
-            style={styles.modalGradient}
-          >
-            <View style={styles.modalHeader}>
-              <View
-                style={[
-                  styles.modalIconContainer,
-                  styles.modalIconContainerDanger,
-                ]}
-              >
-                <LinearGradient
-                  colors={[colors.ui.error, "#E02D20"]}
-                  style={styles.modalIconGradient}
-                >
-                  <Ionicons
-                    name="trash-outline"
-                    size={28}
-                    color={colors.text.light}
-                  />
-                </LinearGradient>
-              </View>
-              <Text style={styles.modalTitle}>Supprimer le groupe</Text>
-              <Text style={styles.modalDescription}>
-                Êtes-vous sûr de vouloir supprimer "{groupDetails?.name}" ?
-                Cette action est irréversible après 7 jours. Tous les membres
-                seront retirés et toutes les données seront supprimées.
-              </Text>
-            </View>
-            <View style={styles.modalActions}>
-              <TouchableOpacity
-                style={styles.modalButtonCancel}
-                onPress={() => {
-                  Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                  setShowDeleteModal(false);
-                }}
-                activeOpacity={0.7}
-              >
-                <Text style={styles.modalButtonCancelText}>Annuler</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={styles.modalButtonDelete}
-                onPress={handleDeleteGroup}
-                disabled={deleting}
-                activeOpacity={0.8}
-              >
-                <LinearGradient
-                  colors={[colors.ui.error, "#E02D20"]}
-                  start={{ x: 0, y: 0 }}
-                  end={{ x: 1, y: 0 }}
-                  style={styles.modalButtonGradient}
-                >
-                  {deleting ? (
-                    <ActivityIndicator size="small" color={colors.text.light} />
-                  ) : (
-                    <>
-                      <Ionicons
-                        name="trash-outline"
-                        size={18}
-                        color={colors.text.light}
-                        style={styles.modalButtonIcon}
-                      />
-                      <Text style={styles.modalButtonDeleteText}>
-                        Supprimer
-                      </Text>
-                    </>
-                  )}
-                </LinearGradient>
-              </TouchableOpacity>
-            </View>
-          </LinearGradient>
-        </AnimatedView>
-      </View>
-    </Modal>
+      title={getLocalizedText("confirm.deleteGroup.title")}
+      description={getLocalizedText("confirm.deleteGroup.description")}
+      expectedText={getLocalizedText("confirm.expectedDelete")}
+      actionLabel={getLocalizedText("confirm.deleteGroup.action")}
+      actionVariant="destructive"
+      loading={deleting}
+      onCancel={() => setShowDeleteModal(false)}
+      onConfirm={handleDeleteGroup}
+    />
   );
 
   const renderTransferAdminModal = () => {
@@ -2711,9 +2572,6 @@ const styles = StyleSheet.create({
     marginBottom: 16,
     overflow: "hidden",
   },
-  modalIconContainerDanger: {
-    // Style spécifique pour le danger
-  },
   modalIconContainerInfo: {
     // Style spécifique pour l'info
   },
@@ -2753,46 +2611,10 @@ const styles = StyleSheet.create({
     borderWidth: 1.5,
     borderColor: withOpacity(colors.ui.divider, 0.3),
   },
-  modalButtonConfirm: {
-    flex: 1,
-    borderRadius: 16,
-    overflow: "hidden",
-    boxShadow: `0px 4px 8px ${withOpacity(colors.primary.main, 0.3)}`,
-    elevation: 5,
-  },
-  modalButtonDelete: {
-    flex: 1,
-    borderRadius: 16,
-    overflow: "hidden",
-    boxShadow: `0px 4px 8px ${withOpacity(colors.ui.error, 0.3)}`,
-    elevation: 5,
-  },
-  modalButtonGradient: {
-    paddingVertical: 16,
-    alignItems: "center",
-    justifyContent: "center",
-    flexDirection: "row",
-    gap: 8,
-  },
-  modalButtonIcon: {
-    marginRight: 4,
-  },
   modalButtonCancelText: {
     fontSize: typography.fontSize.base,
     fontWeight: typography.fontWeight.semiBold,
     color: withOpacity(colors.text.light, 0.9),
-    letterSpacing: 0.3,
-  },
-  modalButtonConfirmText: {
-    fontSize: typography.fontSize.base,
-    fontWeight: typography.fontWeight.bold,
-    color: colors.text.light,
-    letterSpacing: 0.3,
-  },
-  modalButtonDeleteText: {
-    fontSize: typography.fontSize.base,
-    fontWeight: typography.fontWeight.bold,
-    color: colors.text.light,
     letterSpacing: 0.3,
   },
   membersList: {


### PR DESCRIPTION
## Summary

- Replaces the legacy `Modal`-based `showLeaveModal` and `showDeleteModal` flows in `GroupDetailsScreen` with the shared `<DangerConfirmModal>` (typed-confirm UX introduced by WHISPR-1345). Users now have to type `SUPPRIMER` / `DELETE` before the action can fire.
- Last-admin flow is preserved: tapping "Quitter le groupe" while you are the only admin opens the existing `TransferAdmin` modal directly without showing the typed-confirm.
- Bonus: removed the upfront `Haptics.impactAsync(Medium/Heavy)` calls inside `handleLeaveGroup` / `handleDeleteGroup` — the success haptic now only fires after the API call resolves.
- Added FR/EN i18n keys: `confirm.leaveGroup.{title,description,action}` and `confirm.deleteGroup.{title,description,action}`.
- Cleaned up dead styles (`modalButtonConfirm`, `modalButtonDelete`, `modalIconContainerDanger`, etc.) that are no longer referenced.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test -- --watchAll=false` 942/942 green
- [x] New tests in `GroupDetailsScreen.test.tsx`:
  - non-last-admin → tapping "Quitter le groupe" opens the danger modal
  - leave: action button does nothing until `SUPPRIMER` is typed; calls `groupsAPI.leaveGroup` after typing
  - admin: delete button does nothing until `SUPPRIMER` is typed; calls `groupsAPI.deleteGroup` after typing

Closes WHISPR-1346