### PR TITLE
[WHISPR-1351] fix(chat): cleanup TypingIndicator animations

### DIFF
--- a/TypingIndicator.test.tsx
+++ b/TypingIndicator.test.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { TypingIndicator } from "./src/components/Chat/TypingIndicator";
+
+// Avatar fait du fetch / token. On le neutralise ici pour rester sur l'unite.
+jest.mock("./src/components/Chat/Avatar", () => ({
+  Avatar: () => null,
+}));
+
+jest.mock("./src/context/ThemeContext", () => ({
+  useTheme: () => ({
+    getThemeColors: () => ({
+      primary: "#fff",
+      background: { primary: "#000", secondary: "#111" },
+      text: { primary: "#fff", secondary: "#aaa", tertiary: "#555" },
+    }),
+    getFontSize: () => 16,
+    getLocalizedText: (k: string) => k,
+  }),
+}));
+
+describe("TypingIndicator", () => {
+  it("affiche le nom de l'utilisateur en train d'ecrire", () => {
+    const { getByText } = render(<TypingIndicator userName="Alice" />);
+    expect(getByText("Alice est en train d'écrire")).toBeTruthy();
+  });
+
+  it("gere plusieurs utilisateurs", () => {
+    const { getByText } = render(
+      <TypingIndicator userNames={["Alice", "Bob"]} />,
+    );
+    expect(getByText("Alice et Bob sont en train d'écrire")).toBeTruthy();
+  });
+
+  it("monte et demonte plusieurs fois sans warning console", () => {
+    // Important : verifie que le cleanup useEffect (clearTimeout +
+    // cancelAnimation) n'emet pas de warning Reanimated quand le composant
+    // monte/demonte rapidement (ex: indicateur de frappe qui apparait/disparait
+    // dans ConversationsListScreen + ChatScreen).
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    for (let i = 0; i < 5; i++) {
+      const { unmount } = render(<TypingIndicator userName={`U${i}`} />);
+      unmount();
+    }
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+});

--- a/src/components/Chat/TypingIndicator.tsx
+++ b/src/components/Chat/TypingIndicator.tsx
@@ -10,6 +10,7 @@ import Animated, {
   withTiming,
   withRepeat,
   withSequence,
+  cancelAnimation,
   SharedValue,
 } from "react-native-reanimated";
 import { colors } from "../../theme/colors";
@@ -34,9 +35,16 @@ export const TypingIndicator: React.FC<TypingIndicatorProps> = ({
   const dot3Y = useSharedValue(0);
 
   useEffect(() => {
-    // Animate dots with 150ms stagger
+    // Animation des points avec stagger 150ms.
+    // Important : on garde les ids de setTimeout et on annule les boucles
+    // Reanimated au demontage, sinon le composant continue d'animer en
+    // arriere-plan (warnings + CPU non nul + crash potentiel sous Reanimated 3
+    // strict mode quand un setTimeout orphelin set .value sur un noeud
+    // desinscrit).
+    const timeouts: ReturnType<typeof setTimeout>[] = [];
+
     const animateDot = (dotY: SharedValue<number>, delay: number) => {
-      setTimeout(() => {
+      const id = setTimeout(() => {
         dotY.value = withRepeat(
           withSequence(
             withTiming(-8, { duration: 400 }),
@@ -46,11 +54,19 @@ export const TypingIndicator: React.FC<TypingIndicatorProps> = ({
           false,
         );
       }, delay);
+      timeouts.push(id);
     };
 
     animateDot(dot1Y, 0);
     animateDot(dot2Y, 150);
     animateDot(dot3Y, 300);
+
+    return () => {
+      timeouts.forEach(clearTimeout);
+      cancelAnimation(dot1Y);
+      cancelAnimation(dot2Y);
+      cancelAnimation(dot3Y);
+    };
   }, [dot1Y, dot2Y, dot3Y]);
 
   const dot1Style = useAnimatedStyle(() => ({


### PR DESCRIPTION
## Summary

`src/components/Chat/TypingIndicator.tsx` lancait 3 `setTimeout` qui demarraient des `withRepeat(-1)` Reanimated, sans cleanup dans le `useEffect`. Le composant monte/demonte a chaque indicateur de frappe (ConversationsListScreen + ChatScreen), donc apres demontage :

- les animations infinies continuaient sur le thread UI (CPU non nul permanent),
- les `setTimeout` orphelins pouvaient setter `.value` sur un noeud Reanimated desinscrit (warnings + crash potentiel sous Reanimated 3 strict mode Android).

Fix : on capture les ids `setTimeout` dans le `useEffect` et on retourne une cleanup qui `clearTimeout` x3 + `cancelAnimation` x3.

## Test plan

- [x] `npm test -- --watchAll=false` : 945 tests verts (99 suites)
- [x] Test ajoute `TypingIndicator.test.tsx` (3 cas : single user, multi users, mount/unmount x5 sans warning console)
- [x] Lint clean sur le fichier touche
- [ ] Smoke test web preprod (Tudy)

Closes WHISPR-1351