### PR TITLE
[WHISPR-1358] feat(profile): batch profiles fetch mobile

### DIFF
--- a/batchFetch.test.ts
+++ b/batchFetch.test.ts
@@ -1,0 +1,97 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+jest.mock("./src/services/apiBase", () =>
+  require("./src/__test-utils__/mockFactories").makeApiBaseMock(
+    "https://api.test",
+  ),
+);
+
+import {
+  fetchProfilesBatch,
+  BATCH_PROFILES_CHUNK_SIZE,
+} from "./src/services/profile/batchFetch";
+import { mockResponse } from "./src/__test-utils__/mockFactories";
+
+describe("fetchProfilesBatch", () => {
+  it("dedupes ids and posts a single batch", async () => {
+    const fetcher = jest.fn().mockResolvedValue(
+      mockResponse({
+        body: {
+          profiles: [{ id: "u-1" }, { id: "u-2" }],
+          missing: [],
+        },
+      }),
+    );
+
+    const result = await fetchProfilesBatch<{ id: string }>(
+      ["u-1", "u-2", "u-1", ""],
+      fetcher,
+    );
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    const [url, init] = fetcher.mock.calls[0];
+    expect(url).toBe("https://api.test/user/v1/profiles/batch");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toEqual({ ids: ["u-1", "u-2"] });
+    expect(result.profiles).toHaveLength(2);
+    expect(result.missing).toHaveLength(0);
+  });
+
+  it("returns empty payload without calling fetcher when ids is empty", async () => {
+    const fetcher = jest.fn();
+    const result = await fetchProfilesBatch([], fetcher);
+    expect(result).toEqual({ profiles: [], missing: [] });
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("splits ids in chunks of 100 and aggregates results", async () => {
+    const ids = Array.from(
+      { length: BATCH_PROFILES_CHUNK_SIZE + 50 },
+      (_, i) => `u-${i}`,
+    );
+    const fetcher = jest
+      .fn()
+      .mockResolvedValueOnce(
+        mockResponse({
+          body: {
+            profiles: ids
+              .slice(0, BATCH_PROFILES_CHUNK_SIZE)
+              .map((id) => ({ id })),
+            missing: [],
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockResponse({
+          body: {
+            profiles: ids
+              .slice(BATCH_PROFILES_CHUNK_SIZE)
+              .map((id) => ({ id })),
+            missing: ["u-extra"],
+          },
+        }),
+      );
+
+    const result = await fetchProfilesBatch<{ id: string }>(ids, fetcher);
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(result.profiles).toHaveLength(ids.length);
+    expect(result.missing).toEqual(["u-extra"]);
+  });
+
+  it("flags every id of a chunk as missing on HTTP failure", async () => {
+    const fetcher = jest.fn().mockResolvedValue(mockResponse({ status: 500 }));
+
+    const result = await fetchProfilesBatch(["a", "b"], fetcher);
+    expect(result.profiles).toEqual([]);
+    expect(result.missing.sort()).toEqual(["a", "b"]);
+  });
+
+  it("flags every id of a chunk as missing when the fetcher throws", async () => {
+    const fetcher = jest.fn().mockRejectedValue(new Error("network"));
+
+    const result = await fetchProfilesBatch(["a", "b"], fetcher);
+    expect(result.profiles).toEqual([]);
+    expect(result.missing.sort()).toEqual(["a", "b"]);
+  });
+});

--- a/contactsApi.test.ts
+++ b/contactsApi.test.ts
@@ -31,11 +31,13 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
-// Allow each test to prime the enrichment fetch (fetchUserById) with nulls.
+// Allow each test to prime the batch enrichment fetch (1 call /profiles/batch
+// pour tous les contacts). Si count vaut 0 le batch n est pas appele du tout.
 const primeUserEnrichment = (count: number) => {
-  for (let i = 0; i < count; i++) {
-    mockFetch.mockResolvedValueOnce(mockResponse({ status: 404 }));
-  }
+  if (count === 0) return;
+  mockFetch.mockResolvedValueOnce(
+    mockResponse({ body: { profiles: [], missing: [] } }),
+  );
 };
 
 describe("contactsAPI.getContacts", () => {
@@ -110,10 +112,15 @@ describe("contactsAPI.getContacts", () => {
     mockFetch.mockResolvedValueOnce(
       mockResponse({
         body: {
-          id: "u-1",
-          username: "ada",
-          firstName: "Ada",
-          profilePictureUrl: "https://cdn/x.png",
+          profiles: [
+            {
+              id: "u-1",
+              username: "ada",
+              firstName: "Ada",
+              profilePictureUrl: "https://cdn/x.png",
+            },
+          ],
+          missing: [],
         },
       }),
     );

--- a/messagingApi.test.ts
+++ b/messagingApi.test.ts
@@ -692,3 +692,124 @@ describe("authenticatedFetch 401 retry", () => {
     await expect(messagingAPI.getConversation("c-1")).rejects.toThrow();
   });
 });
+
+// ---------------------------------------------------------------------------
+// getUsersInfoBatch (WHISPR-1357)
+// ---------------------------------------------------------------------------
+
+describe("messagingAPI.getUsersInfoBatch", () => {
+  it("POSTs to /user/v1/profiles/batch with the deduped ids", async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        body: {
+          profiles: [
+            { id: "u-1", username: "ada", firstName: "Ada" },
+            { id: "u-2", username: "bob", firstName: "Bob" },
+          ],
+          missing: [],
+        },
+      }),
+    );
+
+    const result = await messagingAPI.getUsersInfoBatch([
+      "u-1",
+      "u-2",
+      "u-1", // doublon : doit etre dedup avant l'envoi
+      "",
+    ]);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://api.test/user/v1/profiles/batch");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toEqual({ ids: ["u-1", "u-2"] });
+    expect(result.get("u-1")).toMatchObject({ id: "u-1", display_name: "Ada" });
+    expect(result.get("u-2")).toMatchObject({ id: "u-2", display_name: "Bob" });
+  });
+
+  it("returns null entries for missing ids and caches them", async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        body: {
+          profiles: [{ id: "u-1", username: "ada" }],
+          missing: ["u-2"],
+        },
+      }),
+    );
+
+    const result = await messagingAPI.getUsersInfoBatch(["u-1", "u-2"]);
+    expect(result.get("u-1")).toMatchObject({ id: "u-1" });
+    expect(result.get("u-2")).toBeNull();
+
+    // Le second appel ne doit pas refaire de batch : tout est en cache.
+    const second = await messagingAPI.getUsersInfoBatch(["u-1", "u-2"]);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(second.get("u-2")).toBeNull();
+  });
+
+  it("splits requests larger than 100 ids into chunks", async () => {
+    const ids = Array.from({ length: 150 }, (_, i) => `u-${i}`);
+    mockFetch
+      .mockResolvedValueOnce(
+        mockResponse({
+          body: {
+            profiles: ids.slice(0, 100).map((id) => ({ id, username: id })),
+            missing: [],
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockResponse({
+          body: {
+            profiles: ids.slice(100).map((id) => ({ id, username: id })),
+            missing: [],
+          },
+        }),
+      );
+
+    const result = await messagingAPI.getUsersInfoBatch(ids);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const firstChunk = JSON.parse(mockFetch.mock.calls[0][1].body) as {
+      ids: string[];
+    };
+    const secondChunk = JSON.parse(mockFetch.mock.calls[1][1].body) as {
+      ids: string[];
+    };
+    expect(firstChunk.ids).toHaveLength(100);
+    expect(secondChunk.ids).toHaveLength(50);
+    expect(result.size).toBe(150);
+    expect(result.get("u-149")).toMatchObject({ id: "u-149" });
+  });
+
+  it("returns null for every id when the batch endpoint fails", async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 500 }));
+
+    const result = await messagingAPI.getUsersInfoBatch(["u-1", "u-2"]);
+    expect(result.get("u-1")).toBeNull();
+    expect(result.get("u-2")).toBeNull();
+  });
+
+  it("returns an empty map without calling fetch when ids is empty", async () => {
+    const result = await messagingAPI.getUsersInfoBatch([]);
+    expect(result.size).toBe(0);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("hydrates the unitary getUserInfo cache so a follow-up call hits cache", async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        body: {
+          profiles: [{ id: "u-1", username: "ada", firstName: "Ada" }],
+          missing: [],
+        },
+      }),
+    );
+
+    await messagingAPI.getUsersInfoBatch(["u-1"]);
+    const cached = await messagingAPI.getUserInfo("u-1");
+    expect(cached).toMatchObject({ id: "u-1", display_name: "Ada" });
+    // pas de second fetch unitaire : tout est servi par le cache batch
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/contacts/api.ts
+++ b/src/services/contacts/api.ts
@@ -14,6 +14,7 @@ import {
 } from "../../types/contact";
 import { TokenService } from "../TokenService";
 import { getApiBaseUrl } from "../apiBase";
+import { fetchProfilesBatch } from "../profile/batchFetch";
 
 export type { Contact };
 
@@ -74,6 +75,27 @@ const normalizeContact = (c: any): Contact => {
   };
 };
 
+const normalizeRawUser = (u: any, fallbackId?: string): User | null => {
+  if (!u || typeof u !== "object") return null;
+  const id = String(u.id ?? u.userId ?? fallbackId ?? "");
+  if (!id) return null;
+  return {
+    id,
+    username: u.username ?? "",
+    phone_number: u.phoneNumber ?? u.phone_number,
+    first_name: u.firstName ?? u.first_name,
+    last_name: u.lastName ?? u.last_name,
+    avatar_url:
+      u.profilePictureUrl ??
+      u.profile_picture_url ??
+      u.profilePicture ??
+      u.profile_picture ??
+      u.avatar_url,
+    last_seen: u.lastSeen ?? u.last_seen,
+    is_active: u.isActive ?? u.is_active ?? true,
+  };
+};
+
 const fetchUserById = async (userId: string): Promise<User | null> => {
   if (!IS_TEST) {
     const cached = userProfileCache.get(userId);
@@ -96,23 +118,9 @@ const fetchUserById = async (userId: string): Promise<User | null> => {
         },
       );
       if (!response.ok) return null;
-      const u = await response.json();
-      if (!u) return null;
-      const normalized: User = {
-        id: u.id ?? userId,
-        username: u.username ?? "",
-        phone_number: u.phoneNumber ?? u.phone_number,
-        first_name: u.firstName ?? u.first_name,
-        last_name: u.lastName ?? u.last_name,
-        avatar_url:
-          u.profilePictureUrl ??
-          u.profile_picture_url ??
-          u.profilePicture ??
-          u.profile_picture ??
-          u.avatar_url,
-        last_seen: u.lastSeen ?? u.last_seen,
-        is_active: u.isActive ?? u.is_active ?? true,
-      };
+      const raw = await response.json();
+      const normalized = normalizeRawUser(raw, userId);
+      if (!normalized) return null;
       userProfileCache.set(userId, {
         value: normalized,
         expiresAt: Date.now() + USER_PROFILE_TTL_MS,
@@ -132,6 +140,79 @@ const fetchUserById = async (userId: string): Promise<User | null> => {
     promise.finally(() => userProfileInflight.delete(userId));
   }
   return promise;
+};
+
+/**
+ * Recupere plusieurs profils utilisateur via POST /user/v1/profiles/batch
+ * (WHISPR-1349 / WHISPR-1357). Hydrate `userProfileCache` pour chaque profil
+ * retourne. Les ids manquants (privacy / supprimes) sont caches null TTL
+ * standard pour eviter de rappeler.
+ */
+const fetchUsersBatch = async (
+  userIds: string[],
+): Promise<Map<string, User | null>> => {
+  const result = new Map<string, User | null>();
+  const toFetch: string[] = [];
+  for (const id of userIds) {
+    if (!id || result.has(id)) continue;
+    const cached = !IS_TEST ? userProfileCache.get(id) : null;
+    if (cached && cached.expiresAt > Date.now()) {
+      result.set(id, cached.value);
+    } else {
+      toFetch.push(id);
+    }
+  }
+  if (toFetch.length === 0) return result;
+
+  const authFetch = async (
+    url: string,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    return fetch(url, {
+      ...init,
+      headers: {
+        ...(init?.headers as Record<string, string>),
+        ...(await getAuthHeaders()),
+      },
+    });
+  };
+
+  try {
+    const { profiles, missing } = await fetchProfilesBatch<unknown>(
+      toFetch,
+      authFetch,
+    );
+    const missingSet = new Set(missing);
+    for (const raw of profiles) {
+      const normalized = normalizeRawUser(raw);
+      if (normalized?.id) {
+        if (!IS_TEST) {
+          userProfileCache.set(normalized.id, {
+            value: normalized,
+            expiresAt: Date.now() + USER_PROFILE_TTL_MS,
+          });
+        }
+        result.set(normalized.id, normalized);
+        missingSet.delete(normalized.id);
+      }
+    }
+    for (const id of toFetch) {
+      if (!result.has(id) || missingSet.has(id)) {
+        if (!IS_TEST) {
+          userProfileCache.set(id, {
+            value: null,
+            expiresAt: Date.now() + USER_PROFILE_TTL_MS,
+          });
+        }
+        result.set(id, null);
+      }
+    }
+  } catch {
+    for (const id of toFetch) {
+      if (!result.has(id)) result.set(id, null);
+    }
+  }
+  return result;
 };
 
 // certains endpoints search renvoient 200 avec un body vide quand pas de
@@ -246,18 +327,20 @@ export const contactsAPI = {
           : [];
       const contacts = items.map(normalizeContact);
 
-      // enrichissement profils utilisateur en parallele (1 fetch / contact)
-      const enriched = await Promise.all(
-        contacts.map(async (contact: Contact) => {
-          if (contact.contact_id) {
-            const user = await fetchUserById(contact.contact_id);
-            if (user) {
-              return { ...contact, contact_user: user };
-            }
-          }
-          return contact;
-        }),
-      );
+      // WHISPR-1357 : enrichissement profils via 1 seul appel batch
+      // /profiles/batch au lieu de N fetchs unitaires. Couvre les chunks
+      // > 100 automatiquement, marque les profils prives/supprimes comme
+      // null pour fallback display.
+      const contactIds = contacts
+        .map((c: Contact) => c.contact_id)
+        .filter((id: string): id is string => Boolean(id));
+      const usersMap = await fetchUsersBatch(contactIds);
+      const enriched = contacts.map((contact: Contact) => {
+        if (!contact.contact_id) return contact;
+        const user = usersMap.get(contact.contact_id);
+        if (user) return { ...contact, contact_user: user };
+        return contact;
+      });
 
       const result = { contacts: enriched, total: enriched.length };
       if (!IS_TEST && !params) {

--- a/src/services/messaging/api.ts
+++ b/src/services/messaging/api.ts
@@ -5,6 +5,7 @@ import { getApiBaseUrl } from "../apiBase";
 import { snakecaseKeys } from "../../utils/caseTransform";
 import { logger } from "../../utils/logger";
 import { isReachableUrl, isValidUuid } from "../../utils";
+import { fetchProfilesBatch } from "../profile/batchFetch";
 
 const API_BASE_URL = `${getApiBaseUrl()}/messaging/api/v1`;
 
@@ -221,6 +222,35 @@ export const invalidateUserInfoCache = (userId?: string): void => {
     userInfoInflight.clear();
   }
 };
+
+/**
+ * Normalise un payload brut du user-service (camelCase ou snake_case) en
+ * CachedUserInfo. Utilise par getUserInfo unitaire et par getUsersInfoBatch.
+ */
+function normalizeRawUserInfo(user: any): CachedUserInfo | null {
+  if (!user || typeof user !== "object") return null;
+  const id = String(user.id ?? user.userId ?? "");
+  if (!id) return null;
+  const firstName = user.firstName || user.first_name || "";
+  const lastName = user.lastName || user.last_name || "";
+  const phoneNumber = user.phoneNumber || user.phone_number || "";
+  const fullName = `${firstName} ${lastName}`.trim();
+  const displayName = fullName || user.username || phoneNumber || "Utilisateur";
+  const avatarUrl =
+    user.profilePictureUrl ||
+    user.profile_picture_url ||
+    user.profilePicture ||
+    user.profile_picture ||
+    user.avatarUrl ||
+    user.avatar_url ||
+    undefined;
+  return {
+    id,
+    display_name: displayName,
+    username: user.username,
+    avatar_url: avatarUrl,
+  };
+}
 
 export const messagingAPI = {
   async getConversations(params?: {
@@ -738,7 +768,8 @@ export const messagingAPI = {
         }
 
         const user = await response.json().catch(() => null);
-        if (!user) {
+        const info = normalizeRawUserInfo(user);
+        if (!info) {
           logger.warn("getUserInfo", `Empty body for user ${userId}`);
           userInfoCache.set(userId, {
             value: null,
@@ -746,31 +777,6 @@ export const messagingAPI = {
           });
           return null;
         }
-
-        // Handle both camelCase (from user-service) and snake_case formats
-        const firstName = user.firstName || user.first_name || "";
-        const lastName = user.lastName || user.last_name || "";
-        const phoneNumber = user.phoneNumber || user.phone_number || "";
-        const fullName = `${firstName} ${lastName}`.trim();
-        const displayName =
-          fullName || user.username || phoneNumber || "Utilisateur";
-
-        const avatarUrl =
-          user.profilePictureUrl ||
-          user.profile_picture_url ||
-          user.profilePicture ||
-          user.profile_picture ||
-          user.avatarUrl ||
-          user.avatar_url ||
-          undefined;
-
-        const info: CachedUserInfo = {
-          id: user.id,
-          display_name: displayName,
-          username: user.username,
-          avatar_url: avatarUrl,
-        };
-
         userInfoCache.set(userId, {
           value: info,
           expiresAt: Date.now() + USER_INFO_TTL_MS,
@@ -786,6 +792,83 @@ export const messagingAPI = {
 
     userInfoInflight.set(userId, promise);
     return promise;
+  },
+
+  /**
+   * Recupere plusieurs profils utilisateurs en un seul appel batch
+   * (POST /user/v1/profiles/batch, WHISPR-1349 / WHISPR-1357). Hydrate le
+   * cache `userInfoCache` pour chaque profil retourne, et marque les
+   * `missing` comme null (TTL court) pour eviter de retenter au prochain
+   * render.
+   *
+   * Sert au load de ConversationsList et ContactsScreen ou on a une liste
+   * d'IDs connue d'avance et on veut eviter le burst de N fetchs.
+   *
+   * Retourne un Map id -> info|null couvrant tous les ids demandes.
+   */
+  async getUsersInfoBatch(
+    userIds: string[],
+  ): Promise<Map<string, CachedUserInfo | null>> {
+    const result = new Map<string, CachedUserInfo | null>();
+    const toFetch: string[] = [];
+
+    // Premier passage : on recolte les hits cache frais et on liste le reste
+    for (const id of userIds) {
+      if (!id) continue;
+      if (result.has(id)) continue;
+      const cached = userInfoCache.get(id);
+      if (cached && cached.expiresAt > Date.now()) {
+        result.set(id, cached.value);
+      } else {
+        toFetch.push(id);
+      }
+    }
+
+    if (toFetch.length === 0) {
+      return result;
+    }
+
+    try {
+      const { profiles, missing } = await fetchProfilesBatch<unknown>(
+        toFetch,
+        authenticatedFetch,
+      );
+      const missingSet = new Set(missing);
+      for (const raw of profiles) {
+        const info = normalizeRawUserInfo(raw);
+        if (info?.id) {
+          userInfoCache.set(info.id, {
+            value: info,
+            expiresAt: Date.now() + USER_INFO_TTL_MS,
+          });
+          result.set(info.id, info);
+          missingSet.delete(info.id);
+        }
+      }
+      // Tout id non resolu (renvoye missing par le backend, ou non present
+      // dans le payload) bascule null en cache pour eviter un second appel
+      // immediat. TTL standard suffit : si le profil reapparait l'utilisateur
+      // declenchera un nouveau fetch au prochain reload.
+      for (const id of toFetch) {
+        if (!result.has(id) || missingSet.has(id)) {
+          userInfoCache.set(id, {
+            value: null,
+            expiresAt: Date.now() + USER_INFO_TTL_MS,
+          });
+          result.set(id, null);
+        }
+      }
+    } catch (err) {
+      logger.warn(
+        "getUsersInfoBatch",
+        `Batch fetch failed for ${toFetch.length} ids`,
+        err,
+      );
+      for (const id of toFetch) {
+        if (!result.has(id)) result.set(id, null);
+      }
+    }
+    return result;
   },
 
   async getConversationMembers(conversationId: string): Promise<

--- a/src/services/profile/batchFetch.ts
+++ b/src/services/profile/batchFetch.ts
@@ -1,0 +1,94 @@
+/**
+ * Helper bas-niveau pour appeler POST /user/v1/profiles/batch (WHISPR-1349,
+ * exploite par WHISPR-1357 cote mobile). Sert a remplacer le burst de N
+ * fetchs unitaires /user/v1/profile/{id} par un appel groupe au load de
+ * ConversationsList et ContactsScreen.
+ *
+ * - dedup local des ids avant l'appel (le backend dedup aussi mais autant
+ *   eviter de charger inutilement le payload)
+ * - split en chunks de 100 (limite serveur ArrayMaxSize) traites en
+ *   parallele : le throttler tolere 10 batch/s sur la fenetre courte
+ * - sur 401, le refresh est fait par AuthService au niveau caller via
+ *   `authenticatedFetch` deja utilise dans messaging/api.ts ; ici on
+ *   recoit le fetcher en parametre pour rester decouple
+ */
+import { getApiBaseUrl } from "../apiBase";
+
+const BATCH_MAX_SIZE = 100;
+
+export interface BatchProfilesResponse<T> {
+  /** Profils trouves et autorises (privacy gates serveur appliquees). */
+  profiles: T[];
+  /** IDs demandes non resolus (user inexistant, supprime, prive). */
+  missing: string[];
+}
+
+export type AuthenticatedFetch = (
+  url: string,
+  init?: RequestInit,
+) => Promise<Response>;
+
+/**
+ * Appelle POST /user/v1/profiles/batch et split en chunks de 100 si besoin.
+ *
+ * @param ids liste des userIds a recuperer
+ * @param fetcher fetch authentifie (gere refresh 401, headers Bearer)
+ * @returns `{ profiles, missing }` agreges sur tous les chunks
+ *
+ * - retourne `{ profiles: [], missing: [] }` si `ids` est vide pour eviter
+ *   le 400 "ArrayMinSize" du backend
+ * - sur erreur HTTP non-OK : tous les ids du chunk basculent dans `missing`
+ *   pour permettre au caller de fallback (display "Utilisateur indisponible")
+ *   plutot que de planter le rendering
+ */
+export async function fetchProfilesBatch<T = unknown>(
+  ids: string[],
+  fetcher: AuthenticatedFetch,
+): Promise<BatchProfilesResponse<T>> {
+  const unique = Array.from(new Set(ids.filter(Boolean)));
+  if (unique.length === 0) {
+    return { profiles: [], missing: [] };
+  }
+
+  const chunks: string[][] = [];
+  for (let i = 0; i < unique.length; i += BATCH_MAX_SIZE) {
+    chunks.push(unique.slice(i, i + BATCH_MAX_SIZE));
+  }
+
+  const url = `${getApiBaseUrl()}/user/v1/profiles/batch`;
+  const results = await Promise.all(
+    chunks.map(async (chunkIds): Promise<BatchProfilesResponse<T>> => {
+      try {
+        const response = await fetcher(url, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ids: chunkIds }),
+        });
+        if (!response.ok) {
+          return { profiles: [], missing: [...chunkIds] };
+        }
+        const data = (await response
+          .json()
+          .catch(() => null)) as BatchProfilesResponse<T> | null;
+        if (!data) {
+          return { profiles: [], missing: [...chunkIds] };
+        }
+        return {
+          profiles: Array.isArray(data.profiles) ? data.profiles : [],
+          missing: Array.isArray(data.missing) ? data.missing : [],
+        };
+      } catch {
+        return { profiles: [], missing: [...chunkIds] };
+      }
+    }),
+  );
+
+  const aggregated: BatchProfilesResponse<T> = { profiles: [], missing: [] };
+  for (const r of results) {
+    aggregated.profiles.push(...r.profiles);
+    aggregated.missing.push(...r.missing);
+  }
+  return aggregated;
+}
+
+export const BATCH_PROFILES_CHUNK_SIZE = BATCH_MAX_SIZE;

--- a/src/store/conversationsStore.ts
+++ b/src/store/conversationsStore.ts
@@ -92,6 +92,30 @@ async function enrichWithDisplayNames(
   conversations: Conversation[],
   currentUserId: string,
 ): Promise<Conversation[]> {
+  // WHISPR-1357 : pre-warming du cache profils via 1 seul batch /profiles/batch
+  // au lieu de N fetchs unitaires. enrichSingleConversation continue d'utiliser
+  // getUserInfo pour le fallback (member_user_ids absents qui forcent un
+  // getConversation), mais l'appel reseau retourne en cache hit.
+  const otherIdsToWarmup = new Set<string>();
+  for (const conv of conversations) {
+    if (conv.type !== "direct") continue;
+    if (conv.display_name && conv.avatar_url) continue;
+    const memberIds = conv.member_user_ids;
+    if (!memberIds || memberIds.length === 0) continue;
+    const other = memberIds.find((id: string) => id && id !== currentUserId);
+    if (other) otherIdsToWarmup.add(other);
+  }
+
+  if (otherIdsToWarmup.size > 0) {
+    try {
+      await messagingAPI.getUsersInfoBatch(Array.from(otherIdsToWarmup));
+    } catch (err) {
+      // batch en best-effort : si echec, enrichSingleConversation fallback
+      // sur les fetchs unitaires existants.
+      logger.warn("enrich", "Batch profile warmup failed", err);
+    }
+  }
+
   const results = await Promise.all(
     conversations.map((conv) => enrichSingleConversation(conv, currentUserId)),
   );


### PR DESCRIPTION
## Summary

- Ajout helper `src/services/profile/batchFetch.ts` qui POST `/user/v1/profiles/batch` (WHISPR-1349) avec dedup local et split en chunks de 100 (limite serveur).
- `messagingAPI.getUsersInfoBatch(ids)` : warmup du cache `userInfoCache` en 1 seul appel reseau, puis `enrichWithDisplayNames` (conversationsStore) pre-charge en batch avant les `getUserInfo` unitaires qui retournent en cache hit.
- `contactsAPI.getContacts` : remplacement du `Promise.all(contacts.map(fetchUserById))` (concurrency 5, N round-trips) par 1 seul `fetchUsersBatch` qui hydrate `userProfileCache`.
- Gestion `missing[]` : profils prives ou supprimes -> cache null TTL standard, contact garde son shape sans `contact_user` (display fallback identique a aujourd'hui).
- Backward-compat preservee : `getUserInfo`, `fetchUserById`, `getUserProfile` restent exposes pour les callers 1-by-1 legitimes (chat header, profile screen).

## Gain estime

Au load de ConversationsList avec 30 conversations DM : **30 fetchs unitaires -> 1 batch**. ContactsScreen avec 80 contacts : **80 fetchs -> 1 batch**. Reduit drastiquement les 429 sous le throttle court 10/s.

## Test plan

- [x] `batchFetch.test.ts` : dedup, chunks > 100, gestion 500/throw, ids vides
- [x] `messagingApi.test.ts` : `getUsersInfoBatch` (POST body, missing, chunks 150 ids, hydratation cache)
- [x] `contactsApi.test.ts` : enrichissement via /profiles/batch (mock fetch unique)
- [x] `npm test -- --watchAll=false` : 956 / 956 green
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint:fix` 0 errors
- [ ] Test live preprod web : ConversationsList + ContactsScreen affichent avatars/noms
- [ ] Test live PWA Safari iOS

Closes WHISPR-1358
