### PR TITLE
[WHISPR-1359] fix(security): SecureStore offlineQueue + 2FA flags

### DIFF
--- a/SettingsScreen.test.tsx
+++ b/SettingsScreen.test.tsx
@@ -77,9 +77,27 @@ jest.mock("./src/services/moderation", () => ({
   getModerationModelVersion: jest.fn().mockResolvedValue("v2"),
   setModerationModelVersion: jest.fn().mockResolvedValue(undefined),
 }));
+// WHISPR-1359 — la categorie security est lue/ecrite via le wrapper
+// SecureStore. Mock in-memory pour tester sans toucher au natif.
+const secureStoreBackend: Record<string, string> = {};
+jest.mock("./src/services/storage", () => ({
+  storage: {
+    getItem: jest.fn(async (key: string) => secureStoreBackend[key] ?? null),
+    setItem: jest.fn(async (key: string, value: string) => {
+      secureStoreBackend[key] = value;
+    }),
+    deleteItem: jest.fn(async (key: string) => {
+      delete secureStoreBackend[key];
+    }),
+  },
+}));
 
 describe("SettingsScreen", () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    for (const key of Object.keys(secureStoreBackend))
+      delete secureStoreBackend[key];
+  });
 
   it("does not render the in-screen header (back button + title)", async () => {
     const { queryByText, queryByLabelText } = render(<SettingsScreen />);
@@ -150,5 +168,47 @@ describe("SettingsScreen", () => {
         configurable: true,
       });
     }
+  });
+
+  it("reads security settings from SecureStore on mount (WHISPR-1359)", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { storage: secureStorageMock } = require("./src/services/storage");
+    secureStoreBackend["@whispr_settings_security"] = JSON.stringify({
+      twoFactorAuth: true,
+      biometricAuth: true,
+    });
+
+    render(<SettingsScreen />);
+    await waitFor(() => {
+      expect(secureStorageMock.getItem).toHaveBeenCalledWith(
+        "@whispr_settings_security",
+      );
+    });
+  });
+
+  it("migrates legacy AsyncStorage security flags to SecureStore (WHISPR-1359)", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const AsyncStorage = require("@react-native-async-storage/async-storage");
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { storage: secureStorageMock } = require("./src/services/storage");
+    const legacyValue = JSON.stringify({
+      twoFactorAuth: true,
+      biometricAuth: false,
+    });
+    AsyncStorage.getItem.mockImplementation(async (key: string) =>
+      key === "@whispr_settings_security" ? legacyValue : null,
+    );
+
+    render(<SettingsScreen />);
+
+    await waitFor(() => {
+      expect(secureStorageMock.setItem).toHaveBeenCalledWith(
+        "@whispr_settings_security",
+        legacyValue,
+      );
+    });
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith(
+      "@whispr_settings_security",
+    );
   });
 });

--- a/offlineQueue.test.ts
+++ b/offlineQueue.test.ts
@@ -1,22 +1,42 @@
 /**
- * Unit tests for offlineQueue.drainAll (WHISPR-1060).
- * AsyncStorage is mocked in-memory so we can exercise persistence without
- * hitting native code.
+ * Unit tests for offlineQueue (WHISPR-1060, WHISPR-1219, WHISPR-1359).
+ * Both AsyncStorage and the SecureStore wrapper are mocked in-memory: the
+ * queue now persists through `services/storage.ts` (SecureStore-backed) but
+ * still touches AsyncStorage during the soft migration of legacy values.
  */
 
-const storage: Record<string, string> = {};
+const secureBackend: Record<string, string> = {};
+const asyncBackend: Record<string, string> = {};
 
 jest.mock("@react-native-async-storage/async-storage", () => ({
-  getItem: jest.fn(async (key: string) => storage[key] ?? null),
+  getItem: jest.fn(async (key: string) => asyncBackend[key] ?? null),
   setItem: jest.fn(async (key: string, value: string) => {
-    storage[key] = value;
+    asyncBackend[key] = value;
   }),
   removeItem: jest.fn(async (key: string) => {
-    delete storage[key];
+    delete asyncBackend[key];
   }),
 }));
 
-import { offlineQueue, type QueuedMessage } from "./src/services/offlineQueue";
+jest.mock("./src/services/storage", () => ({
+  storage: {
+    getItem: jest.fn(async (key: string) => secureBackend[key] ?? null),
+    setItem: jest.fn(async (key: string, value: string) => {
+      secureBackend[key] = value;
+    }),
+    deleteItem: jest.fn(async (key: string) => {
+      delete secureBackend[key];
+    }),
+  },
+}));
+
+import {
+  offlineQueue,
+  type QueuedMessage,
+  __resetMigrationForTests,
+} from "./src/services/offlineQueue";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { storage as secureStorage } from "./src/services/storage";
 
 const makeMessage = (
   overrides: Partial<QueuedMessage> = {},
@@ -31,7 +51,15 @@ const makeMessage = (
 });
 
 beforeEach(async () => {
-  for (const key of Object.keys(storage)) delete storage[key];
+  for (const key of Object.keys(secureBackend)) delete secureBackend[key];
+  for (const key of Object.keys(asyncBackend)) delete asyncBackend[key];
+  __resetMigrationForTests();
+  (AsyncStorage.getItem as jest.Mock).mockClear();
+  (AsyncStorage.setItem as jest.Mock).mockClear();
+  (AsyncStorage.removeItem as jest.Mock).mockClear();
+  (secureStorage.getItem as jest.Mock).mockClear();
+  (secureStorage.setItem as jest.Mock).mockClear();
+  (secureStorage.deleteItem as jest.Mock).mockClear();
 });
 
 describe("offlineQueue.drainAll (WHISPR-1060)", () => {
@@ -212,7 +240,7 @@ describe("offlineQueue.getAll", () => {
   });
 
   it("returns an empty array when persisted JSON is corrupted", async () => {
-    storage["whispr.offline.message.queue"] = "not-json";
+    secureBackend["whispr.offline.message.queue"] = "not-json";
     await expect(offlineQueue.getAll()).resolves.toEqual([]);
   });
 });
@@ -278,5 +306,76 @@ describe("offlineQueue.getForConversation", () => {
 
     const result = await offlineQueue.getForConversation("conv-a");
     expect(result.map((m) => m.client_random)).toEqual([701, 703]);
+  });
+});
+
+describe("offlineQueue SecureStore routing (WHISPR-1359)", () => {
+  it("persists enqueued messages through the SecureStore wrapper, not AsyncStorage", async () => {
+    await offlineQueue.enqueue(makeMessage({ client_random: 901 }));
+
+    expect(secureStorage.setItem).toHaveBeenCalledWith(
+      "whispr.offline.message.queue",
+      expect.any(String),
+    );
+    expect(secureBackend["whispr.offline.message.queue"]).toBeDefined();
+    // No write to AsyncStorage past the migration path.
+    expect(asyncBackend["whispr.offline.message.queue"]).toBeUndefined();
+  });
+
+  it("clearAll deletes the SecureStore key", async () => {
+    await offlineQueue.enqueue(makeMessage({ client_random: 902 }));
+    await offlineQueue.clearAll();
+
+    expect(secureStorage.deleteItem).toHaveBeenCalledWith(
+      "whispr.offline.message.queue",
+    );
+    expect(secureBackend["whispr.offline.message.queue"]).toBeUndefined();
+  });
+
+  it("migrates a legacy AsyncStorage queue to SecureStore on first read", async () => {
+    const legacy: QueuedMessage[] = [
+      makeMessage({ client_random: 911, content: "legacy-1" }),
+      makeMessage({ client_random: 912, content: "legacy-2" }),
+    ];
+    asyncBackend["whispr.offline.message.queue"] = JSON.stringify(legacy);
+
+    const all = await offlineQueue.getAll();
+
+    expect(all.map((m) => m.content)).toEqual(["legacy-1", "legacy-2"]);
+    // Migrated to SecureStore.
+    expect(secureBackend["whispr.offline.message.queue"]).toBeDefined();
+    // Legacy key purged.
+    expect(asyncBackend["whispr.offline.message.queue"]).toBeUndefined();
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith(
+      "whispr.offline.message.queue",
+    );
+  });
+
+  it("does not touch AsyncStorage when SecureStore already has data", async () => {
+    secureBackend["whispr.offline.message.queue"] = JSON.stringify([
+      makeMessage({ client_random: 921, content: "secure-only" }),
+    ]);
+    asyncBackend["whispr.offline.message.queue"] = JSON.stringify([
+      makeMessage({ client_random: 999, content: "should-be-ignored" }),
+    ]);
+
+    const all = await offlineQueue.getAll();
+
+    expect(all).toHaveLength(1);
+    expect(all[0].content).toBe("secure-only");
+    // Legacy still there because we did not migrate this user.
+    expect(asyncBackend["whispr.offline.message.queue"]).toBeDefined();
+  });
+
+  it("runs the migration only once per session", async () => {
+    asyncBackend["whispr.offline.message.queue"] = JSON.stringify([
+      makeMessage({ client_random: 931 }),
+    ]);
+
+    await offlineQueue.getAll();
+    await offlineQueue.getAll();
+    await offlineQueue.getAll();
+
+    expect(AsyncStorage.removeItem).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -19,6 +19,7 @@ import {
 import * as ImagePicker from "expo-image-picker";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { storage as secureStorage } from "../../services/storage";
 import { LinearGradient } from "expo-linear-gradient";
 import { BlurView } from "expo-blur";
 import { useNavigation } from "@react-navigation/native";
@@ -148,17 +149,30 @@ export const SettingsScreen: React.FC = () => {
   });
 
   /**
-   * Persist a settings category to AsyncStorage
+   * Persist a settings category to storage. The security category is routed
+   * through SecureStore (Keychain iOS / Keystore Android, encrypted vault on
+   * web) — WHISPR-1359 — so the local 2FA / biometric flags can not be
+   * tampered with by a rooted device or an unencrypted ADB backup. Other
+   * categories stay on AsyncStorage: they are UX preferences, not security
+   * boundaries.
+   *
+   * fix(settings) Le flag local biometricAuth/twoFactorAuth ne suffit PAS
+   * pour autoriser une action sensible. Toujours valider cote serveur (cf
+   * endpoint /auth/v1/2fa/status). Le flag sert juste a piloter l UI.
    */
   const persistSettings = useCallback(
     async (key: string, value: Record<string, any>) => {
       try {
+        if (key === STORAGE_KEYS.security) {
+          await secureStorage.setItem(key, JSON.stringify(value));
+          return;
+        }
         await AsyncStorage.setItem(key, JSON.stringify(value));
       } catch (error) {
         console.error("Error persisting settings:", error);
       }
     },
-    [],
+    [STORAGE_KEYS.security],
   );
 
   /**
@@ -289,7 +303,36 @@ export const SettingsScreen: React.FC = () => {
   );
 
   /**
-   * Load all settings from AsyncStorage and privacy from API on mount
+   * Lit la categorie security depuis SecureStore. Si vide, regarde encore
+   * AsyncStorage pour migrer les users existants, puis purge la cle legacy.
+   */
+  const loadSecurityFromStorage = useCallback(async (): Promise<
+    string | null
+  > => {
+    try {
+      const secureRaw = await secureStorage.getItem(STORAGE_KEYS.security);
+      if (secureRaw !== null) return secureRaw;
+      const legacyRaw = await AsyncStorage.getItem(STORAGE_KEYS.security);
+      if (legacyRaw === null) return null;
+      await secureStorage.setItem(STORAGE_KEYS.security, legacyRaw);
+      await AsyncStorage.removeItem(STORAGE_KEYS.security);
+      return legacyRaw;
+    } catch {
+      return null;
+    }
+  }, [STORAGE_KEYS.security]);
+
+  /**
+   * Load all settings from storage and privacy from API on mount.
+   *
+   * fix(settings) Le flag local biometricAuth/twoFactorAuth ne suffit PAS
+   * pour autoriser une action sensible. Toujours valider cote serveur (cf
+   * endpoint /auth/v1/2fa/status). Le flag sert juste a piloter l UI.
+   *
+   * WHISPR-1359 — la categorie security est lue depuis SecureStore. Pour les
+   * users existants qui ont encore la valeur dans AsyncStorage, on migre
+   * doucement : fallback AsyncStorage si SecureStore vide, puis purge la
+   * cle legacy.
    */
   useEffect(() => {
     const loadSettings = async () => {
@@ -300,7 +343,7 @@ export const SettingsScreen: React.FC = () => {
             AsyncStorage.getItem(STORAGE_KEYS.notifications),
             AsyncStorage.getItem(STORAGE_KEYS.messaging),
             AsyncStorage.getItem(STORAGE_KEYS.app),
-            AsyncStorage.getItem(STORAGE_KEYS.security),
+            loadSecurityFromStorage(),
           ]);
 
         if (privacyJson) setPrivacySettings(JSON.parse(privacyJson));

--- a/src/services/offlineQueue.ts
+++ b/src/services/offlineQueue.ts
@@ -6,8 +6,48 @@
 
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as ExpoCrypto from "expo-crypto";
+import { storage } from "./storage";
 
 const QUEUE_KEY = "whispr.offline.message.queue";
+
+// WHISPR-1359 — migration douce AsyncStorage → SecureStore. Sur Android
+// rooté ou backup ADB non chiffré, lire les messages texte en clair depuis
+// AsyncStorage etait possible. On bascule sur SecureStore (Keychain iOS /
+// Keystore Android, encrypted localStorage sur web via storage.web.ts).
+// Au premier read d'une session, si SecureStore est vide on regarde encore
+// AsyncStorage pour migrer les users existants, puis on purge la cle legacy.
+let migrationDone = false;
+
+async function migrateLegacyQueue(): Promise<void> {
+  if (migrationDone) return;
+  try {
+    const secureRaw = await storage.getItem(QUEUE_KEY);
+    if (secureRaw !== null) {
+      migrationDone = true;
+      return;
+    }
+    const legacyRaw = await AsyncStorage.getItem(QUEUE_KEY);
+    if (legacyRaw === null) {
+      migrationDone = true;
+      return;
+    }
+    await storage.setItem(QUEUE_KEY, legacyRaw);
+    await AsyncStorage.removeItem(QUEUE_KEY);
+    migrationDone = true;
+  } catch {
+    // Swallow — la migration est best-effort. On ne marque pas migrationDone
+    // pour que la prochaine lecture re-essaie.
+  }
+}
+
+/**
+ * Reset the migration latch. Test-only helper so each test starts with a
+ * fresh process state (the in-memory `migrationDone` flag would otherwise
+ * leak across `it` blocks).
+ */
+export const __resetMigrationForTests = (): void => {
+  migrationDone = false;
+};
 
 export interface QueuedMessage {
   id: string; // temp id (temp-{timestamp}-{random})
@@ -65,7 +105,8 @@ export interface DrainResult {
 export const offlineQueue = {
   async getAll(): Promise<QueuedMessage[]> {
     try {
-      const raw = await AsyncStorage.getItem(QUEUE_KEY);
+      await migrateLegacyQueue();
+      const raw = await storage.getItem(QUEUE_KEY);
       if (!raw) return [];
       return JSON.parse(raw) as QueuedMessage[];
     } catch {
@@ -83,10 +124,7 @@ export const offlineQueue = {
         ...message,
         client_message_id: message.client_message_id ?? generateUUID(),
       };
-      await AsyncStorage.setItem(
-        QUEUE_KEY,
-        JSON.stringify([...current, persisted]),
-      );
+      await storage.setItem(QUEUE_KEY, JSON.stringify([...current, persisted]));
     } catch (error) {
       console.error("[offlineQueue] enqueue error:", error);
     }
@@ -95,7 +133,7 @@ export const offlineQueue = {
   async remove(clientRandom: number): Promise<void> {
     try {
       const current = await this.getAll();
-      await AsyncStorage.setItem(
+      await storage.setItem(
         QUEUE_KEY,
         JSON.stringify(current.filter((m) => m.client_random !== clientRandom)),
       );
@@ -106,7 +144,7 @@ export const offlineQueue = {
 
   async clearAll(): Promise<void> {
     try {
-      await AsyncStorage.removeItem(QUEUE_KEY);
+      await storage.deleteItem(QUEUE_KEY);
     } catch (error) {
       console.error("[offlineQueue] clearAll error:", error);
     }

--- a/src/services/storage.web.ts
+++ b/src/services/storage.web.ts
@@ -1,12 +1,16 @@
 import { isWrapped, unwrap, wrap } from "./webCryptoVault.web";
 
 // Cles dont les valeurs ne doivent jamais finir en clair dans localStorage.
-// On y inclut la cle d'identite Signal (WHISPR-1212) et les tokens d'auth
-// (WHISPR-1328) pour limiter l'exposition en cas de XSS sur le PWA web.
+// On y inclut la cle d'identite Signal (WHISPR-1212), les tokens d'auth
+// (WHISPR-1328), la queue offline qui contient des messages en clair tant
+// qu'ils n'ont pas pu etre envoyes (WHISPR-1359) et les flags security
+// (WHISPR-1359) pour limiter l'exposition en cas de XSS sur le PWA web.
 const SECURE_KEYS = new Set<string>([
   "whispr.signal.identityKeyPrivate",
   "whispr.auth.accessToken",
   "whispr.auth.refreshToken",
+  "whispr.offline.message.queue",
+  "@whispr_settings_security",
 ]);
 
 function isSecure(key: string): boolean {


### PR DESCRIPTION
## Summary

- offlineQueue: les messages offline sont maintenant persistes via SecureStore (Keychain iOS / Keystore Android, vault chiffre cote web PWA) au lieu d AsyncStorage. Plus de lecture en clair des messages texte sur Android roote ou via un backup ADB non chiffre.
- SettingsScreen: meme migration pour la categorie security (flags `biometricAuth`, `twoFactorAuth`). Le flag local ne peut plus etre tamper par modification AsyncStorage.
- Migration douce : au premier read si SecureStore est vide on fallback AsyncStorage et on migre la valeur, puis on purge la cle legacy. Une seule passe par session.
- `storage.web.ts` : ajout des deux cles a `SECURE_KEYS` pour chiffrer aussi cote PWA via WebCryptoVault.
- Commentaires rappel `fix(settings)` : le flag local biometricAuth/twoFactorAuth ne suffit PAS pour autoriser une action sensible. Toute action sensitive (delete account, change password, disable 2FA) doit valider l etat 2FA cote serveur.

## Test plan

- [x] `npm test -- --watchAll=false` : 963/963 tests pass
- [x] Tests dedies routing SecureStore + migration douce (offlineQueue + SettingsScreen)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint:fix` : 0 errors
- [ ] Smoke iOS sim : send offline + 2FA toggle restent fonctionnels
- [ ] Smoke web PWA preprod : settings security persisted across refresh

Closes WHISPR-1359