### PR TITLE
[WHISPR-1366] fix(security): fail-closed pour cles Signal sensibles

### DIFF
--- a/src/screens/Auth/OtpScreen.tsx
+++ b/src/screens/Auth/OtpScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
+  Alert,
   Animated,
   KeyboardAvoidingView,
   Platform,
@@ -133,7 +134,23 @@ export const OtpScreen: React.FC = () => {
         })),
       );
     } catch (err) {
-      // Do not block the auth flow — keys can be uploaded later
+      const message = (err as Error)?.message ?? String(err);
+      // Vault crypto indisponible (Safari mode privé, IDB bloque, etc.) -
+      // on ne persiste PAS la cle d'identite en clair. On previent l'user
+      // que le chiffrement E2EE n'est pas supporte ici et il devra rouvrir
+      // hors mode privé pour s'enroler.
+      if (message.includes("[storage.web]")) {
+        console.error(
+          "[OtpScreen] crypto vault unavailable, Signal enrollment aborted:",
+          err,
+        );
+        Alert.alert(
+          "Chiffrement indisponible",
+          "Votre navigateur ne permet pas de stocker la clé E2EE en sécurité (mode privé ou ancien navigateur). Veuillez rouvrir l'app hors navigation privée pour activer la messagerie chiffrée.",
+        );
+        return;
+      }
+      // Autres erreurs (reseau, backend) - non bloquant, retry plus tard.
       console.warn("[OtpScreen] Signal key upload failed (non-blocking):", err);
     }
   };

--- a/src/services/storage.web.ts
+++ b/src/services/storage.web.ts
@@ -51,10 +51,18 @@ export const storage = {
         const wrapped = await wrap(value);
         localStorage.setItem(key, wrapped);
         return;
-      } catch {
-        // IndexedDB / SubtleCrypto unavailable (e.g. private mode). Fall back
-        // to plaintext rather than blocking the write — that matches the
-        // behaviour before this fix, so we never regress functionality.
+      } catch (error) {
+        // IndexedDB / SubtleCrypto indisponible (Safari mode privé, vieux
+        // navigateurs sans IDB, Firefox restrictif). Fail-closed sur les
+        // cles sensibles (cle d'identite Signal, tokens auth, queue offline)
+        // pour eviter qu'un XSS exfiltre des secrets via localStorage.
+        // Le caller doit catch et proposer un parcours user-friendly
+        // (logout / re-enrollment / "rouvrez hors mode privé").
+        throw new Error(
+          `[storage.web] crypto vault unavailable, refusing to persist sensitive key "${key}" in plaintext: ${
+            (error as Error)?.message ?? error
+          }`,
+        );
       }
     }
     localStorage.setItem(key, value);

--- a/storage.web.test.ts
+++ b/storage.web.test.ts
@@ -100,4 +100,50 @@ describe("storage.web (secure key handling)", () => {
     await storage.deleteItem(IDENTITY_KEY);
     expect(localStorage.getItem(IDENTITY_KEY)).toBeNull();
   });
+
+  describe("fail-closed when crypto vault is unavailable (WHISPR-1366)", () => {
+    let originalSubtle: SubtleCrypto | undefined;
+
+    beforeEach(() => {
+      originalSubtle = (globalThis.crypto as Crypto | undefined)?.subtle;
+    });
+
+    afterEach(() => {
+      if (originalSubtle && globalThis.crypto) {
+        Object.defineProperty(globalThis.crypto, "subtle", {
+          value: originalSubtle,
+          configurable: true,
+        });
+      }
+    });
+
+    function breakSubtleCrypto(): void {
+      Object.defineProperty(globalThis.crypto, "subtle", {
+        value: undefined,
+        configurable: true,
+      });
+    }
+
+    it("throws on setItem for a sensitive key when wrap fails", async () => {
+      breakSubtleCrypto();
+      await expect(
+        storage.setItem(IDENTITY_KEY, "must-not-leak"),
+      ).rejects.toThrow(/crypto vault unavailable/);
+      expect(localStorage.getItem(IDENTITY_KEY)).toBeNull();
+    });
+
+    it("throws on setItem for auth tokens when wrap fails", async () => {
+      breakSubtleCrypto();
+      await expect(
+        storage.setItem("whispr.auth.accessToken", "jwt-secret"),
+      ).rejects.toThrow(/crypto vault unavailable/);
+      expect(localStorage.getItem("whispr.auth.accessToken")).toBeNull();
+    });
+
+    it("still writes plaintext for non-sensitive keys", async () => {
+      breakSubtleCrypto();
+      await storage.setItem("whispr.misc.flag", "ok");
+      expect(localStorage.getItem("whispr.misc.flag")).toBe("ok");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- `storage.web.setItem` ne fait plus de fallback plaintext silencieux pour les cles sensibles (`whispr.signal.identityKeyPrivate`, `whispr.auth.accessToken`, `whispr.auth.refreshToken`, `whispr.offline.message.queue`, `@whispr_settings_security`). Quand SubtleCrypto/IndexedDB est indisponible (Safari mode privé, vieux navigateurs, Firefox restrictif), on throw au lieu d'ecrire la cle d'identite Signal en clair dans `localStorage`.
- `OtpScreen.generateAndUploadSignalKeys` catch l'erreur `[storage.web] crypto vault unavailable...` et affiche un Alert clair pour que l'user rouvre l'app hors mode privé.
- 3 nouveaux tests Jest dans `storage.web.test.ts` qui mocquent un `crypto.subtle` casse et verifient: cle Signal throw, tokens auth throw, cle non-sensible OK.

## Why

Avant ce fix, un XSS sur la PWA web aurait pu exfiltrer la cle privee Signal directement depuis `localStorage` quand le navigateur ne supporte pas le vault crypto. Catastrophique pour le E2EE. Maintenant fail-closed.

## Test plan

- [x] `npm test -- --watchAll=false --no-coverage` -> 966 tests verts (100 suites)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` sur les fichiers touches: 0 erreur (warnings pre-existants only)
- [ ] Manuel sur Safari iOS PWA mode privé: alert "Chiffrement indisponible" s'affiche, pas de cle en clair dans localStorage (a verifier post-deploy preprod)

Closes WHISPR-1366