### PR TITLE
[WHISPR-1378] fix(mobile): WS leave + send guard

### DIFF
--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -87,6 +87,10 @@ export const useWebSocket = (options: UseWebSocketOptions) => {
 
     return () => {
       removeListener();
+      // libere le ref count cote socket : si ce hook etait le dernier
+      // consumer (logout, changement de user) le channel est ferme cote
+      // serveur, sinon les autres screens continuent a recevoir leurs events.
+      userChannel.leave();
     };
   }, [options.userId, options.token]);
 

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -330,6 +330,9 @@ export const ChatScreen: React.FC = () => {
   const conversationChannelRef = useRef<any>(null);
   const flatListRef = useRef<FlatList>(null);
   const cacheWriteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // eviter le double-tap envoyant 2 messages distincts sur connexion lente :
+  // chaque tap a son propre client_random donc le serveur ne peut pas dedup.
+  const sendingRef = useRef(false);
   // Horizontal swipe to reveal per-message timestamps. The shared value is
   // consumed by every MessageBubble through MessageSwipeProvider, so all rows
   // translate together without re-rendering.
@@ -1184,134 +1187,148 @@ export const ChatScreen: React.FC = () => {
 
   const handleSendMessage = useCallback(
     async (content: string, replyToId?: string, mentions?: string[]) => {
-      // Stop typing indicator
-      sendTyping(conversationId, false);
+      // ref-lock : sur connexion lente, un double-tap genererait 2 messages
+      // avec des client_random differents (donc pas dedup serveur). On ignore
+      // les calls concurrents sans desactiver le bouton (UX intacte).
+      if (sendingRef.current) return;
+      sendingRef.current = true;
+      try {
+        // Stop typing indicator
+        sendTyping(conversationId, false);
 
-      // If editing, update the message
-      if (editingMessage) {
-        try {
-          const updated = await messagingAPI.editMessage(
-            editingMessage.id,
-            conversationId,
+        // If editing, update the message
+        if (editingMessage) {
+          try {
+            const updated = await messagingAPI.editMessage(
+              editingMessage.id,
+              conversationId,
+              content,
+            );
+            setMessages((prev) =>
+              prev.map((msg) =>
+                msg.id === editingMessage.id
+                  ? { ...msg, ...updated, edited_at: updated.edited_at }
+                  : msg,
+              ),
+            );
+            setEditingMessage(null);
+            useConversationsStore
+              .getState()
+              .applyMessageUpdated(updated as any);
+          } catch (error) {
+            logger.error("ChatScreen", "Error editing message", error);
+            Alert.alert(
+              getLocalizedText("notif.error"),
+              getLocalizedText("chat.errorEditMessage"),
+            );
+            setEditingMessage(null);
+          }
+          return;
+        }
+
+        const tempMessage: MessageWithRelations = {
+          id: `temp-${Date.now()}`,
+          conversation_id: conversationId,
+          sender_id: userId,
+          message_type: "text",
+          content,
+          metadata: {},
+          client_random: Math.floor(Math.random() * 1000000),
+          sent_at: new Date().toISOString(),
+          is_deleted: false,
+          delete_for_everyone: false,
+          status: "sending",
+          reply_to_id: replyToId,
+          reply_to: replyingTo || undefined,
+        };
+
+        setMessages((prev) => [tempMessage, ...prev]);
+        setReplyingTo(null);
+        useConversationsStore
+          .getState()
+          .applyNewMessage(tempMessage as any, userId)
+          .catch(() => {});
+        useConversationsStore.getState().resetUnreadCount(conversationId);
+
+        // Scroll to bottom so the newly sent text message is visible
+        // (FlatList is inverted, so offset 0 is the bottom)
+        setTimeout(() => {
+          flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
+        }, 100);
+
+        // If offline, queue the message for later delivery
+        if (connectionState !== "connected") {
+          const queued: QueuedMessage = {
+            id: tempMessage.id,
+            conversation_id: conversationId,
             content,
-          );
+            message_type: "text",
+            client_random: tempMessage.client_random as number,
+            reply_to_id: replyToId,
+            queued_at: new Date().toISOString(),
+          };
+          await offlineQueue.enqueue(queued);
           setMessages((prev) =>
-            prev.map((msg) =>
-              msg.id === editingMessage.id
-                ? { ...msg, ...updated, edited_at: updated.edited_at }
-                : msg,
+            prev.map((m) =>
+              m.id === tempMessage.id ? { ...m, status: "queued" as const } : m,
             ),
           );
-          setEditingMessage(null);
-          useConversationsStore.getState().applyMessageUpdated(updated as any);
-        } catch (error) {
-          logger.error("ChatScreen", "Error editing message", error);
-          Alert.alert(
-            getLocalizedText("notif.error"),
-            getLocalizedText("chat.errorEditMessage"),
-          );
-          setEditingMessage(null);
+          useConversationsStore
+            .getState()
+            .applyNewMessage(
+              { ...tempMessage, status: "queued" } as any,
+              userId,
+            )
+            .catch(() => {});
+          useConversationsStore.getState().resetUnreadCount(conversationId);
+          return;
         }
-        return;
-      }
 
-      const tempMessage: MessageWithRelations = {
-        id: `temp-${Date.now()}`,
-        conversation_id: conversationId,
-        sender_id: userId,
-        message_type: "text",
-        content,
-        metadata: {},
-        client_random: Math.floor(Math.random() * 1000000),
-        sent_at: new Date().toISOString(),
-        is_deleted: false,
-        delete_for_everyone: false,
-        status: "sending",
-        reply_to_id: replyToId,
-        reply_to: replyingTo || undefined,
-      };
+        try {
+          const sent = await messagingAPI.sendMessage(conversationId, {
+            content,
+            message_type: "text",
+            client_random: tempMessage.client_random as number,
 
-      setMessages((prev) => [tempMessage, ...prev]);
-      setReplyingTo(null);
-      useConversationsStore
-        .getState()
-        .applyNewMessage(tempMessage as any, userId)
-        .catch(() => {});
-      useConversationsStore.getState().resetUnreadCount(conversationId);
-
-      // Scroll to bottom so the newly sent text message is visible
-      // (FlatList is inverted, so offset 0 is the bottom)
-      setTimeout(() => {
-        flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
-      }, 100);
-
-      // If offline, queue the message for later delivery
-      if (connectionState !== "connected") {
-        const queued: QueuedMessage = {
-          id: tempMessage.id,
-          conversation_id: conversationId,
-          content,
-          message_type: "text",
-          client_random: tempMessage.client_random as number,
-          reply_to_id: replyToId,
-          queued_at: new Date().toISOString(),
-        };
-        await offlineQueue.enqueue(queued);
-        setMessages((prev) =>
-          prev.map((m) =>
-            m.id === tempMessage.id ? { ...m, status: "queued" as const } : m,
-          ),
-        );
-        useConversationsStore
-          .getState()
-          .applyNewMessage({ ...tempMessage, status: "queued" } as any, userId)
-          .catch(() => {});
-        useConversationsStore.getState().resetUnreadCount(conversationId);
-        return;
-      }
-
-      try {
-        const sent = await messagingAPI.sendMessage(conversationId, {
-          content,
-          message_type: "text",
-          client_random: tempMessage.client_random as number,
-
-          metadata: {},
-          reply_to_id: replyToId,
-        });
-
-        setMessages((prev) => {
-          const next: MessageWithRelations[] = prev.map((m) => {
-            if (
-              m.id.startsWith("temp-") &&
-              m.client_random === tempMessage.client_random
-            ) {
-              const updated: MessageWithRelations = {
-                ...(sent as MessageWithRelations),
-                status: "sent" as const,
-                reply_to: tempMessage.reply_to,
-              };
-              return updated;
-            }
-            return m;
+            metadata: {},
+            reply_to_id: replyToId,
           });
-          return next;
-        });
-        useConversationsStore
-          .getState()
-          .applyNewMessage(sent as any, userId)
-          .catch(() => {});
-        useConversationsStore.getState().resetUnreadCount(conversationId);
-      } catch (error) {
-        logger.error("ChatScreen", "Error sending message", error);
-        setMessages((prev) => {
-          return prev.map((m) => {
-            if (m.id === tempMessage.id) {
-              return { ...m, status: "failed" };
-            }
-            return m;
+
+          setMessages((prev) => {
+            const next: MessageWithRelations[] = prev.map((m) => {
+              if (
+                m.id.startsWith("temp-") &&
+                m.client_random === tempMessage.client_random
+              ) {
+                const updated: MessageWithRelations = {
+                  ...(sent as MessageWithRelations),
+                  status: "sent" as const,
+                  reply_to: tempMessage.reply_to,
+                };
+                return updated;
+              }
+              return m;
+            });
+            return next;
           });
-        });
+          useConversationsStore
+            .getState()
+            .applyNewMessage(sent as any, userId)
+            .catch(() => {});
+          useConversationsStore.getState().resetUnreadCount(conversationId);
+        } catch (error) {
+          logger.error("ChatScreen", "Error sending message", error);
+          setMessages((prev) => {
+            return prev.map((m) => {
+              if (m.id === tempMessage.id) {
+                return { ...m, status: "failed" };
+              }
+              return m;
+            });
+          });
+        }
+      } finally {
+        sendingRef.current = false;
       }
     },
     [

--- a/src/services/messaging/websocket.ts
+++ b/src/services/messaging/websocket.ts
@@ -118,6 +118,10 @@ export class SocketConnection {
       callbacks: Record<string, EventCallback[]>;
       joined: boolean;
       joinRef: string | null; // tracks the join_ref for this channel
+      // ref count : plusieurs hooks/screens partagent le meme topic
+      // (ex user:<id> joine par ChatScreen + ConversationsListScreen + ContactsScreen).
+      // leave() ne fait phx_leave que quand le dernier consumer relache son ref.
+      refCount: number;
     }
   > = {};
   private pendingTopics: Set<string> = new Set();
@@ -448,12 +452,18 @@ export class SocketConnection {
         callbacks: {},
         joined: false,
         joinRef: null,
+        refCount: 0,
       };
     }
 
     const join = async (): Promise<{ status: string }> => {
       const ch = this.channels[topic];
-      if (ch?.joined) return { status: "ok" };
+      if (!ch) return { status: "error" };
+      // chaque join() incremente le compteur. leave() decremente, et
+      // n envoie phx_leave que quand le dernier consumer s en va.
+      ch.refCount += 1;
+
+      if (ch.joined) return { status: "ok" };
 
       if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
         this.pendingTopics.add(topic);
@@ -487,11 +497,17 @@ export class SocketConnection {
     };
 
     const leave = (): void => {
+      const ch = this.channels[topic];
+      if (!ch) return;
+      // ref counting : tant qu un autre consumer (ChatScreen, ContactsScreen,
+      // etc) partage ce topic, on ne touche pas le channel cote serveur.
+      if (ch.refCount > 0) ch.refCount -= 1;
+      if (ch.refCount > 0) return;
+
       if (this.socket && this.socket.readyState === WebSocket.OPEN) {
-        const ch = this.channels[topic];
         const ref = nextRef();
         this.socket.send(
-          encodeMessage(ch?.joinRef ?? null, ref, topic, "phx_leave", {}),
+          encodeMessage(ch.joinRef ?? null, ref, topic, "phx_leave", {}),
         );
       }
       delete this.channels[topic];

--- a/useWebSocket.test.tsx
+++ b/useWebSocket.test.tsx
@@ -12,13 +12,14 @@ const mockChannelPush = jest.fn();
 const mockChannelOn = jest.fn();
 const mockChannelOff = jest.fn();
 const mockChannelJoin = jest.fn();
+const mockChannelLeave = jest.fn();
 const mockIsConnected = jest.fn(() => true);
 const mockChannel = {
   push: mockChannelPush,
   on: mockChannelOn,
   off: mockChannelOff,
   join: mockChannelJoin,
-  leave: jest.fn(),
+  leave: mockChannelLeave,
 };
 const mockSocket = {
   channel: jest.fn(() => mockChannel),
@@ -100,6 +101,7 @@ beforeEach(() => {
   mockChannelOn.mockClear();
   mockChannelOff.mockClear();
   mockChannelJoin.mockClear();
+  mockChannelLeave.mockClear();
   mockIsConnected.mockClear();
   mockIsConnected.mockReturnValue(true);
   mockApplyMessageUnread.mockClear();
@@ -219,5 +221,15 @@ describe("useWebSocket - message_unread handler", () => {
     handler({});
 
     expect(mockApplyMessageUnread).not.toHaveBeenCalled();
+  });
+});
+
+describe("useWebSocket - user channel leave on unmount", () => {
+  it("appelle channel.leave() au cleanup pour relacher le ref count", () => {
+    const { unmount } = renderHook(() => useWebSocket(baseOptions));
+
+    expect(mockChannelLeave).not.toHaveBeenCalled();
+    unmount();
+    expect(mockChannelLeave).toHaveBeenCalled();
   });
 });

--- a/websocket.test.ts
+++ b/websocket.test.ts
@@ -436,6 +436,39 @@ describe("SocketConnection basics", () => {
     socket.disconnect();
   });
 
+  it("channel leave is ref-counted: phx_leave only on last consumer", async () => {
+    const socket = new SocketConnection();
+    const ws = await connectAndOpen(socket);
+
+    // 2 consumers (ex ChatScreen + ConversationsListScreen) prennent la
+    // meme entree user channel via socket.channel(...).
+    const consumerA = socket.channel("user:42");
+    const consumerB = socket.channel("user:42");
+    consumerA.join();
+    consumerB.join();
+
+    // reset des sends pour ne compter que les phx_leave qui suivent
+    ws.send.mockClear();
+
+    // premier leave : ref count > 0, pas de phx_leave
+    consumerA.leave();
+    let leaveCalls = ws.send.mock.calls.filter((call: any[]) => {
+      const parsed = JSON.parse(call[0]);
+      return parsed[3] === "phx_leave" && parsed[2] === "user:42";
+    });
+    expect(leaveCalls.length).toBe(0);
+
+    // dernier consumer : phx_leave envoye au serveur
+    consumerB.leave();
+    leaveCalls = ws.send.mock.calls.filter((call: any[]) => {
+      const parsed = JSON.parse(call[0]);
+      return parsed[3] === "phx_leave" && parsed[2] === "user:42";
+    });
+    expect(leaveCalls.length).toBe(1);
+
+    socket.disconnect();
+  });
+
   it("channel join queues as pending if socket is not open", async () => {
     const socket = new SocketConnection();
     await socket.connect("user-1", "token-1");


### PR DESCRIPTION
## Summary

Fix 2 bugs HIGH cote mobile-app shared WS infra :

- **WS user channel leak** : `useWebSocket.ts` cleanup faisait juste `off()` les listeners, jamais `channel.leave()`. Sur logout / re-login / changement de user le channel restait ouvert cote serveur (presence inflated, fanout vers fantome). Ajout d'un ref-count par topic dans `SocketConnection` : chaque `join()` incremente, chaque `leave()` decremente, et `phx_leave` n'est envoye qu'au dernier consumer. Cleanup du hook appelle desormais `userChannel.leave()`.
- **Double-send guard** : `ChatScreen.handleSendMessage` n'avait aucune protection double-tap. Sur connexion lente, 2 clics = 2 messages avec `client_random` differents (pas dedup serveur). Ajout d'un `sendingRef = useRef(false)` : early return si deja en cours, reset en `finally`. Bouton non desactive (UX intacte), juste ref-lock invisible.

## Pourquoi ref-count plutot que leave() direct

`socket.channel(topic)` est idempotent : 4 hooks (`ChatScreen`, `ConversationsListScreen`, `ContactsScreen` + autres) partagent la meme entree `user:<id>` du registry. Un `leave()` brutal en cleanup d'un screen aurait coupe le channel pour TOUS les autres consumers encore montes (perte des incoming_call / message_created / contact_request). Le ref-count protege ce cas multi-consumer.

## Files

- `src/services/messaging/websocket.ts` : ajout `refCount` dans `channels[topic]`, increment dans `join()`, decrement + early return dans `leave()`.
- `src/hooks/useWebSocket.ts` : cleanup appelle `userChannel.leave()`.
- `src/screens/Chat/ChatScreen.tsx` : `sendingRef = useRef(false)` + try/finally autour du corps de `handleSendMessage`.
- `websocket.test.ts` : test ref-count phx_leave seulement au dernier consumer.
- `useWebSocket.test.tsx` : test cleanup appelle `channel.leave()`.

## Test plan

- [x] tsc --noEmit : 0 erreur
- [x] eslint : 0 erreur (44 warnings preexistants)
- [x] jest websocket.test useWebSocket.test ChatScreen.test : 57/57 verts
- [x] jest full suite : 968/968 verts
- [ ] Live test PWA preprod : double-tap send button -> 1 seul message envoye
- [ ] Live test PWA preprod : logout -> verifier fermeture user channel cote serveur

Note : test Jest pour double-send guard dans ChatScreen omis (mocks profonds non triviaux), validation prevue en live preprod apres deploy.

Closes WHISPR-1378