### PR TITLE
[WHISPR-1385] fix(a11y): hitSlop + ActivityIndicator + i18n BlockedUsers

### DIFF
--- a/BlockedUsersScreen.test.tsx
+++ b/BlockedUsersScreen.test.tsx
@@ -25,6 +25,7 @@ jest.mock('./src/context/ThemeContext', () => ({
     }),
     getFontSize: () => 16,
     getLocalizedText: (key: string) => key,
+    settings: { language: 'fr' },
   }),
 }));
 jest.mock('./src/components/Chat/Avatar', () => ({ Avatar: () => null }));

--- a/src/components/Chat/MessageInput/RecordingBar.tsx
+++ b/src/components/Chat/MessageInput/RecordingBar.tsx
@@ -191,6 +191,8 @@ export const RecordingBar: React.FC<RecordingBarProps> = ({
           onPress={onCancel}
           style={styles.sideButton}
           activeOpacity={0.7}
+          // hitSlop pour respecter iOS HIG 44pt
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
           accessibilityRole="button"
           accessibilityLabel="Annuler l'enregistrement vocal"
         >
@@ -244,6 +246,8 @@ export const RecordingBar: React.FC<RecordingBarProps> = ({
             onPress={handleTogglePause}
             style={styles.sideButton}
             activeOpacity={0.7}
+            // hitSlop pour respecter iOS HIG 44pt
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
             accessibilityRole="button"
             accessibilityLabel={
               isPaused
@@ -262,6 +266,8 @@ export const RecordingBar: React.FC<RecordingBarProps> = ({
           testID="recording-stop-btn"
           onPress={onStop}
           activeOpacity={0.7}
+          // hitSlop pour respecter iOS HIG 44pt
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
           accessibilityRole="button"
           accessibilityLabel="Arrêter l'enregistrement vocal"
         >

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -713,6 +713,7 @@ const localizedTexts: Record<Language, Record<string, string>> = {
     "auth.errorConnection": "Une erreur est survenue lors de la connexion",
     "auth.errorSendCode": "Impossible d'envoyer le code de vérification",
     "settings.blockedUsers": "Utilisateurs bloqués",
+    "blockedUsers.blockedSince": "Bloqué le",
     "settings.blockedUsersSubtitle":
       "Voir et débloquer les utilisateurs que vous avez bloqués",
     "devices.title": "Mes appareils",
@@ -1048,6 +1049,7 @@ const localizedTexts: Record<Language, Record<string, string>> = {
     "auth.errorConnection": "An error occurred during connection",
     "auth.errorSendCode": "Unable to send verification code",
     "settings.blockedUsers": "Blocked users",
+    "blockedUsers.blockedSince": "Blocked on",
     "settings.blockedUsersSubtitle": "View and unblock users you've blocked",
     "devices.title": "My devices",
     "devices.subtitle": "View and sign out active sessions",

--- a/src/screens/Auth/ProfileSetupScreen.tsx
+++ b/src/screens/Auth/ProfileSetupScreen.tsx
@@ -308,7 +308,12 @@ export const ProfileSetupScreen: React.FC = () => {
               accessibilityHint="Ouvre la bibliothèque photo pour choisir une image de profil"
             >
               {avatarUri ? (
-                <Image source={{ uri: avatarUri }} style={styles.avatar} />
+                // image decorative, le bouton parent porte deja le label
+                <Image
+                  source={{ uri: avatarUri }}
+                  style={styles.avatar}
+                  accessible={false}
+                />
               ) : (
                 <View style={styles.avatarPlaceholder}>
                   <Text style={styles.avatarPlaceholderIcon}>📷</Text>

--- a/src/screens/Chat/ChatHeader.tsx
+++ b/src/screens/Chat/ChatHeader.tsx
@@ -125,6 +125,8 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
           }
         }}
         style={styles.backButton}
+        // hitSlop pour respecter iOS HIG 44pt
+        hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
         accessibilityRole="button"
         accessibilityLabel="Retour"
       >
@@ -196,6 +198,8 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
               styles.actionButton,
               !callsAvailable && styles.actionButtonDisabled,
             ]}
+            // hitSlop pour respecter iOS HIG 44pt
+            hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
             accessibilityRole="button"
             accessibilityLabel="Lancer un appel"
           >

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -2629,7 +2629,13 @@ export const ChatScreen: React.FC = () => {
               style={styles.notContactBannerButton}
             >
               {addingContact ? (
-                <ActivityIndicator size="small" color={colors.text.light} />
+                // wrapper pour annoncer l'etat busy au screen reader
+                <View
+                  accessibilityState={{ busy: true }}
+                  accessibilityLiveRegion="polite"
+                >
+                  <ActivityIndicator size="small" color={colors.text.light} />
+                </View>
               ) : (
                 <Text style={styles.notContactBannerButtonText}>Ajouter</Text>
               )}
@@ -2690,7 +2696,11 @@ export const ChatScreen: React.FC = () => {
               }
               ListFooterComponent={
                 loadingMore ? (
-                  <View style={styles.loadingMore}>
+                  <View
+                    style={styles.loadingMore}
+                    accessibilityState={{ busy: true }}
+                    accessibilityLiveRegion="polite"
+                  >
                     <ActivityIndicator
                       size="small"
                       color={themeColors.primary}

--- a/src/screens/Contacts/BlockedUsersScreen.tsx
+++ b/src/screens/Contacts/BlockedUsersScreen.tsx
@@ -28,8 +28,10 @@ export const BlockedUsersScreen: React.FC = () => {
   const [blockedUsers, setBlockedUsers] = useState<BlockedUser[]>([]);
   const [loading, setLoading] = useState(true);
   const [unblockingId, setUnblockingId] = useState<string | null>(null);
-  const { getThemeColors } = useTheme();
+  const { getThemeColors, getLocalizedText, settings } = useTheme();
   const themeColors = getThemeColors();
+  // locale dynamique selon la langue choisie par l'utilisateur
+  const dateLocale = settings.language === "en" ? "en-US" : "fr-FR";
 
   const loadBlockedUsers = useCallback(async () => {
     try {
@@ -130,7 +132,8 @@ export const BlockedUsersScreen: React.FC = () => {
               style={[styles.blockDate, { color: themeColors.text.tertiary }]}
               numberOfLines={1}
             >
-              Bloqué le {new Date(item.blocked_at).toLocaleDateString("fr-FR")}
+              {getLocalizedText("blockedUsers.blockedSince")}{" "}
+              {new Date(item.blocked_at).toLocaleDateString(dateLocale)}
             </Text>
           </View>
           <TouchableOpacity
@@ -158,7 +161,7 @@ export const BlockedUsersScreen: React.FC = () => {
         </View>
       );
     },
-    [unblockingId, handleUnblock, themeColors],
+    [unblockingId, handleUnblock, themeColors, getLocalizedText, dateLocale],
   );
 
   return (

--- a/src/screens/Moderation/AppealFormScreen.tsx
+++ b/src/screens/Moderation/AppealFormScreen.tsx
@@ -310,7 +310,11 @@ export const AppealFormScreen: React.FC = () => {
               <View style={styles.imagesRow}>
                 {images.map((uri, index) => (
                   <View key={index} style={styles.imageWrapper}>
-                    <Image source={{ uri }} style={styles.imagePreview} />
+                    <Image
+                      source={{ uri }}
+                      style={styles.imagePreview}
+                      accessibilityLabel={`Preuve ${index + 1}`}
+                    />
                     <TouchableOpacity
                       style={styles.removeImageButton}
                       onPress={() => handleRemoveImage(index)}

--- a/src/screens/Security/TwoFactorAuthScreen.tsx
+++ b/src/screens/Security/TwoFactorAuthScreen.tsx
@@ -242,6 +242,8 @@ export const TwoFactorAuthScreen: React.FC = () => {
                 navigation.goBack();
               }}
               activeOpacity={0.7}
+              // hitSlop pour respecter iOS HIG 44pt
+              hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
             >
               <Ionicons
                 name="arrow-back"
@@ -455,7 +457,13 @@ export const TwoFactorAuthScreen: React.FC = () => {
                     activeOpacity={0.8}
                   >
                     {actionLoading ? (
-                      <ActivityIndicator size="small" color="#FFFFFF" />
+                      // wrapper pour annoncer l'etat busy au screen reader
+                      <View
+                        accessibilityState={{ busy: true }}
+                        accessibilityLiveRegion="polite"
+                      >
+                        <ActivityIndicator size="small" color="#FFFFFF" />
+                      </View>
                     ) : (
                       <Text
                         style={{
@@ -530,7 +538,13 @@ export const TwoFactorAuthScreen: React.FC = () => {
                     ]}
                   >
                     {actionLoading ? (
-                      <ActivityIndicator size="small" color={accentColor} />
+                      // wrapper pour annoncer l'etat busy au screen reader
+                      <View
+                        accessibilityState={{ busy: true }}
+                        accessibilityLiveRegion="polite"
+                      >
+                        <ActivityIndicator size="small" color={accentColor} />
+                      </View>
                     ) : (
                       <Ionicons
                         name="key-outline"
@@ -671,7 +685,13 @@ export const TwoFactorAuthScreen: React.FC = () => {
                       activeOpacity={0.8}
                     >
                       {actionLoading ? (
-                        <ActivityIndicator size="small" color="#FFFFFF" />
+                        // wrapper pour annoncer l'etat busy au screen reader
+                        <View
+                          accessibilityState={{ busy: true }}
+                          accessibilityLiveRegion="polite"
+                        >
+                          <ActivityIndicator size="small" color="#FFFFFF" />
+                        </View>
                       ) : (
                         <Text
                           style={{


### PR DESCRIPTION
## Summary
- a11y HIGH: hitSlop sur les 3 boutons de RecordingBar (cancel/pause/stop) pour respecter iOS HIG 44pt
- a11y HIGH: wrappers View accessibilityState busy + accessibilityLiveRegion polite autour des ActivityIndicator dans ChatScreen (2x) et TwoFactorAuthScreen (3x) pour les screen readers
- a11y MEDIUM: accessible=false sur Image avatar de ProfileSetupScreen (le bouton parent porte deja le label) + accessibilityLabel sur Image preuve dans AppealFormScreen
- a11y MEDIUM: hitSlop sur backButton et actionButton de ChatHeader, et backButton de TwoFactorAuthScreen
- i18n MEDIUM: BlockedUsersScreen utilise getLocalizedText et locale dynamique au lieu de "Bloqué le" et "fr-FR" hardcodes (cle blockedUsers.blockedSince ajoutee FR + EN dans ThemeContext)

## Test plan
- [x] Lint clean (0 erreurs, warnings preexistants)
- [x] TypeScript clean (npx tsc --noEmit)
- [x] Tests verts: 100 suites, 968 tests
- [x] Mock useTheme dans BlockedUsersScreen.test mis a jour pour exposer settings.language
- [ ] Test manuel iOS / Android
- [ ] Test screen reader VoiceOver / TalkBack

Closes WHISPR-1385