### PR TITLE
[WHISPR-1388] fix(mobile): fetch signal+timeout sur useResolvedMediaUrl et useVoiceRecorder

### DIFF
--- a/src/hooks/useResolvedMediaUrl.ts
+++ b/src/hooks/useResolvedMediaUrl.ts
@@ -242,16 +242,63 @@ export function uriNeedsAuthResolution(uri: string | undefined): boolean {
  * `data:` URL because `blob:` URIs don't round-trip cleanly through React
  * Native's media elements.
  */
+// timeout de garde reseau pour eviter qu'un fetch reste bloque ad vitam
+// sur un mobile lent ou un proxy qui ne ferme jamais la connexion
+const STREAM_FETCH_TIMEOUT_MS = 15_000;
+const PROBE_FETCH_TIMEOUT_MS = 15_000;
+
+// fallback portable a AbortSignal.any / AbortSignal.timeout (Hermes peut
+// ne pas exposer les deux) : on chaine un AbortController au signal du
+// caller et on declenche un abort si le timeout expire ou si le caller
+// annule.
+function createLinkedTimeoutSignal(
+  externalSignal: AbortSignal | undefined,
+  timeoutMs: number,
+): { signal: AbortSignal; cleanup: () => void } {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const onExternalAbort = () => controller.abort();
+  if (externalSignal) {
+    if (externalSignal.aborted) {
+      controller.abort();
+    } else {
+      externalSignal.addEventListener("abort", onExternalAbort);
+    }
+  }
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      clearTimeout(timer);
+      if (externalSignal) {
+        externalSignal.removeEventListener("abort", onExternalAbort);
+      }
+    },
+  };
+}
+
 export async function streamMediaToRenderableUri(
   uri: string,
   token: string | null,
+  signal?: AbortSignal,
 ): Promise<string> {
   const headers: Record<string, string> = {
     Accept: "application/octet-stream",
   };
   if (token) headers["Authorization"] = `Bearer ${token}`;
   const separator = uri.includes("?") ? "&" : "?";
-  const response = await fetch(`${uri}${separator}stream=1`, { headers });
+  const { signal: linkedSignal, cleanup } = createLinkedTimeoutSignal(
+    signal,
+    STREAM_FETCH_TIMEOUT_MS,
+  );
+  let response: Response;
+  try {
+    response = await fetch(`${uri}${separator}stream=1`, {
+      headers,
+      signal: linkedSignal,
+    });
+  } finally {
+    cleanup();
+  }
   if (!response.ok) {
     throw new Error(`stream failed: HTTP ${response.status}`);
   }
@@ -331,12 +378,13 @@ function isRetryableStreamError(err: unknown): boolean {
 export async function streamMediaToRenderableUriThrottled(
   uri: string,
   token: string | null,
+  signal?: AbortSignal,
 ): Promise<string> {
   const maxAttempts = 4;
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     await acquireStreamSlot();
     try {
-      return await streamMediaToRenderableUri(uri, token);
+      return await streamMediaToRenderableUri(uri, token, signal);
     } catch (err) {
       if (!isRetryableStreamError(err) || attempt === maxAttempts) {
         throw err;
@@ -359,14 +407,24 @@ export async function streamMediaToRenderableUriThrottled(
 export async function probeMediaUrlThrottled(
   uri: string,
   headers: Record<string, string>,
+  signal?: AbortSignal,
 ): Promise<Response> {
   const maxAttempts = 4;
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     await acquireStreamSlot();
     let res: Response;
+    const { signal: linkedSignal, cleanup } = createLinkedTimeoutSignal(
+      signal,
+      PROBE_FETCH_TIMEOUT_MS,
+    );
     try {
-      res = await fetch(uri, { headers, redirect: "follow" });
+      res = await fetch(uri, {
+        headers,
+        redirect: "follow",
+        signal: linkedSignal,
+      });
     } finally {
+      cleanup();
       releaseStreamSlot();
     }
     if (res.ok) return res;
@@ -421,6 +479,9 @@ export function useResolvedMediaUrl(uri: string | undefined): ResolvedMediaUrl {
     }
 
     let cancelled = false;
+    // controller propage aux fetch sous-jacents pour qu'un unmount du
+    // composant arrete vraiment la requete au lieu de la laisser leaker
+    const abortController = new AbortController();
     const canUseNativeCache = Platform.OS !== "web";
     if (canUseNativeCache) {
       const cached = readNativeCache(uri);
@@ -430,6 +491,7 @@ export function useResolvedMediaUrl(uri: string | undefined): ResolvedMediaUrl {
         setError(false);
         return () => {
           cancelled = true;
+          abortController.abort();
           revokeBlobUrl();
         };
       }
@@ -465,7 +527,11 @@ export function useResolvedMediaUrl(uri: string | undefined): ResolvedMediaUrl {
         if (isThumbnail) {
           let blobExists = true;
           try {
-            const probeRes = await probeMediaUrlThrottled(uri, headers);
+            const probeRes = await probeMediaUrlThrottled(
+              uri,
+              headers,
+              abortController.signal,
+            );
             if (!cancelled && probeRes.ok) {
               const contentType = probeRes.headers.get("content-type") || "";
               if (contentType.includes("application/json")) {
@@ -502,7 +568,11 @@ export function useResolvedMediaUrl(uri: string | undefined): ResolvedMediaUrl {
         // the server-side 30 req/s short throttle.
         const renderableUri =
           Platform.OS === "web"
-            ? await streamMediaToRenderableUriThrottled(uri, token)
+            ? await streamMediaToRenderableUriThrottled(
+                uri,
+                token,
+                abortController.signal,
+              )
             : await writeDiskCache(uri, token);
         if (cancelled) {
           if (
@@ -523,6 +593,13 @@ export function useResolvedMediaUrl(uri: string | undefined): ResolvedMediaUrl {
         setResolvedUri(renderableUri);
       } catch (err) {
         if (cancelled) return;
+        // un AbortError vient soit du unmount soit du timeout reseau, on
+        // ne le remonte pas comme une erreur visible quand le composant
+        // est deja parti
+        const isAbort =
+          err instanceof Error &&
+          (err.name === "AbortError" || err.message.includes("aborted"));
+        if (isAbort && abortController.signal.aborted) return;
         console.warn("[useResolvedMediaUrl] Error resolving media URL:", err);
         setError(true);
       } finally {
@@ -532,6 +609,7 @@ export function useResolvedMediaUrl(uri: string | undefined): ResolvedMediaUrl {
 
     return () => {
       cancelled = true;
+      abortController.abort();
       revokeBlobUrl();
     };
   }, [uri]);

--- a/src/hooks/useVoiceRecorder.ts
+++ b/src/hooks/useVoiceRecorder.ts
@@ -414,11 +414,20 @@ export function useVoiceRecorder({
         finalMimeType,
       );
       if (Platform.OS === "web" && uri.startsWith("blob:")) {
+        // timeout de garde meme sur un blob: local pour eviter de bloquer
+        // l'UI si jamais le navigateur ne resout pas la lecture
+        const blobFetchController = new AbortController();
+        const blobFetchTimer = setTimeout(
+          () => blobFetchController.abort(),
+          10_000,
+        );
         try {
           const mime = recordingMimeRef.current || "audio/webm";
           const ext = mime === "audio/mp4" ? "m4a" : "webm";
           const fileName = `voice-${Date.now()}.${ext}`;
-          const response = await fetch(uri);
+          const response = await fetch(uri, {
+            signal: blobFetchController.signal,
+          });
           const blob = await response.blob();
           const file = new File([blob], fileName, { type: mime });
           finalUri = URL.createObjectURL(file);
@@ -429,6 +438,8 @@ export function useVoiceRecorder({
             "[useVoiceRecorder] Failed to rewrap blob, sending raw URI:",
             rewrapError,
           );
+        } finally {
+          clearTimeout(blobFetchTimer);
         }
       }
       recordingMimeRef.current = null;

--- a/streamMediaToRenderableUri.test.ts
+++ b/streamMediaToRenderableUri.test.ts
@@ -19,6 +19,7 @@ jest.mock("react-native", () => ({
 
 import {
   probeMediaUrlThrottled,
+  streamMediaToRenderableUri,
   streamMediaToRenderableUriThrottled,
 } from "./src/hooks/useResolvedMediaUrl";
 
@@ -246,5 +247,104 @@ describe("probeMediaUrlThrottled", () => {
     await expect(
       probeMediaUrlThrottled("/media/v1/abc/thumbnail", {}),
     ).rejects.toThrow(/offline/);
+  });
+});
+
+describe("fetch abort signal propagation", () => {
+  it("propage le signal abort du caller au fetch (stream)", async () => {
+    const fetchMock = jest.fn(
+      (_url: string, init?: { signal?: AbortSignal }) =>
+        new Promise<Response>((_resolve, reject) => {
+          const sig = init?.signal;
+          if (!sig) return;
+          const onAbort = () => {
+            const err = new Error("aborted");
+            err.name = "AbortError";
+            reject(err);
+          };
+          if (sig.aborted) onAbort();
+          else sig.addEventListener("abort", onAbort);
+        }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    // on appelle la version non-throttled pour eviter les retries qui
+    // multiplient les calls fetch et brouillent l'assertion
+    const controller = new AbortController();
+    const pending = streamMediaToRenderableUri(
+      "/media/v1/abc/blob",
+      "token",
+      controller.signal,
+    );
+    // simule un unmount du composant pendant que le fetch est en l'air
+    setTimeout(() => controller.abort(), 5);
+    await expect(pending).rejects.toThrow(/abort/i);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const callInit = fetchMock.mock.calls[0][1] as
+      | { signal?: AbortSignal }
+      | undefined;
+    expect(callInit?.signal).toBeDefined();
+  });
+
+  it("propage le signal abort du caller au fetch (probe)", async () => {
+    const fetchMock = jest.fn(
+      (_url: string, init?: { signal?: AbortSignal }) =>
+        new Promise<Response>((_resolve, reject) => {
+          const sig = init?.signal;
+          if (!sig) return;
+          const onAbort = () => {
+            const err = new Error("aborted");
+            err.name = "AbortError";
+            reject(err);
+          };
+          if (sig.aborted) onAbort();
+          else sig.addEventListener("abort", onAbort);
+        }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const controller = new AbortController();
+    const pending = probeMediaUrlThrottled(
+      "/media/v1/abc/thumbnail",
+      {},
+      controller.signal,
+    );
+    setTimeout(() => controller.abort(), 5);
+    await expect(pending).rejects.toThrow(/abort/i);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("declenche un abort apres le timeout interne sur le stream", async () => {
+    jest.useFakeTimers();
+    const fetchMock = jest.fn(
+      (_url: string, init?: { signal?: AbortSignal }) =>
+        new Promise<Response>((_resolve, reject) => {
+          const sig = init?.signal;
+          if (!sig) return;
+          const onAbort = () => {
+            const err = new Error("aborted by timeout");
+            err.name = "AbortError";
+            reject(err);
+          };
+          if (sig.aborted) onAbort();
+          else sig.addEventListener("abort", onAbort);
+        }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    // version non-throttled pour eviter les retries qui consommeraient
+    // chacun un timeout 15s
+    const pending = streamMediaToRenderableUri(
+      "/media/v1/abc/blob",
+      "token",
+    );
+    // catch en avance pour eviter unhandled rejection avant l'advance timers
+    const settled = pending.catch((err) => err);
+    // avance le temps au-dela du timeout interne 15s
+    await jest.advanceTimersByTimeAsync(16_000);
+    const result = await settled;
+    expect(result).toBeInstanceOf(Error);
+    expect(String(result)).toMatch(/abort/i);
+    jest.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary

Ajoute un AbortSignal + timeout sur les bare fetch des hooks media pour eviter les promises jamais settled sur reseau lent et les leaks au unmount du composant.

- `streamMediaToRenderableUri` (line 254) : nouveau parametre `signal?: AbortSignal`, propage au fetch et combine avec un timeout interne 15s via un AbortController chaine (fallback portable a `AbortSignal.any`/`timeout` si Hermes ne les expose pas).
- `probeMediaUrlThrottled` (line 368) : meme traitement avec timeout 15s.
- `streamMediaToRenderableUriThrottled` : passe le signal au inner.
- Hook `useResolvedMediaUrl` : cree un `AbortController` au useEffect, propage aux fetch sous-jacents, abort dans le cleanup. AbortError silencieux quand cause par unmount.
- `useVoiceRecorder` (line 421) : timeout 10s sur le fetch de blob local pour eviter de bloquer l'UI si le navigateur ne resout pas.

## Test plan

- [x] Unit tests verts (16/16 sur `streamMediaToRenderableUri.test.ts`, 971/971 sur la suite complete)
- [x] Lint clean (warnings preexistants `any` non touches)
- [x] tsc --noEmit clean
- [ ] Audit visuel web : a tester apres deploy preprod (charger une image, naviguer en arriere pendant le load, verifier pas de warning console "Can't perform state update on unmounted")
- [ ] Audit visuel iOS Simulator
- [ ] Audit visuel Android Emulator

## Behavior change

- Au unmount d'un composant qui rend une image media, le fetch en cours est maintenant annule plutot que de continuer en background et tenter un setState mort.
- Apres 15s sans reponse, le fetch media abandonne avec un AbortError au lieu de rester pending indefiniment.
- Apres 10s sur un blob local audio, meme garde.

Closes WHISPR-1388