### PR TITLE
[WHISPR-1395] fix(ws): jitter reconnect + close 1011 fatal

### DIFF
--- a/src/services/messaging/websocket.ts
+++ b/src/services/messaging/websocket.ts
@@ -73,6 +73,12 @@ function nextRef(): string {
 /** Phoenix/custom close codes that indicate an authentication failure. */
 const AUTH_CLOSE_CODES = new Set([1008, 4001]);
 
+// codes serveur fatals : 1011 = internal server error, 1010 = mandatory ext.
+// quand le serveur les renvoie c est pas la peine de marteler la reconnexion,
+// on circuit-break en limitant le nombre de tentatives.
+const FATAL_CLOSE_CODES = new Set([1010, 1011]);
+const FATAL_MAX_RECONNECT_ATTEMPTS = 3;
+
 /**
  * Encode a message in Phoenix v2 array format.
  */
@@ -217,6 +223,9 @@ export class SocketConnection {
 
       logger.info("WS", "Connected");
       this.reconnectAttempt = 0;
+      // si on avait baisse maxReconnectAttempts a cause d un close fatal,
+      // on remonte la limite vu que la reconnexion vient de reussir.
+      this.maxReconnectAttempts = 20;
       this.setConnectionState("connected");
       this.startHeartbeat();
 
@@ -306,6 +315,14 @@ export class SocketConnection {
         ch.joined = false;
         ch.joinRef = null;
       });
+      // close code fatal cote serveur : on coupe la boucle de reconnect
+      // pour eviter de marteler un backend en panne.
+      if (FATAL_CLOSE_CODES.has(ev.code)) {
+        this.maxReconnectAttempts = Math.min(
+          this.maxReconnectAttempts,
+          FATAL_MAX_RECONNECT_ATTEMPTS,
+        );
+      }
       if (this.shouldReconnect) {
         this.setConnectionState("reconnecting");
         this.scheduleReconnect();
@@ -380,10 +397,14 @@ export class SocketConnection {
       return;
     }
 
-    const delay = Math.min(
-      this.baseReconnectDelay * Math.pow(2, this.reconnectAttempt),
-      this.maxReconnectDelay,
-    );
+    // jitter pour eviter le thundering herd quand tous les clients
+    // reconnectent simultanement (rolling update k8s, blip reseau global).
+    const jitter = 0.5 + Math.random() * 0.5;
+    const delay =
+      Math.min(
+        this.baseReconnectDelay * Math.pow(2, this.reconnectAttempt),
+        this.maxReconnectDelay,
+      ) * jitter;
     this.reconnectAttempt++;
 
     this.reconnectTimer = setTimeout(async () => {
@@ -443,6 +464,7 @@ export class SocketConnection {
     }
     this.reconnectAttempt = 0;
     this.lastCloseCode = 0;
+    this.maxReconnectAttempts = 20;
     this.setConnectionState("disconnected");
   }
 

--- a/websocket.test.ts
+++ b/websocket.test.ts
@@ -889,3 +889,119 @@ describe("WS short-lived token (WHISPR-1214)", () => {
     socket.disconnect();
   });
 });
+
+describe("SocketConnection reconnect jitter (WHISPR-1395)", () => {
+  it("applies a random jitter so successive reconnect delays differ", async () => {
+    // on capture les delays passes a setTimeout par scheduleReconnect en
+    // espionnant globalThis.setTimeout.
+    const setTimeoutSpy = jest.spyOn(globalThis, "setTimeout");
+    const socket = new SocketConnection();
+    await connectAndOpen(socket);
+
+    const delays: number[] = [];
+    for (let i = 0; i < 10; i++) {
+      latestWs().simulateClose(1006, "network");
+      // recupere le dernier delay scheduled, ignore le 0 du token refresh
+      const lastCall =
+        setTimeoutSpy.mock.calls[setTimeoutSpy.mock.calls.length - 1];
+      if (lastCall && typeof lastCall[1] === "number" && lastCall[1] > 0) {
+        delays.push(lastCall[1] as number);
+      }
+      await jest.advanceTimersByTimeAsync(60_000);
+    }
+
+    // au moins 5 valeurs distinctes prouvent que le jitter est applique
+    // (sans jitter on aurait toujours min(2^n * base, 30000))
+    const unique = new Set(delays);
+    expect(unique.size).toBeGreaterThanOrEqual(5);
+
+    // chaque delay doit rester dans la fenetre [0.5x, 1.0x] du base capped
+    delays.forEach((d) => {
+      expect(d).toBeGreaterThan(0);
+      expect(d).toBeLessThanOrEqual(30_000);
+    });
+
+    setTimeoutSpy.mockRestore();
+    socket.disconnect();
+  });
+});
+
+describe("SocketConnection fatal close codes (WHISPR-1395)", () => {
+  it("limits reconnect attempts to 3 after close code 1011", async () => {
+    const socket = new SocketConnection();
+    await connectAndOpen(socket);
+
+    // premier close avec code fatal 1011 (server internal error)
+    latestWs().simulateClose(1011, "internal server error");
+
+    // 3 tentatives max apres un fatal : on les enchaine
+    for (let i = 0; i < 3; i++) {
+      await jest.advanceTimersByTimeAsync(60_000);
+      const ws = latestWs();
+      // re-close sans open pour incrementer reconnectAttempt
+      if (ws && ws.readyState !== MockWebSocket.CLOSED) {
+        ws.simulateClose(1011, "internal server error");
+      }
+    }
+
+    // au tour suivant, on doit avoir emit sessionExpired (max atteint)
+    expect(mockEmitSessionExpired).toHaveBeenCalledWith("ws_max_reconnect");
+    expect(socket.connectionState).toBe("disconnected");
+
+    socket.disconnect();
+  });
+
+  it("limits reconnect attempts to 3 after close code 1010", async () => {
+    const socket = new SocketConnection();
+    await connectAndOpen(socket);
+
+    latestWs().simulateClose(1010, "mandatory extension");
+
+    for (let i = 0; i < 3; i++) {
+      await jest.advanceTimersByTimeAsync(60_000);
+      const ws = latestWs();
+      if (ws && ws.readyState !== MockWebSocket.CLOSED) {
+        ws.simulateClose(1010, "mandatory extension");
+      }
+    }
+
+    expect(mockEmitSessionExpired).toHaveBeenCalledWith("ws_max_reconnect");
+    socket.disconnect();
+  });
+
+  it("does not lower the reconnect limit on non-fatal codes (1006)", async () => {
+    const socket = new SocketConnection();
+    await connectAndOpen(socket);
+
+    // close 1006 = network blip, pas fatal
+    for (let i = 0; i < 5; i++) {
+      latestWs().simulateClose(1006, "network");
+      await jest.advanceTimersByTimeAsync(60_000);
+    }
+
+    // 5 closes 1006 < 20 limite par defaut => pas encore d expiration
+    expect(mockEmitSessionExpired).not.toHaveBeenCalledWith("ws_max_reconnect");
+    socket.disconnect();
+  });
+
+  it("restores the default reconnect limit on a successful reopen", async () => {
+    const socket = new SocketConnection();
+    await connectAndOpen(socket);
+
+    // close fatal 1011 => limite baissee a 3
+    latestWs().simulateClose(1011, "internal server error");
+    await jest.advanceTimersByTimeAsync(60_000);
+
+    // la reconnect cree un nouveau ws, on le ouvre = success
+    latestWs().simulateOpen();
+
+    // ensuite enchainer 5 closes 1006 ne doit pas declencher max_reconnect
+    for (let i = 0; i < 5; i++) {
+      latestWs().simulateClose(1006, "network");
+      await jest.advanceTimersByTimeAsync(60_000);
+    }
+
+    expect(mockEmitSessionExpired).not.toHaveBeenCalledWith("ws_max_reconnect");
+    socket.disconnect();
+  });
+});


### PR DESCRIPTION
## Summary

- **Jitter sur reconnect** : multiplie le delay exponentiel par un random `[0.5, 1.0]` pour eviter le thundering herd quand tous les clients reconnectent en meme temps (rolling update k8s, blip reseau global).
- **Close codes fatals 1010 / 1011** : si le serveur renvoie ces codes (mandatory extension / internal server error), on circuit-break a 3 tentatives max au lieu de 20. Sur reconnect reussi, la limite remonte a 20.

## Changes

- `src/services/messaging/websocket.ts` :
  - Nouveau set `FATAL_CLOSE_CODES = {1010, 1011}` + constante `FATAL_MAX_RECONNECT_ATTEMPTS = 3`
  - `onclose` : applique le circuit-break sur close fatal
  - `scheduleReconnect` : applique le jitter
  - `onopen` + `disconnect` : restaurent `maxReconnectAttempts = 20` apres succes / cleanup
- `websocket.test.ts` : 4 tests pour jitter + fatal limits + restauration

## Test plan

- [x] Unit tests : 976 passed (53 sur websocket dont 4 nouveaux)
- [x] Lint clean
- [x] Type-check clean
- [ ] Tester en preprod : declencher rolling update messaging-service et verifier que les clients ne reconnect pas synchroniquement

Closes WHISPR-1395