### PR TITLE
[WHISPR-1402] chore(secrets): gitignore Firebase config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ web-build/
 .env.local
 .env.*.local
 
+# Firebase config files - rotated via EAS secrets, see WHISPR-1402
+google-services.json
+GoogleService-Info.plist
+
 # Logs
 *.log
 npm-debug.log*


### PR DESCRIPTION
## Action user requise
- Rotater la Firebase API key via console Firebase
- Configurer EAS secret `EXPO_GOOGLE_SERVICES_JSON_BASE64` pour les builds CI/EAS
- Optionnel: retirer la key actuelle de l'history git (git filter-branch ou BFG)

## Why
La key actuelle est committée et permanente dans git history. Restricted donc usage limité, mais bonne hygiène d'éviter futurs commits accidentels.

Fichier reste tracké pour ne pas casser le build local / Metro CI - le fix gitignore protège seulement des futures modifications committées par accident.

Closes WHISPR-1402