### PR TITLE
[WHISPR-1405] fix(crypto): prekey ID via CSPRNG

### DIFF
--- a/SignalKeyService.test.ts
+++ b/SignalKeyService.test.ts
@@ -123,4 +123,37 @@ describe("SignalKeyService.generateKeyBundle", () => {
     // 1 identity + 1 signed-prekey + 100 one-time prekeys
     expect(mockedNacl.box.keyPair).toHaveBeenCalledTimes(102);
   });
+
+  it("derives prekey ids from CSPRNG (expo-crypto), not Math.random", async () => {
+    // les ids viennent de getRandomBytes(4), donc on doit pouvoir les piloter
+    // via le mock pour verifier que c'est bien la source utilisee.
+    const expoCrypto = jest.requireMock("expo-crypto") as {
+      getRandomBytes: jest.Mock;
+    };
+    let call = 0;
+    expoCrypto.getRandomBytes.mockImplementation((n: number) => {
+      call += 1;
+      const buf = new Uint8Array(n);
+      // octets non-zero pour eviter l'ambiguite avec un mock par defaut
+      for (let i = 0; i < n; i++) buf[i] = (call * 13 + i) & 0xff;
+      return buf;
+    });
+
+    const bundle = await SignalKeyService.generateKeyBundle();
+
+    // au moins 2 appels dedies aux ids prekey (signed + base) sur l'ensemble
+    expect(expoCrypto.getRandomBytes).toHaveBeenCalledWith(4);
+    expect(bundle.signedPreKey.keyId).toBeGreaterThan(0);
+    expect(bundle.preKeys[0].keyId).toBeGreaterThan(0);
+    // ids dans l'INT32 signe
+    expect(bundle.signedPreKey.keyId).toBeLessThan(0x80000000);
+    for (const pk of bundle.preKeys) {
+      expect(pk.keyId).toBeLessThan(0x80000000);
+    }
+
+    expoCrypto.getRandomBytes.mockReset();
+    expoCrypto.getRandomBytes.mockImplementation(
+      (n: number) => new Uint8Array(n),
+    );
+  });
 });

--- a/src/services/SignalKeyService.ts
+++ b/src/services/SignalKeyService.ts
@@ -2,6 +2,7 @@ import nacl from "tweetnacl";
 import { encodeBase64 } from "tweetnacl-util";
 import { getRandomBytes } from "expo-crypto";
 import { TokenService } from "./TokenService";
+import { generateClientRandom } from "../utils/crypto";
 import type { SignalKeyBundleDto } from "../types/auth";
 
 // tweetnacl looks for self.crypto which doesn't exist in Hermes — wire it up explicitly
@@ -16,15 +17,16 @@ const NUM_ONE_TIME_PREKEYS = 100;
 // Random 30-bit base avoids same-second collisions when the user
 // reconnects multiple times, and leaves ~100 slots below 2^31 for the
 // one-time prekeys numbered `base + i` (i < 100).
+// CSPRNG pour coherence avec NaCl deja en place (cf. nacl.setPRNG ci-dessus).
 function generateSignedPrekeyId(): number {
-  return Math.floor(Math.random() * 0x40000000);
+  return generateClientRandom() & 0x3fffffff;
 }
 
 function generatePrekeyIdBase(signedPrekeyId: number): number {
   // Pick a different random base for one-time prekeys so they never
   // overlap the signed prekey id even if both are generated in the same
   // second. The +/- spread within 2^30 keeps everything in INT32 range.
-  let base = Math.floor(Math.random() * 0x40000000);
+  let base = generateClientRandom() & 0x3fffffff;
   if (Math.abs(base - signedPrekeyId) < 200) {
     // In the unlikely collision, shift far enough away from signedPrekeyId.
     base = (signedPrekeyId + 0x20000000) & 0x3fffffff;


### PR DESCRIPTION
## Summary

- `generateSignedPrekeyId` et `generatePrekeyIdBase` utilisaient `Math.random()` alors que NaCl est deja sur `expo-crypto` (CSPRNG natif).
- On reutilise le helper `generateClientRandom()` de `src/utils/crypto.ts` (cree pour WHISPR-1399) pour avoir la meme source CSPRNG partout.
- Garde le bitmask `& 0x3fffffff` pour rester sous 2^31 (INT32 signe attendu par le serveur).

## Test plan

- [x] Tests SignalKeyService verts (7/7) dont nouveau test "derives prekey ids from CSPRNG"
- [x] Tests signalKeyReplenisher verts (regression)
- [x] Lint clean
- [x] IDs restent dans la plage INT32 signe

Closes WHISPR-1405