### PR TITLE
[WHISPR-1412] fix(theme): dark mode hardcoded colors batch

### DIFF
--- a/src/components/Chat/CameraCapture.tsx
+++ b/src/components/Chat/CameraCapture.tsx
@@ -61,8 +61,9 @@ export const CameraCapture: React.FC<CameraCaptureProps> = ({
   onCapture,
   allowVideo = true,
 }) => {
-  const { getThemeColors } = useTheme();
+  const { getThemeColors, settings } = useTheme();
   const themeColors = getThemeColors();
+  const isDark = settings.theme !== "light";
   const [capturedMedia, setCapturedMedia] = useState<{
     uri: string;
     type: "image" | "video";
@@ -348,7 +349,7 @@ export const CameraCapture: React.FC<CameraCaptureProps> = ({
       onRequestClose={handleCancel}
       statusBarTranslucent
     >
-      <StatusBar barStyle="light-content" />
+      <StatusBar barStyle={isDark ? "light-content" : "dark-content"} />
       <Animated.View style={[styles.modalOverlay, modalAnimatedStyle]}>
         <LinearGradient
           colors={[

--- a/src/components/Chat/EmptyState.tsx
+++ b/src/components/Chat/EmptyState.tsx
@@ -2,27 +2,42 @@
  * EmptyState - Empty state component for conversations list
  */
 
-import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient';
-import { Ionicons } from '@expo/vector-icons';
-import { colors } from '../../theme/colors';
+import React from "react";
+import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import { Ionicons } from "@expo/vector-icons";
+import { colors, withOpacity } from "../../theme/colors";
+import { useTheme } from "../../context/ThemeContext";
 
 interface EmptyStateProps {
   onNewConversation?: () => void;
 }
 
-export const EmptyState: React.FC<EmptyStateProps> = ({ onNewConversation }) => {
+export const EmptyState: React.FC<EmptyStateProps> = ({
+  onNewConversation,
+}) => {
+  const { getThemeColors } = useTheme();
+  const themeColors = getThemeColors();
+
   return (
-    <View style={[styles.container, { backgroundColor: 'transparent' }]}>
-      <Text style={[styles.title, { color: '#FFFFFF' }]}>
+    <View style={[styles.container, { backgroundColor: "transparent" }]}>
+      <Text style={[styles.title, { color: themeColors.text.primary }]}>
         Aucune conversation
       </Text>
-      <Text style={[styles.subtitle, { color: 'rgba(255, 255, 255, 0.7)' }]}>
+      <Text
+        style={[
+          styles.subtitle,
+          { color: withOpacity(themeColors.text.primary, 0.7) },
+        ]}
+      >
         Commencez une nouvelle conversation pour démarrer
       </Text>
       {onNewConversation && (
-        <TouchableOpacity onPress={onNewConversation} style={styles.button} activeOpacity={0.7}>
+        <TouchableOpacity
+          onPress={onNewConversation}
+          style={styles.button}
+          activeOpacity={0.7}
+        >
           <LinearGradient
             colors={[colors.primary.main, colors.secondary.main]}
             start={{ x: 0, y: 0 }}
@@ -41,8 +56,8 @@ export const EmptyState: React.FC<EmptyStateProps> = ({ onNewConversation }) => 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+    justifyContent: "center",
+    alignItems: "center",
     paddingHorizontal: 32,
   },
   iconContainer: {
@@ -50,23 +65,23 @@ const styles = StyleSheet.create({
   },
   title: {
     fontSize: 22,
-    fontWeight: '600',
+    fontWeight: "600",
     marginBottom: 8,
-    textAlign: 'center',
+    textAlign: "center",
   },
   subtitle: {
     fontSize: 16,
-    textAlign: 'center',
+    textAlign: "center",
     marginBottom: 32,
     lineHeight: 22,
   },
   button: {
     borderRadius: 25,
-    overflow: 'hidden',
+    overflow: "hidden",
   },
   gradientButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     paddingVertical: 12,
     paddingHorizontal: 24,
     borderRadius: 25,
@@ -74,7 +89,7 @@ const styles = StyleSheet.create({
   buttonText: {
     color: colors.text.light,
     fontSize: 16,
-    fontWeight: '600',
+    fontWeight: "600",
     marginLeft: 8,
   },
 });

--- a/src/components/Chat/ScheduleDateTimePicker.tsx
+++ b/src/components/Chat/ScheduleDateTimePicker.tsx
@@ -3,7 +3,7 @@
  * Custom implementation (no external datetimepicker dependency).
  */
 
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo } from "react";
 import {
   View,
   Text,
@@ -12,11 +12,11 @@ import {
   TouchableOpacity,
   ScrollView,
   Platform,
-} from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient';
-import { Ionicons } from '@expo/vector-icons';
-import * as Haptics from 'expo-haptics';
-import { colors, withOpacity } from '../../theme/colors';
+} from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import { Ionicons } from "@expo/vector-icons";
+import * as Haptics from "expo-haptics";
+import { colors, withOpacity } from "../../theme/colors";
 
 interface ScheduleDateTimePickerProps {
   visible: boolean;
@@ -25,23 +25,23 @@ interface ScheduleDateTimePickerProps {
 }
 
 const QUICK_OPTIONS = [
-  { label: 'Dans 30 min', minutes: 30 },
-  { label: 'Dans 1 heure', minutes: 60 },
-  { label: 'Dans 2 heures', minutes: 120 },
-  { label: 'Dans 4 heures', minutes: 240 },
-  { label: 'Demain 9h', custom: 'tomorrow9' as const },
-  { label: 'Demain 14h', custom: 'tomorrow14' as const },
+  { label: "Dans 30 min", minutes: 30 },
+  { label: "Dans 1 heure", minutes: 60 },
+  { label: "Dans 2 heures", minutes: 120 },
+  { label: "Dans 4 heures", minutes: 240 },
+  { label: "Demain 9h", custom: "tomorrow9" as const },
+  { label: "Demain 14h", custom: "tomorrow14" as const },
 ];
 
-function getQuickDate(option: typeof QUICK_OPTIONS[number]): Date {
+function getQuickDate(option: (typeof QUICK_OPTIONS)[number]): Date {
   const now = new Date();
-  if (option.custom === 'tomorrow9') {
+  if (option.custom === "tomorrow9") {
     const d = new Date(now);
     d.setDate(d.getDate() + 1);
     d.setHours(9, 0, 0, 0);
     return d;
   }
-  if (option.custom === 'tomorrow14') {
+  if (option.custom === "tomorrow14") {
     const d = new Date(now);
     d.setDate(d.getDate() + 1);
     d.setHours(14, 0, 0, 0);
@@ -55,8 +55,18 @@ function padZero(n: number): string {
 }
 
 const MONTHS = [
-  'Janvier', 'Février', 'Mars', 'Avril', 'Mai', 'Juin',
-  'Juillet', 'Août', 'Septembre', 'Octobre', 'Novembre', 'Décembre',
+  "Janvier",
+  "Février",
+  "Mars",
+  "Avril",
+  "Mai",
+  "Juin",
+  "Juillet",
+  "Août",
+  "Septembre",
+  "Octobre",
+  "Novembre",
+  "Décembre",
 ];
 
 export const ScheduleDateTimePicker: React.FC<ScheduleDateTimePickerProps> = ({
@@ -65,13 +75,13 @@ export const ScheduleDateTimePicker: React.FC<ScheduleDateTimePickerProps> = ({
   onConfirm,
 }) => {
   const now = useMemo(() => new Date(), [visible]);
-  const [mode, setMode] = useState<'quick' | 'custom'>('quick');
+  const [mode, setMode] = useState<"quick" | "custom">("quick");
   const [selectedDay, setSelectedDay] = useState(now.getDate());
   const [selectedMonth, setSelectedMonth] = useState(now.getMonth());
   const [selectedYear, setSelectedYear] = useState(now.getFullYear());
   const [selectedHour, setSelectedHour] = useState(now.getHours());
   const [selectedMinute, setSelectedMinute] = useState(
-    Math.ceil(now.getMinutes() / 5) * 5 % 60,
+    (Math.ceil(now.getMinutes() / 5) * 5) % 60,
   );
 
   // Reset state when modal opens
@@ -82,8 +92,8 @@ export const ScheduleDateTimePicker: React.FC<ScheduleDateTimePickerProps> = ({
       setSelectedMonth(fresh.getMonth());
       setSelectedYear(fresh.getFullYear());
       setSelectedHour(fresh.getHours());
-      setSelectedMinute(Math.ceil(fresh.getMinutes() / 5) * 5 % 60);
-      setMode('quick');
+      setSelectedMinute((Math.ceil(fresh.getMinutes() / 5) * 5) % 60);
+      setMode("quick");
     }
   }, [visible]);
 
@@ -92,14 +102,25 @@ export const ScheduleDateTimePicker: React.FC<ScheduleDateTimePickerProps> = ({
   }, [selectedYear, selectedMonth]);
 
   const buildDate = useCallback((): Date => {
-    return new Date(selectedYear, selectedMonth, selectedDay, selectedHour, selectedMinute, 0, 0);
+    return new Date(
+      selectedYear,
+      selectedMonth,
+      selectedDay,
+      selectedHour,
+      selectedMinute,
+      0,
+      0,
+    );
   }, [selectedYear, selectedMonth, selectedDay, selectedHour, selectedMinute]);
 
-  const handleQuickSelect = useCallback((option: typeof QUICK_OPTIONS[number]) => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    const date = getQuickDate(option);
-    onConfirm(date);
-  }, [onConfirm]);
+  const handleQuickSelect = useCallback(
+    (option: (typeof QUICK_OPTIONS)[number]) => {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      const date = getQuickDate(option);
+      onConfirm(date);
+    },
+    [onConfirm],
+  );
 
   const handleCustomConfirm = useCallback(() => {
     const date = buildDate();
@@ -117,9 +138,16 @@ export const ScheduleDateTimePicker: React.FC<ScheduleDateTimePickerProps> = ({
 
   const formattedPreview = useMemo(() => {
     const date = buildDate();
-    const dayName = date.toLocaleDateString('fr-FR', { weekday: 'long' });
+    const dayName = date.toLocaleDateString("fr-FR", { weekday: "long" });
     return `${dayName} ${selectedDay} ${MONTHS[selectedMonth]} ${selectedYear} à ${padZero(selectedHour)}:${padZero(selectedMinute)}`;
-  }, [buildDate, selectedDay, selectedMonth, selectedYear, selectedHour, selectedMinute]);
+  }, [
+    buildDate,
+    selectedDay,
+    selectedMonth,
+    selectedYear,
+    selectedHour,
+    selectedMinute,
+  ]);
 
   return (
     <Modal
@@ -147,35 +175,56 @@ export const ScheduleDateTimePicker: React.FC<ScheduleDateTimePickerProps> = ({
             {/* Mode Tabs */}
             <View style={styles.tabs}>
               <TouchableOpacity
-                style={[styles.tab, mode === 'quick' && styles.tabActive]}
-                onPress={() => setMode('quick')}
+                style={[styles.tab, mode === "quick" && styles.tabActive]}
+                onPress={() => setMode("quick")}
               >
                 <Ionicons
                   name="flash-outline"
                   size={16}
-                  color={mode === 'quick' ? colors.text.light : withOpacity(colors.text.light, 0.5)}
+                  color={
+                    mode === "quick"
+                      ? colors.text.light
+                      : withOpacity(colors.text.light, 0.5)
+                  }
                 />
-                <Text style={[styles.tabText, mode === 'quick' && styles.tabTextActive]}>
+                <Text
+                  style={[
+                    styles.tabText,
+                    mode === "quick" && styles.tabTextActive,
+                  ]}
+                >
                   Rapide
                 </Text>
               </TouchableOpacity>
               <TouchableOpacity
-                style={[styles.tab, mode === 'custom' && styles.tabActive]}
-                onPress={() => setMode('custom')}
+                style={[styles.tab, mode === "custom" && styles.tabActive]}
+                onPress={() => setMode("custom")}
               >
                 <Ionicons
                   name="calendar-outline"
                   size={16}
-                  color={mode === 'custom' ? colors.text.light : withOpacity(colors.text.light, 0.5)}
+                  color={
+                    mode === "custom"
+                      ? colors.text.light
+                      : withOpacity(colors.text.light, 0.5)
+                  }
                 />
-                <Text style={[styles.tabText, mode === 'custom' && styles.tabTextActive]}>
+                <Text
+                  style={[
+                    styles.tabText,
+                    mode === "custom" && styles.tabTextActive,
+                  ]}
+                >
                   Personnalisé
                 </Text>
               </TouchableOpacity>
             </View>
 
-            <ScrollView style={styles.body} showsVerticalScrollIndicator={false}>
-              {mode === 'quick' ? (
+            <ScrollView
+              style={styles.body}
+              showsVerticalScrollIndicator={false}
+            >
+              {mode === "quick" ? (
                 <View style={styles.quickOptions}>
                   {QUICK_OPTIONS.map((option, idx) => {
                     const date = getQuickDate(option);
@@ -187,12 +236,22 @@ export const ScheduleDateTimePicker: React.FC<ScheduleDateTimePickerProps> = ({
                         onPress={() => handleQuickSelect(option)}
                         activeOpacity={0.7}
                       >
-                        <Ionicons name="time-outline" size={20} color={colors.primary.main} />
+                        <Ionicons
+                          name="time-outline"
+                          size={20}
+                          color={colors.primary.main}
+                        />
                         <View style={styles.quickOptionText}>
-                          <Text style={styles.quickOptionLabel}>{option.label}</Text>
+                          <Text style={styles.quickOptionLabel}>
+                            {option.label}
+                          </Text>
                           <Text style={styles.quickOptionTime}>{timeStr}</Text>
                         </View>
-                        <Ionicons name="chevron-forward" size={18} color={withOpacity(colors.text.light, 0.3)} />
+                        <Ionicons
+                          name="chevron-forward"
+                          size={18}
+                          color={withOpacity(colors.text.light, 0.3)}
+                        />
                       </TouchableOpacity>
                     );
                   })}
@@ -206,16 +265,30 @@ export const ScheduleDateTimePicker: React.FC<ScheduleDateTimePickerProps> = ({
                     <View style={styles.pickerCol}>
                       <TouchableOpacity
                         style={styles.pickerArrow}
-                        onPress={() => setSelectedDay(d => d < daysInMonth ? d + 1 : 1)}
+                        onPress={() =>
+                          setSelectedDay((d) => (d < daysInMonth ? d + 1 : 1))
+                        }
                       >
-                        <Ionicons name="chevron-up" size={20} color={colors.text.light} />
+                        <Ionicons
+                          name="chevron-up"
+                          size={20}
+                          color={colors.text.light}
+                        />
                       </TouchableOpacity>
-                      <Text style={styles.pickerValue}>{padZero(selectedDay)}</Text>
+                      <Text style={styles.pickerValue}>
+                        {padZero(selectedDay)}
+                      </Text>
                       <TouchableOpacity
                         style={styles.pickerArrow}
-                        onPress={() => setSelectedDay(d => d > 1 ? d - 1 : daysInMonth)}
+                        onPress={() =>
+                          setSelectedDay((d) => (d > 1 ? d - 1 : daysInMonth))
+                        }
                       >
-                        <Ionicons name="chevron-down" size={20} color={colors.text.light} />
+                        <Ionicons
+                          name="chevron-down"
+                          size={20}
+                          color={colors.text.light}
+                        />
                       </TouchableOpacity>
                       <Text style={styles.pickerLabel}>Jour</Text>
                     </View>
@@ -224,16 +297,30 @@ export const ScheduleDateTimePicker: React.FC<ScheduleDateTimePickerProps> = ({
                     <View style={styles.pickerCol}>
                       <TouchableOpacity
                         style={styles.pickerArrow}
-                        onPress={() => setSelectedMonth(m => m < 11 ? m + 1 : 0)}
+                        onPress={() =>
+                          setSelectedMonth((m) => (m < 11 ? m + 1 : 0))
+                        }
                       >
-                        <Ionicons name="chevron-up" size={20} color={colors.text.light} />
+                        <Ionicons
+                          name="chevron-up"
+                          size={20}
+                          color={colors.text.light}
+                        />
                       </TouchableOpacity>
-                      <Text style={styles.pickerValue}>{MONTHS[selectedMonth].substring(0, 3)}</Text>
+                      <Text style={styles.pickerValue}>
+                        {MONTHS[selectedMonth].substring(0, 3)}
+                      </Text>
                       <TouchableOpacity
                         style={styles.pickerArrow}
-                        onPress={() => setSelectedMonth(m => m > 0 ? m - 1 : 11)}
+                        onPress={() =>
+                          setSelectedMonth((m) => (m > 0 ? m - 1 : 11))
+                        }
                       >
-                        <Ionicons name="chevron-down" size={20} color={colors.text.light} />
+                        <Ionicons
+                          name="chevron-down"
+                          size={20}
+                          color={colors.text.light}
+                        />
                       </TouchableOpacity>
                       <Text style={styles.pickerLabel}>Mois</Text>
                     </View>
@@ -242,38 +329,66 @@ export const ScheduleDateTimePicker: React.FC<ScheduleDateTimePickerProps> = ({
                     <View style={styles.pickerCol}>
                       <TouchableOpacity
                         style={styles.pickerArrow}
-                        onPress={() => setSelectedYear(y => y + 1)}
+                        onPress={() => setSelectedYear((y) => y + 1)}
                       >
-                        <Ionicons name="chevron-up" size={20} color={colors.text.light} />
+                        <Ionicons
+                          name="chevron-up"
+                          size={20}
+                          color={colors.text.light}
+                        />
                       </TouchableOpacity>
                       <Text style={styles.pickerValue}>{selectedYear}</Text>
                       <TouchableOpacity
                         style={styles.pickerArrow}
-                        onPress={() => setSelectedYear(y => Math.max(y - 1, now.getFullYear()))}
+                        onPress={() =>
+                          setSelectedYear((y) =>
+                            Math.max(y - 1, now.getFullYear()),
+                          )
+                        }
                       >
-                        <Ionicons name="chevron-down" size={20} color={colors.text.light} />
+                        <Ionicons
+                          name="chevron-down"
+                          size={20}
+                          color={colors.text.light}
+                        />
                       </TouchableOpacity>
                       <Text style={styles.pickerLabel}>Année</Text>
                     </View>
                   </View>
 
                   {/* Time Row */}
-                  <Text style={[styles.sectionLabel, { marginTop: 20 }]}>HEURE</Text>
+                  <Text style={[styles.sectionLabel, { marginTop: 20 }]}>
+                    HEURE
+                  </Text>
                   <View style={styles.pickerRow}>
                     {/* Hour */}
                     <View style={styles.pickerCol}>
                       <TouchableOpacity
                         style={styles.pickerArrow}
-                        onPress={() => setSelectedHour(h => h < 23 ? h + 1 : 0)}
+                        onPress={() =>
+                          setSelectedHour((h) => (h < 23 ? h + 1 : 0))
+                        }
                       >
-                        <Ionicons name="chevron-up" size={20} color={colors.text.light} />
+                        <Ionicons
+                          name="chevron-up"
+                          size={20}
+                          color={colors.text.light}
+                        />
                       </TouchableOpacity>
-                      <Text style={styles.pickerValue}>{padZero(selectedHour)}</Text>
+                      <Text style={styles.pickerValue}>
+                        {padZero(selectedHour)}
+                      </Text>
                       <TouchableOpacity
                         style={styles.pickerArrow}
-                        onPress={() => setSelectedHour(h => h > 0 ? h - 1 : 23)}
+                        onPress={() =>
+                          setSelectedHour((h) => (h > 0 ? h - 1 : 23))
+                        }
                       >
-                        <Ionicons name="chevron-down" size={20} color={colors.text.light} />
+                        <Ionicons
+                          name="chevron-down"
+                          size={20}
+                          color={colors.text.light}
+                        />
                       </TouchableOpacity>
                       <Text style={styles.pickerLabel}>Heures</Text>
                     </View>
@@ -284,16 +399,30 @@ export const ScheduleDateTimePicker: React.FC<ScheduleDateTimePickerProps> = ({
                     <View style={styles.pickerCol}>
                       <TouchableOpacity
                         style={styles.pickerArrow}
-                        onPress={() => setSelectedMinute(m => m < 55 ? m + 5 : 0)}
+                        onPress={() =>
+                          setSelectedMinute((m) => (m < 55 ? m + 5 : 0))
+                        }
                       >
-                        <Ionicons name="chevron-up" size={20} color={colors.text.light} />
+                        <Ionicons
+                          name="chevron-up"
+                          size={20}
+                          color={colors.text.light}
+                        />
                       </TouchableOpacity>
-                      <Text style={styles.pickerValue}>{padZero(selectedMinute)}</Text>
+                      <Text style={styles.pickerValue}>
+                        {padZero(selectedMinute)}
+                      </Text>
                       <TouchableOpacity
                         style={styles.pickerArrow}
-                        onPress={() => setSelectedMinute(m => m > 0 ? m - 5 : 55)}
+                        onPress={() =>
+                          setSelectedMinute((m) => (m > 0 ? m - 5 : 55))
+                        }
                       >
-                        <Ionicons name="chevron-down" size={20} color={colors.text.light} />
+                        <Ionicons
+                          name="chevron-down"
+                          size={20}
+                          color={colors.text.light}
+                        />
                       </TouchableOpacity>
                       <Text style={styles.pickerLabel}>Minutes</Text>
                     </View>
@@ -301,7 +430,11 @@ export const ScheduleDateTimePicker: React.FC<ScheduleDateTimePickerProps> = ({
 
                   {/* Preview */}
                   <View style={styles.preview}>
-                    <Ionicons name="calendar" size={16} color={colors.primary.main} />
+                    <Ionicons
+                      name="calendar"
+                      size={16}
+                      color={colors.primary.main}
+                    />
                     <Text style={styles.previewText}>{formattedPreview}</Text>
                   </View>
 
@@ -312,12 +445,20 @@ export const ScheduleDateTimePicker: React.FC<ScheduleDateTimePickerProps> = ({
                     activeOpacity={0.7}
                   >
                     <LinearGradient
-                      colors={isCustomDateValid ? ['#FFB07B', '#F04882'] : ['#555', '#444']}
+                      colors={
+                        isCustomDateValid
+                          ? ["#FFB07B", "#F04882"]
+                          : ["#555", "#444"]
+                      }
                       start={{ x: 0, y: 0 }}
                       end={{ x: 1, y: 1 }}
                       style={styles.confirmButton}
                     >
-                      <Ionicons name="send" size={18} color={colors.text.light} />
+                      <Ionicons
+                        name="send"
+                        size={18}
+                        color={colors.text.light}
+                      />
                       <Text style={styles.confirmButtonText}>
                         Programmer l'envoi
                       </Text>
@@ -342,14 +483,14 @@ export const ScheduleDateTimePicker: React.FC<ScheduleDateTimePickerProps> = ({
 const styles = StyleSheet.create({
   overlay: {
     flex: 1,
-    backgroundColor: 'rgba(0, 0, 0, 0.8)',
-    justifyContent: 'flex-end',
+    backgroundColor: "rgba(0, 0, 0, 0.8)",
+    justifyContent: "flex-end",
   },
   container: {
     borderTopLeftRadius: 24,
     borderTopRightRadius: 24,
-    maxHeight: '80%',
-    overflow: 'hidden',
+    maxHeight: "80%",
+    overflow: "hidden",
     borderTopWidth: 1,
     borderLeftWidth: 1,
     borderRightWidth: 1,
@@ -361,9 +502,9 @@ const styles = StyleSheet.create({
     paddingBottom: 30,
   },
   header: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
     paddingHorizontal: 24,
     paddingTop: 24,
     paddingBottom: 16,
@@ -372,7 +513,7 @@ const styles = StyleSheet.create({
   },
   title: {
     fontSize: 20,
-    fontWeight: '700',
+    fontWeight: "700",
     color: colors.text.light,
     letterSpacing: -0.5,
   },
@@ -382,7 +523,7 @@ const styles = StyleSheet.create({
     backgroundColor: withOpacity(colors.background.dark, 0.4),
   },
   tabs: {
-    flexDirection: 'row',
+    flexDirection: "row",
     marginHorizontal: 24,
     marginTop: 16,
     borderRadius: 12,
@@ -391,9 +532,9 @@ const styles = StyleSheet.create({
   },
   tab: {
     flex: 1,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
     paddingVertical: 10,
     borderRadius: 10,
     gap: 6,
@@ -403,7 +544,7 @@ const styles = StyleSheet.create({
   },
   tabText: {
     fontSize: 14,
-    fontWeight: '600',
+    fontWeight: "600",
     color: withOpacity(colors.text.light, 0.5),
   },
   tabTextActive: {
@@ -417,8 +558,8 @@ const styles = StyleSheet.create({
     gap: 8,
   },
   quickOption: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     paddingVertical: 14,
     paddingHorizontal: 16,
     borderRadius: 12,
@@ -432,7 +573,7 @@ const styles = StyleSheet.create({
   },
   quickOptionLabel: {
     fontSize: 15,
-    fontWeight: '600',
+    fontWeight: "600",
     color: colors.text.light,
   },
   quickOptionTime: {
@@ -445,20 +586,20 @@ const styles = StyleSheet.create({
   },
   sectionLabel: {
     fontSize: 11,
-    fontWeight: '600',
+    fontWeight: "600",
     letterSpacing: 1.2,
     color: withOpacity(colors.text.light, 0.5),
     marginBottom: 12,
-    textTransform: 'uppercase',
+    textTransform: "uppercase",
   },
   pickerRow: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
+    flexDirection: "row",
+    justifyContent: "center",
+    alignItems: "center",
     gap: 16,
   },
   pickerCol: {
-    alignItems: 'center',
+    alignItems: "center",
     minWidth: 70,
   },
   pickerArrow: {
@@ -466,14 +607,14 @@ const styles = StyleSheet.create({
   },
   pickerValue: {
     fontSize: 24,
-    fontWeight: '700',
+    fontWeight: "700",
     color: colors.text.light,
     paddingVertical: 8,
     minWidth: 60,
-    textAlign: 'center',
+    textAlign: "center",
     backgroundColor: withOpacity(colors.background.dark, 0.4),
     borderRadius: 10,
-    overflow: 'hidden',
+    overflow: "hidden",
   },
   pickerLabel: {
     fontSize: 11,
@@ -482,14 +623,14 @@ const styles = StyleSheet.create({
   },
   timeSeparator: {
     fontSize: 24,
-    fontWeight: '700',
+    fontWeight: "700",
     color: colors.text.light,
     marginBottom: 20,
   },
   preview: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
     marginTop: 20,
     marginBottom: 20,
     paddingVertical: 12,
@@ -502,26 +643,26 @@ const styles = StyleSheet.create({
   },
   previewText: {
     fontSize: 14,
-    fontWeight: '600',
+    fontWeight: "600",
     color: colors.text.light,
   },
   confirmButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
     paddingVertical: 14,
     borderRadius: 14,
     gap: 8,
   },
   confirmButtonText: {
     fontSize: 16,
-    fontWeight: '700',
+    fontWeight: "700",
     color: colors.text.light,
   },
   errorText: {
     fontSize: 12,
-    color: '#F04882',
-    textAlign: 'center',
+    color: colors.warning,
+    textAlign: "center",
     marginTop: 8,
   },
 });

--- a/src/components/Chat/ScheduleDateTimePicker.tsx
+++ b/src/components/Chat/ScheduleDateTimePicker.tsx
@@ -661,7 +661,7 @@ const styles = StyleSheet.create({
   },
   errorText: {
     fontSize: 12,
-    color: colors.warning,
+    color: colors.ui.warning,
     textAlign: "center",
     marginTop: 8,
   },

--- a/src/screens/Chat/ScheduledMessagesScreen.tsx
+++ b/src/screens/Chat/ScheduledMessagesScreen.tsx
@@ -2,7 +2,7 @@
  * ScheduledMessagesScreen - List and manage pending scheduled messages.
  */
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback } from "react";
 import {
   View,
   Text,
@@ -12,26 +12,26 @@ import {
   ActivityIndicator,
   Alert,
   RefreshControl,
-} from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { LinearGradient } from 'expo-linear-gradient';
-import { useNavigation, useRoute } from '@react-navigation/native';
-import { StackScreenProps } from '@react-navigation/stack';
-import { Ionicons } from '@expo/vector-icons';
-import * as Haptics from 'expo-haptics';
-import { colors, withOpacity } from '../../theme/colors';
-import { useTheme } from '../../context/ThemeContext';
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { LinearGradient } from "expo-linear-gradient";
+import { useNavigation, useRoute } from "@react-navigation/native";
+import { StackScreenProps } from "@react-navigation/stack";
+import { Ionicons } from "@expo/vector-icons";
+import * as Haptics from "expo-haptics";
+import { colors, withOpacity } from "../../theme/colors";
+import { useTheme } from "../../context/ThemeContext";
 import {
   SchedulingService,
   ScheduledMessage,
-} from '../../services/SchedulingService';
-import { AuthStackParamList } from '../../navigation/AuthNavigator';
-import { logger } from '../../utils/logger';
+} from "../../services/SchedulingService";
+import { AuthStackParamList } from "../../navigation/AuthNavigator";
+import { logger } from "../../utils/logger";
 
 type ScheduledMessagesRouteProp = StackScreenProps<
   AuthStackParamList,
-  'ScheduledMessages'
->['route'];
+  "ScheduledMessages"
+>["route"];
 
 function formatScheduledDate(iso: string): string {
   const date = new Date(iso);
@@ -41,46 +41,46 @@ function formatScheduledDate(iso: string): string {
   tomorrow.setDate(tomorrow.getDate() + 1);
   const isTomorrow = date.toDateString() === tomorrow.toDateString();
 
-  const time = date.toLocaleTimeString('fr-FR', {
-    hour: '2-digit',
-    minute: '2-digit',
+  const time = date.toLocaleTimeString("fr-FR", {
+    hour: "2-digit",
+    minute: "2-digit",
   });
 
   if (isToday) return `Aujourd'hui à ${time}`;
   if (isTomorrow) return `Demain à ${time}`;
 
-  const dayMonth = date.toLocaleDateString('fr-FR', {
-    day: 'numeric',
-    month: 'long',
+  const dayMonth = date.toLocaleDateString("fr-FR", {
+    day: "numeric",
+    month: "long",
   });
   return `${dayMonth} à ${time}`;
 }
 
-function getStatusColor(status: ScheduledMessage['status']): string {
+function getStatusColor(status: ScheduledMessage["status"]): string {
   switch (status) {
-    case 'pending':
-      return '#FFB07B';
-    case 'sent':
-      return '#4CAF50';
-    case 'failed':
-      return '#F04882';
-    case 'cancelled':
+    case "pending":
+      return "#FFB07B";
+    case "sent":
+      return "#4CAF50";
+    case "failed":
+      return "#F04882";
+    case "cancelled":
       return withOpacity(colors.text.light, 0.4);
     default:
       return colors.text.light;
   }
 }
 
-function getStatusLabel(status: ScheduledMessage['status']): string {
+function getStatusLabel(status: ScheduledMessage["status"]): string {
   switch (status) {
-    case 'pending':
-      return 'En attente';
-    case 'sent':
-      return 'Envoyé';
-    case 'failed':
-      return 'Échoué';
-    case 'cancelled':
-      return 'Annulé';
+    case "pending":
+      return "En attente";
+    case "sent":
+      return "Envoyé";
+    case "failed":
+      return "Échoué";
+    case "cancelled":
+      return "Annulé";
     default:
       return status;
   }
@@ -105,11 +105,16 @@ export const ScheduledMessagesScreen: React.FC = () => {
       // Sort by scheduled_at ascending (soonest first)
       data.sort(
         (a, b) =>
-          new Date(a.scheduled_at).getTime() - new Date(b.scheduled_at).getTime(),
+          new Date(a.scheduled_at).getTime() -
+          new Date(b.scheduled_at).getTime(),
       );
       setMessages(data);
     } catch (error) {
-      logger.error('ScheduledMessages', 'Error loading scheduled messages', error);
+      logger.error(
+        "ScheduledMessages",
+        "Error loading scheduled messages",
+        error,
+      );
     } finally {
       setLoading(false);
       setRefreshing(false);
@@ -125,44 +130,43 @@ export const ScheduledMessagesScreen: React.FC = () => {
     loadMessages();
   }, [loadMessages]);
 
-  const handleCancel = useCallback(
-    (message: ScheduledMessage) => {
-      Alert.alert(
-        'Annuler le message programmé',
-        `Voulez-vous annuler l'envoi de ce message ?\n\n"${message.content.substring(0, 80)}${message.content.length > 80 ? '...' : ''}"`,
-        [
-          { text: 'Non', style: 'cancel' },
-          {
-            text: 'Annuler le message',
-            style: 'destructive',
-            onPress: async () => {
-              try {
-                Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-                await SchedulingService.cancelScheduledMessage(message.id);
-                setMessages((prev) =>
-                  prev.map((m) =>
-                    m.id === message.id ? { ...m, status: 'cancelled' as const } : m,
-                  ),
-                );
-              } catch (error) {
-                logger.error(
-                  'ScheduledMessages',
-                  'Error cancelling scheduled message',
-                  error,
-                );
-                Alert.alert('Erreur', "Impossible d'annuler le message.");
-              }
-            },
+  const handleCancel = useCallback((message: ScheduledMessage) => {
+    Alert.alert(
+      "Annuler le message programmé",
+      `Voulez-vous annuler l'envoi de ce message ?\n\n"${message.content.substring(0, 80)}${message.content.length > 80 ? "..." : ""}"`,
+      [
+        { text: "Non", style: "cancel" },
+        {
+          text: "Annuler le message",
+          style: "destructive",
+          onPress: async () => {
+            try {
+              Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+              await SchedulingService.cancelScheduledMessage(message.id);
+              setMessages((prev) =>
+                prev.map((m) =>
+                  m.id === message.id
+                    ? { ...m, status: "cancelled" as const }
+                    : m,
+                ),
+              );
+            } catch (error) {
+              logger.error(
+                "ScheduledMessages",
+                "Error cancelling scheduled message",
+                error,
+              );
+              Alert.alert("Erreur", "Impossible d'annuler le message.");
+            }
           },
-        ],
-      );
-    },
-    [],
-  );
+        },
+      ],
+    );
+  }, []);
 
   const renderItem = useCallback(
     ({ item }: { item: ScheduledMessage }) => {
-      const isPending = item.status === 'pending';
+      const isPending = item.status === "pending";
       const statusColor = getStatusColor(item.status);
 
       return (
@@ -208,7 +212,7 @@ export const ScheduledMessagesScreen: React.FC = () => {
     [handleCancel],
   );
 
-  const pendingCount = messages.filter((m) => m.status === 'pending').length;
+  const pendingCount = messages.filter((m) => m.status === "pending").length;
 
   return (
     <LinearGradient
@@ -217,7 +221,7 @@ export const ScheduledMessagesScreen: React.FC = () => {
       end={{ x: 1, y: 1 }}
       style={styles.gradientContainer}
     >
-      <SafeAreaView style={styles.container} edges={['top']}>
+      <SafeAreaView style={styles.container} edges={["top"]}>
         {/* Header */}
         <View style={styles.header}>
           <TouchableOpacity
@@ -252,11 +256,10 @@ export const ScheduledMessagesScreen: React.FC = () => {
               size={64}
               color={withOpacity(colors.text.light, 0.2)}
             />
-            <Text style={styles.emptyTitle}>
-              Aucun message programmé
-            </Text>
+            <Text style={styles.emptyTitle}>Aucun message programmé</Text>
             <Text style={styles.emptySubtitle}>
-              Appuyez longuement sur le bouton d'envoi pour programmer un message
+              Appuyez longuement sur le bouton d'envoi pour programmer un
+              message
             </Text>
           </View>
         ) : (
@@ -287,12 +290,12 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   header: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     paddingHorizontal: 16,
     paddingVertical: 12,
     borderBottomWidth: 1,
-    borderBottomColor: 'rgba(255, 255, 255, 0.1)',
+    borderBottomColor: "rgba(255, 255, 255, 0.1)",
   },
   backButton: {
     marginRight: 12,
@@ -302,7 +305,7 @@ const styles = StyleSheet.create({
   },
   headerTitle: {
     fontSize: 18,
-    fontWeight: '700',
+    fontWeight: "700",
     color: colors.text.light,
   },
   headerSubtitle: {
@@ -312,25 +315,25 @@ const styles = StyleSheet.create({
   },
   loadingContainer: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+    justifyContent: "center",
+    alignItems: "center",
   },
   emptyContainer: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+    justifyContent: "center",
+    alignItems: "center",
     paddingHorizontal: 40,
   },
   emptyTitle: {
     fontSize: 18,
-    fontWeight: '700',
+    fontWeight: "700",
     color: colors.text.light,
     marginTop: 16,
   },
   emptySubtitle: {
     fontSize: 14,
     color: withOpacity(colors.text.light, 0.5),
-    textAlign: 'center',
+    textAlign: "center",
     marginTop: 8,
     lineHeight: 20,
   },
@@ -346,14 +349,14 @@ const styles = StyleSheet.create({
     borderColor: withOpacity(colors.ui.divider, 0.1),
   },
   messageHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
     marginBottom: 10,
   },
   statusBadge: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     gap: 6,
   },
   statusDot: {
@@ -363,11 +366,11 @@ const styles = StyleSheet.create({
   },
   statusText: {
     fontSize: 12,
-    fontWeight: '600',
+    fontWeight: "600",
   },
   scheduleTime: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     gap: 4,
   },
   scheduleTimeText: {
@@ -380,20 +383,20 @@ const styles = StyleSheet.create({
     lineHeight: 22,
   },
   cancelButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
     marginTop: 12,
     paddingVertical: 8,
     borderRadius: 10,
-    backgroundColor: withOpacity('#F04882', 0.1),
+    backgroundColor: withOpacity("#F04882", 0.1),
     borderWidth: 1,
-    borderColor: withOpacity('#F04882', 0.2),
+    borderColor: withOpacity("#F04882", 0.2),
     gap: 6,
   },
   cancelButtonText: {
     fontSize: 13,
-    fontWeight: '600',
-    color: '#F04882',
+    fontWeight: "600",
+    color: colors.warning,
   },
 });

--- a/src/screens/Chat/ScheduledMessagesScreen.tsx
+++ b/src/screens/Chat/ScheduledMessagesScreen.tsx
@@ -397,6 +397,6 @@ const styles = StyleSheet.create({
   cancelButtonText: {
     fontSize: 13,
     fontWeight: "600",
-    color: colors.warning,
+    color: colors.ui.warning,
   },
 });


### PR DESCRIPTION
## Summary
- EmptyState: replaced `#FFFFFF` literal with `themeColors.text.primary` (invisible in light mode)
- CameraCapture: StatusBar barStyle now follows theme (`isDark ? "light-content" : "dark-content"`)
- ScheduledMessagesScreen + ScheduleDateTimePicker: replaced hardcoded `#F04882` with `colors.ui.warning` token

## Test plan
- [x] Unit tests green (102 suites, 981 tests)
- [x] Lint clean (0 errors, 9 pre-existing warnings)
- [x] TS check clean
- [ ] Visual smoke test on whispr-preprod.roadmvn.com after deploy (light + dark mode chat empty state, camera capture)

Closes WHISPR-1412