### PR TITLE
[WHISPR-1417] fix(groups): refresh state avant leave + recover

### DIFF
--- a/GroupDetailsScreen.test.tsx
+++ b/GroupDetailsScreen.test.tsx
@@ -301,7 +301,10 @@ describe("GroupDetailsScreen", () => {
 
       fireEvent.press(getByText("Quitter le groupe"));
 
-      expect(getByTestId("danger-confirm-input")).toBeTruthy();
+      // refresh state async avant ouverture modal
+      await waitFor(() => {
+        expect(getByTestId("danger-confirm-input")).toBeTruthy();
+      });
     });
 
     it("leave: action desactivee tant que SUPPRIMER n'est pas tape", async () => {
@@ -323,6 +326,10 @@ describe("GroupDetailsScreen", () => {
       });
 
       fireEvent.press(getByText("Quitter le groupe"));
+      // refresh state async avant ouverture modal
+      await waitFor(() => {
+        expect(getByTestId("danger-confirm-action")).toBeTruthy();
+      });
       // tap sur action sans input -> rien ne se passe
       fireEvent.press(getByTestId("danger-confirm-action"));
       expect((mockedGroupsAPI as any).leaveGroup).not.toHaveBeenCalled();

--- a/src/screens/Groups/GroupDetailsScreen.tsx
+++ b/src/screens/Groups/GroupDetailsScreen.tsx
@@ -473,6 +473,8 @@ export const GroupDetailsScreen: React.FC = () => {
           "Error transferring and leaving",
           error,
         );
+        // resync local state apres echec partiel transfer/leave
+        loadGroupData().catch(() => {});
         Alert.alert(
           "Erreur",
           error.message || "Impossible de transférer et quitter le groupe",
@@ -488,6 +490,7 @@ export const GroupDetailsScreen: React.FC = () => {
       conversationId,
       conversationKey,
       groupId,
+      loadGroupData,
       navigation,
       refreshConversations,
       removeConversationLocal,
@@ -1536,8 +1539,10 @@ export const GroupDetailsScreen: React.FC = () => {
           </AnimatedTouchableOpacity>
           <AnimatedTouchableOpacity
             style={styles.actionButton}
-            onPress={() => {
+            onPress={async () => {
               Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+              // refresh members avant decision pour eviter isLastAdmin stale (concurrent demote)
+              await loadGroupData().catch(() => {});
               // si dernier admin, on saute la typed-confirm et on force le transfert direct
               if (isLastAdmin) {
                 setShowTransferAdminModal(true);


### PR DESCRIPTION
## Summary
- ajoute `loadGroupData()` dans le catch de `handleTransferAndLeave` pour resync apres echec partiel transfer/leave (network err sur leave laisse user dans groupe sans admin avec UI cassee)
- refresh members via `loadGroupData()` avant decision leave/transfer pour eviter `isLastAdmin` stale (concurrent admin demote silencieux)

## Test plan
- [x] Unit tests GroupDetailsScreen (14/14 passent)
- [x] Suite complete (981/981 passent)
- [x] Lint clean

Closes WHISPR-1417