### PR TITLE
[WHISPR-1420] perf(flatlist): getItemLayout Contacts + Archived

### DIFF
--- a/src/screens/Chat/ArchivedConversationsScreen.tsx
+++ b/src/screens/Chat/ArchivedConversationsScreen.tsx
@@ -50,6 +50,8 @@ type NavigationProp = StackNavigationProp<
 
 const SWIPE_BUTTON_SIZE = 52;
 const SWIPE_BUTTON_GAP = 12;
+// hauteur d'une row ConversationItem - meme valeur que ConversationsListScreen
+const ARCHIVED_ITEM_HEIGHT = 72;
 
 interface SwipeableArchivedItemProps {
   conversation: Conversation;
@@ -203,6 +205,16 @@ export const ArchivedConversationsScreen: React.FC = () => {
 
   const keyExtractor = useCallback((item: Conversation) => item.id, []);
 
+  // hauteur fixe d'une row ConversationItem (cf ConversationsListScreen)
+  const getItemLayout = useCallback(
+    (_data: ArrayLike<Conversation> | null | undefined, index: number) => ({
+      length: ARCHIVED_ITEM_HEIGHT,
+      offset: ARCHIVED_ITEM_HEIGHT * index,
+      index,
+    }),
+    [],
+  );
+
   const renderFooter = () => {
     if (!archived.loadingMore) return null;
     return (
@@ -266,6 +278,7 @@ export const ArchivedConversationsScreen: React.FC = () => {
         data={archived.items}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
+        getItemLayout={getItemLayout}
         contentContainerStyle={[
           styles.listContent,
           { paddingBottom: insets.bottom + 32 },

--- a/src/screens/Contacts/ContactsScreen.tsx
+++ b/src/screens/Contacts/ContactsScreen.tsx
@@ -72,6 +72,9 @@ import { filterAndSortContacts } from "../../utils/contactsFilter";
 
 declare module "@expo/vector-icons";
 
+// hauteur d'une row ContactItem (avatar 52 + padding vertical 14*2 + marginBottom 12)
+const CONTACT_ITEM_HEIGHT = 98;
+
 export const ContactsScreen: React.FC = () => {
   const navigation =
     useNavigation<StackNavigationProp<AuthStackParamList, "Contacts">>();
@@ -289,6 +292,16 @@ export const ContactsScreen: React.FC = () => {
   );
 
   const keyExtractor = useCallback((item: Contact) => item.id, []);
+
+  // hauteur fixe d'une ContactItem (avatar 52 + padding 14*2 + marginBottom 12)
+  const getItemLayout = useCallback(
+    (_data: ArrayLike<Contact> | null | undefined, index: number) => ({
+      length: CONTACT_ITEM_HEIGHT,
+      offset: CONTACT_ITEM_HEIGHT * index,
+      index,
+    }),
+    [],
+  );
 
   return (
     <LinearGradient
@@ -647,6 +660,7 @@ export const ContactsScreen: React.FC = () => {
             data={filteredContacts}
             renderItem={renderContact}
             keyExtractor={keyExtractor}
+            getItemLayout={getItemLayout}
             style={styles.list}
             showsVerticalScrollIndicator={Platform.OS === "web"}
             refreshControl={


### PR DESCRIPTION
## Summary

Ajoute `getItemLayout` sur les FlatLists a hauteur fixe pour eviter le measure de chaque row au scroll (layout thrash).

- ContactsScreen : ContactItem hauteur fixe 98px (avatar 52 + padding 14*2 + marginBottom 12)
- ArchivedConversationsScreen : ConversationItem hauteur fixe 72px (meme valeur que ConversationsListScreen)

ChatScreen messages volontairement skip - rows variables (textes longs, replies, medias).

CallHistoryScreen skip - cards avec metaInfoRow flexWrap, subtitle conditionnel et duration pill optionnelle.

## Test plan

- [x] Unit tests verts (981 passed)
- [x] Lint clean
- [x] tsc --noEmit clean
- [ ] Tested sur iOS simulator
- [ ] Tested sur Android emulator

Closes WHISPR-1420