### PR TITLE
[WHISPR-1423] fix(conversations): Utilisateur fallback chain

### DIFF
--- a/conversationsStore.test.ts
+++ b/conversationsStore.test.ts
@@ -1635,3 +1635,81 @@ describe("conversationsStore — markAsUnread API call (WHISPR-1302)", () => {
     expect(state.manuallyUnreadIds.has("c-fail")).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// enrichSingleConversation — fallback chain (WHISPR-1423)
+// ---------------------------------------------------------------------------
+// le user profile peut etre masque par privacy CONTACTS : display_name vide
+// mais username ou phone_number_masked encore exposes. on doit propager ce
+// qui reste pour eviter "Utilisateur" en clair dans la liste des DM.
+
+describe("conversationsStore — enrichSingleConversation fallback (WHISPR-1423)", () => {
+  beforeEach(() => {
+    mockedTokenService.getAccessToken.mockResolvedValue("fake-token");
+    mockedTokenService.decodeAccessToken.mockReturnValue({ sub: "me" });
+  });
+
+  it("propage username quand display_name est vide", async () => {
+    const conv = makeConv("c-1", {
+      display_name: undefined,
+      avatar_url: undefined,
+    });
+    mockedMessagingAPI.getConversations.mockResolvedValueOnce([conv]);
+    mockedMessagingAPI.getUserInfo.mockResolvedValueOnce({
+      id: "other",
+      display_name: "",
+      username: "ada",
+    });
+
+    await act(async () => {
+      await useConversationsStore.getState().fetchConversations();
+    });
+
+    const stored = useConversationsStore.getState().conversations[0];
+    expect(stored.username).toBe("ada");
+  });
+
+  it("propage phone_number_masked quand display_name et username sont vides", async () => {
+    const conv = makeConv("c-2", {
+      display_name: undefined,
+      avatar_url: undefined,
+    });
+    mockedMessagingAPI.getConversations.mockResolvedValueOnce([conv]);
+    mockedMessagingAPI.getUserInfo.mockResolvedValueOnce({
+      id: "other",
+      display_name: "",
+      username: undefined,
+      phone_number_masked: "+33 6 ** ** 64 12",
+    });
+
+    await act(async () => {
+      await useConversationsStore.getState().fetchConversations();
+    });
+
+    const stored = useConversationsStore.getState().conversations[0];
+    expect(stored.phone_number).toBe("+33 6 ** ** 64 12");
+  });
+
+  it("ne touche pas a la conversation si tout est vide cote profil", async () => {
+    const conv = makeConv("c-3", {
+      display_name: undefined,
+      avatar_url: undefined,
+    });
+    mockedMessagingAPI.getConversations.mockResolvedValueOnce([conv]);
+    mockedMessagingAPI.getUserInfo.mockResolvedValueOnce({
+      id: "other",
+      display_name: "",
+      username: undefined,
+      phone_number_masked: undefined,
+    });
+
+    await act(async () => {
+      await useConversationsStore.getState().fetchConversations();
+    });
+
+    const stored = useConversationsStore.getState().conversations[0];
+    expect(stored.display_name).toBeUndefined();
+    expect(stored.username).toBeUndefined();
+    expect(stored.phone_number).toBeUndefined();
+  });
+});

--- a/getConversationDisplayName.test.ts
+++ b/getConversationDisplayName.test.ts
@@ -1,0 +1,60 @@
+// Tests pour la fallback chain de getConversationDisplayName (WHISPR-1423).
+// le but : eviter d afficher "Utilisateur" en clair quand on a encore un
+// username ou un phone_number_masked a montrer.
+
+import { getConversationDisplayName } from "./src/utils";
+
+describe("getConversationDisplayName — direct conversation fallback chain", () => {
+  it("retourne display_name quand present", () => {
+    expect(
+      getConversationDisplayName({
+        type: "direct",
+        display_name: "Alice Cooper",
+        username: "alice",
+        phone_number: "+33 6 12 34 56 78",
+      }),
+    ).toBe("Alice Cooper");
+  });
+
+  it("retourne @username quand display_name est vide", () => {
+    expect(
+      getConversationDisplayName({
+        type: "direct",
+        display_name: undefined,
+        username: "ada",
+      }),
+    ).toBe("@ada");
+  });
+
+  it("retourne phone_number quand display_name et username sont vides", () => {
+    expect(
+      getConversationDisplayName({
+        type: "direct",
+        display_name: "",
+        username: undefined,
+        phone_number: "+33 6 ** ** 64 12",
+      }),
+    ).toBe("+33 6 ** ** 64 12");
+  });
+
+  it("fallback final reste 'Utilisateur' quand tout est vide", () => {
+    expect(
+      getConversationDisplayName({
+        type: "direct",
+        display_name: undefined,
+        username: undefined,
+        phone_number: undefined,
+      }),
+    ).toBe("Utilisateur");
+  });
+
+  it("ignore display_name qui ressemble a un UUID brut", () => {
+    expect(
+      getConversationDisplayName({
+        type: "direct",
+        display_name: "fab8817a-27a0-4537-89c1-be05f783150b",
+        username: "ada",
+      }),
+    ).toBe("@ada");
+  });
+});

--- a/src/services/messaging/api.ts
+++ b/src/services/messaging/api.ts
@@ -193,6 +193,10 @@ type CachedUserInfo = {
   id: string;
   display_name: string;
   username?: string;
+  // numero masque expose par le backend pour les contacts non-self
+  // (ex: "+33 6 ** ** 64 12") - sert de fallback dans la chaine d'affichage
+  // quand display_name + username sont vides cf WHISPR-1423
+  phone_number_masked?: string;
   avatar_url?: string;
 };
 
@@ -234,8 +238,17 @@ function normalizeRawUserInfo(user: any): CachedUserInfo | null {
   const firstName = user.firstName || user.first_name || "";
   const lastName = user.lastName || user.last_name || "";
   const phoneNumber = user.phoneNumber || user.phone_number || "";
+  // forward-compat avec PR user-service #1430 (champ phoneNumberMasked
+  // expose pour les contacts non-self apres privacy CONTACTS)
+  const phoneNumberMasked =
+    user.phoneNumberMasked || user.phone_number_masked || "";
   const fullName = `${firstName} ${lastName}`.trim();
-  const displayName = fullName || user.username || phoneNumber || "Utilisateur";
+  const displayName =
+    fullName ||
+    user.username ||
+    phoneNumber ||
+    phoneNumberMasked ||
+    "Utilisateur";
   const avatarUrl =
     user.profilePictureUrl ||
     user.profile_picture_url ||
@@ -248,6 +261,7 @@ function normalizeRawUserInfo(user: any): CachedUserInfo | null {
     id,
     display_name: displayName,
     username: user.username,
+    phone_number_masked: phoneNumberMasked || undefined,
     avatar_url: avatarUrl,
   };
 }

--- a/src/store/conversationsStore.ts
+++ b/src/store/conversationsStore.ts
@@ -67,12 +67,21 @@ async function enrichSingleConversation(
     }
 
     const userInfo = await messagingAPI.getUserInfo(otherUserId);
-    if (userInfo?.display_name) {
+    // fallback chain robuste pour eviter "Utilisateur" affiche en clair
+    // quand le profil est masque par privacy CONTACTS (display_name vide
+    // mais username ou phone_number_masked presents) cf WHISPR-1423
+    const userPhoneMasked = (userInfo as any)?.phone_number_masked;
+    if (
+      userInfo?.display_name ||
+      (userInfo as any)?.username ||
+      userPhoneMasked
+    ) {
       return {
         ...conv,
-        display_name: userInfo.display_name,
-        username: (userInfo as any).username ?? conv.username,
-        avatar_url: userInfo.avatar_url || conv.avatar_url,
+        display_name: userInfo?.display_name || conv.display_name,
+        username: (userInfo as any)?.username ?? conv.username,
+        phone_number: userPhoneMasked ?? conv.phone_number,
+        avatar_url: userInfo?.avatar_url || conv.avatar_url,
         member_user_ids: memberIds,
       };
     }


### PR DESCRIPTION
## Summary

- `enrichSingleConversation` propage maintenant `username` et `phone_number_masked` meme quand `display_name` est vide (privacy CONTACTS masque les noms reels mais expose encore ces champs).
- `normalizeRawUserInfo` consomme `phoneNumberMasked` du backend (forward-compat avec PR user-service #1430) et le persiste dans `CachedUserInfo.phone_number_masked`.
- La fallback chain de `getConversationDisplayName` reste intacte : display_name -> @username -> phone_number -> "Utilisateur". On ecrit le masked phone dans `conv.phone_number` cote enrichissement, donc l UI le ramasse via la chaine existante.

## Why

Sur preprod 5 DM affichaient "Utilisateur" car les profils etaient masques par privacy CONTACTS et le mobile ne propageait pas les fallbacks (`username`, `phone_number_masked`) quand `display_name` etait vide.

## Test plan

- [x] `npm test -- --watchAll=false --no-coverage --testPathPattern="getConversationDisplayName|conversationsStore|messagingApi"` -> green (76 + 59)
- [x] `npx tsc --noEmit` -> green
- [x] `npx eslint src/store/conversationsStore.ts src/services/messaging/api.ts src/utils/index.ts` -> 0 erreurs
- [ ] Tester en preprod sur les 5 DM "Utilisateur" apres deploy

Closes WHISPR-1423