### PR TITLE
fix(conversations): bypass sentinel display_name in enrichment guard

### DIFF
--- a/conversationsStore.test.ts
+++ b/conversationsStore.test.ts
@@ -15,6 +15,7 @@ jest.mock("./src/services/messaging/api", () => ({
     getConversation: jest.fn().mockResolvedValue(null),
     getConversationMembers: jest.fn().mockResolvedValue([]),
     getUserInfo: jest.fn().mockResolvedValue(null),
+    getUsersInfoBatch: jest.fn().mockResolvedValue(new Map()),
     deleteConversation: jest.fn().mockResolvedValue(undefined),
     archiveConversation: jest.fn().mockResolvedValue(undefined),
     unarchiveConversation: jest.fn().mockResolvedValue(undefined),
@@ -281,6 +282,7 @@ beforeEach(() => {
     mockedMessagingAPI.getConversations,
     mockedMessagingAPI.getConversation,
     mockedMessagingAPI.getUserInfo,
+    mockedMessagingAPI.getUsersInfoBatch,
     mockedMessagingAPI.deleteConversation,
     mockedMessagingAPI.archiveConversation,
     mockedMessagingAPI.unarchiveConversation,
@@ -304,6 +306,7 @@ beforeEach(() => {
   mockedMessagingAPI.getConversations.mockResolvedValue([]);
   mockedMessagingAPI.getConversation.mockResolvedValue(null);
   mockedMessagingAPI.getUserInfo.mockResolvedValue(null);
+  mockedMessagingAPI.getUsersInfoBatch.mockResolvedValue(new Map());
   mockedMessagingAPI.deleteConversation.mockResolvedValue(undefined);
   mockedMessagingAPI.archiveConversation.mockResolvedValue(undefined);
   mockedMessagingAPI.unarchiveConversation.mockResolvedValue(undefined);
@@ -1711,5 +1714,119 @@ describe("conversationsStore — enrichSingleConversation fallback (WHISPR-1423)
     expect(stored.display_name).toBeUndefined();
     expect(stored.username).toBeUndefined();
     expect(stored.phone_number).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enrichSingleConversation — sentinel bypass (WHISPR-1426)
+// ---------------------------------------------------------------------------
+// Regression : le messaging-service pre-remplit display_name="Utilisateur" et
+// avatar_url avec une valeur non-null. L early-return de enrichSingleConversation
+// voyait (display_name && avatar_url) = truthy et sautait l enrichment entier.
+// Result : l UI affichait "Utilisateur" meme quand getUserInfo retourne un vrai nom.
+
+describe("conversationsStore — enrichSingleConversation sentinel bypass (WHISPR-1426)", () => {
+  beforeEach(() => {
+    mockedTokenService.getAccessToken.mockResolvedValue("fake-token");
+    mockedTokenService.decodeAccessToken.mockReturnValue({ sub: "me" });
+  });
+
+  it('force l enrichment quand display_name="Utilisateur" meme si avatar_url est set', async () => {
+    const conv = makeConv("c-sentinel", {
+      display_name: "Utilisateur",
+      avatar_url: "https://cdn/placeholder.png",
+      member_user_ids: ["other", "me"],
+    });
+    mockedMessagingAPI.getConversations.mockResolvedValueOnce([conv]);
+    mockedMessagingAPI.getUserInfo.mockResolvedValueOnce({
+      id: "other",
+      display_name: "Alice Dupont",
+      username: "alice",
+      avatar_url: "https://cdn/alice.png",
+    });
+
+    await act(async () => {
+      await useConversationsStore.getState().fetchConversations();
+    });
+
+    const stored = useConversationsStore.getState().conversations[0];
+    expect(stored.display_name).toBe("Alice Dupont");
+    expect(stored.avatar_url).toBe("https://cdn/alice.png");
+  });
+
+  it('force l enrichment quand display_name="User" (variante anglaise du sentinel)', async () => {
+    const conv = makeConv("c-sentinel-en", {
+      display_name: "User",
+      avatar_url: "https://cdn/placeholder.png",
+      member_user_ids: ["other", "me"],
+    });
+    mockedMessagingAPI.getConversations.mockResolvedValueOnce([conv]);
+    mockedMessagingAPI.getUserInfo.mockResolvedValueOnce({
+      id: "other",
+      display_name: "Bob Martin",
+      username: "bob",
+      avatar_url: "https://cdn/bob.png",
+    });
+
+    await act(async () => {
+      await useConversationsStore.getState().fetchConversations();
+    });
+
+    const stored = useConversationsStore.getState().conversations[0];
+    expect(stored.display_name).toBe("Bob Martin");
+  });
+
+  it("ne refetche pas une conv deja correctement enrichie (display_name reel + avatar_url)", async () => {
+    const conv = makeConv("c-already-enriched", {
+      display_name: "Charlie Leclerc",
+      avatar_url: "https://cdn/charlie.png",
+      member_user_ids: ["other", "me"],
+    });
+    mockedMessagingAPI.getConversations.mockResolvedValueOnce([conv]);
+
+    await act(async () => {
+      await useConversationsStore.getState().fetchConversations();
+    });
+
+    // getUserInfo ne doit pas etre appele : l early-return doit laisser passer
+    expect(mockedMessagingAPI.getUserInfo).not.toHaveBeenCalled();
+    const stored = useConversationsStore.getState().conversations[0];
+    expect(stored.display_name).toBe("Charlie Leclerc");
+  });
+
+  it('sentinel bypass declenche enrichment via applyConversationSummaries (WS path)', async () => {
+    mockedTokenService.getAccessToken.mockResolvedValue("fake-token");
+    mockedTokenService.decodeAccessToken.mockReturnValue({ sub: "me" });
+    mockedMessagingAPI.getUserInfo.mockResolvedValue({
+      id: "other",
+      display_name: "Diana Prince",
+      username: "diana",
+      avatar_url: "https://cdn/diana.png",
+    });
+
+    act(() => {
+      useConversationsStore.getState().applyConversationSummaries([
+        {
+          id: "c-ws-sentinel",
+          type: "direct",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+          is_active: true,
+          display_name: "Utilisateur",
+          avatar_url: "https://cdn/placeholder.png",
+          member_user_ids: ["other", "me"],
+        } as any,
+      ]);
+    });
+
+    // async enrichment is kicked off — wait for it
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    const stored = useConversationsStore
+      .getState()
+      .conversations.find((c) => c.id === "c-ws-sentinel");
+    expect(stored?.display_name).toBe("Diana Prince");
   });
 });

--- a/conversationsStore.test.ts
+++ b/conversationsStore.test.ts
@@ -1829,4 +1829,58 @@ describe("conversationsStore — enrichSingleConversation sentinel bypass (WHISP
       .conversations.find((c) => c.id === "c-ws-sentinel");
     expect(stored?.display_name).toBe("Diana Prince");
   });
+
+  it('sentinel bypass declenche enrichment via applyConversationUpdate (nouvelle conv avec display_name="Utilisateur")', async () => {
+    mockedTokenService.getAccessToken.mockResolvedValue("fake-token");
+    mockedTokenService.decodeAccessToken.mockReturnValue({ sub: "me" });
+    mockedMessagingAPI.getUserInfo.mockResolvedValue({
+      id: "other",
+      display_name: "Eve Torres",
+      username: "eve",
+      avatar_url: "https://cdn/eve.png",
+    });
+
+    act(() => {
+      useConversationsStore.getState().applyConversationUpdate(
+        makeConv("c-update-sentinel", {
+          display_name: "Utilisateur",
+          avatar_url: "https://cdn/placeholder.png",
+          member_user_ids: ["other", "me"],
+        }),
+      );
+    });
+
+    // async enrichment is kicked off — wait for it
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    const stored = useConversationsStore
+      .getState()
+      .conversations.find((c) => c.id === "c-update-sentinel");
+    expect(stored?.display_name).toBe("Eve Torres");
+  });
+
+  it("enrichWithDisplayNames inclut les convs avec sentinel dans le batch warmup", async () => {
+    const conv = makeConv("c-batch-sentinel", {
+      display_name: "Utilisateur",
+      avatar_url: "https://cdn/placeholder.png",
+      member_user_ids: ["other", "me"],
+    });
+    mockedMessagingAPI.getConversations.mockResolvedValueOnce([conv]);
+    mockedMessagingAPI.getUserInfo.mockResolvedValueOnce({
+      id: "other",
+      display_name: "Frank Castle",
+      username: "frank",
+    });
+
+    await act(async () => {
+      await useConversationsStore.getState().fetchConversations();
+    });
+
+    // getUsersInfoBatch doit avoir ete appele pour le warmup (sentinel = non enrichi)
+    expect(mockedMessagingAPI.getUsersInfoBatch).toHaveBeenCalled();
+    const stored = useConversationsStore.getState().conversations[0];
+    expect(stored.display_name).toBe("Frank Castle");
+  });
 });

--- a/src/store/conversationsStore.ts
+++ b/src/store/conversationsStore.ts
@@ -10,6 +10,20 @@ import { logger } from "../utils/logger";
 // Short grace period: absorbs transient empty fetches (e.g. first WS payload
 // arriving just after an HTTP fetch returns []) without flashing an empty UI.
 const EMPTY_STATE_GRACE_PERIOD_MS = 2_000;
+
+/**
+ * Valeurs sentinelles que le messaging-service injecte quand la resolution du
+ * profil echoue cote backend. Ces valeurs NE doivent PAS bloquer l enrichment
+ * cote frontend - elles doivent etre traitees comme "absent" dans les gardes
+ * early-return de enrichSingleConversation et enrichWithDisplayNames.
+ * cf WHISPR-1426 : "Utilisateur" faux positif bloque l early-return.
+ */
+const SENTINEL_DISPLAY_NAMES = new Set(["Utilisateur", "User"]);
+
+function isEnrichedDisplayName(value: string | undefined | null): boolean {
+  if (!value) return false;
+  return !SENTINEL_DISPLAY_NAMES.has(value.trim());
+}
 const MANUALLY_UNREAD_KEY = "@whispr/manually_unread_ids";
 const RECENT_MESSAGE_IDS_MAX = 50;
 const recentMessageIdsByConversation = new Map<string, string[]>();
@@ -37,7 +51,10 @@ async function enrichSingleConversation(
   conv: Conversation,
   currentUserId: string,
 ): Promise<Conversation> {
-  if (conv.type !== "direct" || (conv.display_name && conv.avatar_url)) {
+  if (
+    conv.type !== "direct" ||
+    (isEnrichedDisplayName(conv.display_name) && conv.avatar_url)
+  ) {
     return conv;
   }
 
@@ -108,7 +125,7 @@ async function enrichWithDisplayNames(
   const otherIdsToWarmup = new Set<string>();
   for (const conv of conversations) {
     if (conv.type !== "direct") continue;
-    if (conv.display_name && conv.avatar_url) continue;
+    if (isEnrichedDisplayName(conv.display_name) && conv.avatar_url) continue;
     const memberIds = conv.member_user_ids;
     if (!memberIds || memberIds.length === 0) continue;
     const other = memberIds.find((id: string) => id && id !== currentUserId);
@@ -326,7 +343,8 @@ export const useConversationsStore = create<
       next = [conversation, ...conversations];
       needsEnrichment =
         conversation.type === "direct" &&
-        (!conversation.display_name || !conversation.avatar_url);
+        (!isEnrichedDisplayName(conversation.display_name) ||
+          !conversation.avatar_url);
     } else {
       // Preserve display_name from existing conversation if the update doesn't include one
       const existing = conversations[index];
@@ -422,7 +440,8 @@ export const useConversationsStore = create<
     // Async enrichment for any conversations without display_name
     const needEnrichment = merged.filter(
       (c: Conversation) =>
-        c.type === "direct" && (!c.display_name || !c.avatar_url),
+        c.type === "direct" &&
+        (!isEnrichedDisplayName(c.display_name) || !c.avatar_url),
     );
     if (needEnrichment.length > 0) {
       getCurrentUserId().then((userId) => {


### PR DESCRIPTION
## Summary

- Le messaging-service pre-remplit `display_name="Utilisateur"` quand son lookup de profil echoue. L early-return `if (display_name && avatar_url)` dans `enrichSingleConversation` voyait cette valeur comme truthy et sautait l enrichment - bloquant l UI sur "Utilisateur" pour toutes les convs dont le backend avait pre-rempli les deux champs.
- Introduit `isEnrichedDisplayName()` avec un Set de valeurs sentinelles (`"Utilisateur"`, `"User"`) traites comme manquants dans tous les gardes early-return du store.
- Corrige 4 sites dans `conversationsStore.ts` : `enrichSingleConversation`, `enrichWithDisplayNames`, `applyConversationSummaries`, `applyConversationUpdate`.

## Test plan

- [x] 993 tests verts (`npm test -- --watchAll=false`)
- [x] 4 nouveaux tests regression WHISPR-1426 ajoutés dans `conversationsStore.test.ts`
- [x] Lint propre (0 erreurs)
- [x] TypeScript `tsc --noEmit` vert (vérifié via pre-push hook)

Closes WHISPR-1426