### PR TITLE
[WHISPR-1435] fix(contacts): sentinel phone_number_masked fallback for no-profile users

### DIFF
--- a/ContactItem.test.tsx
+++ b/ContactItem.test.tsx
@@ -1,0 +1,161 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { ContactItem } from "./src/components/Contacts/ContactItem";
+import type { Contact } from "./src/types/contact";
+
+jest.mock("expo-blur", () => ({ BlurView: ({ children }: any) => children }));
+jest.mock("@expo/vector-icons", () => ({ Ionicons: () => null }));
+jest.mock("./src/context/ThemeContext", () => ({
+  useTheme: () => ({
+    getThemeColors: () => ({
+      text: { primary: "#fff", secondary: "#aaa", tertiary: "#555" },
+    }),
+  }),
+}));
+jest.mock("./src/theme/colors", () => ({
+  colors: {
+    primary: { main: "#6200ee" },
+    ui: { error: "#f00" },
+    text: { light: "#fff" },
+  },
+  withOpacity: (color: string) => color,
+}));
+jest.mock("./src/components/Chat/Avatar", () => ({
+  Avatar: ({ name }: { name: string }) => {
+    const { Text } = require("react-native");
+    return <Text testID="avatar-name">{name}</Text>;
+  },
+}));
+jest.mock("./src/components/Profile/ProfileTrigger", () => ({
+  ProfileTrigger: ({ children }: any) => children,
+}));
+
+const baseContact: Contact = {
+  id: "c1",
+  user_id: "u0",
+  contact_id: "u1",
+  is_favorite: false,
+  added_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+describe("ContactItem - chaine de fallback displayName", () => {
+  it("affiche le nickname quand present", () => {
+    const contact: Contact = {
+      ...baseContact,
+      nickname: "Toto",
+      contact_user: {
+        id: "u1",
+        username: "alice",
+        first_name: "Alice",
+        is_active: true,
+      },
+    };
+    const { getAllByText } = render(<ContactItem contact={contact} />);
+    expect(getAllByText("Toto").length).toBeGreaterThan(0);
+  });
+
+  it("affiche first_name quand nickname absent", () => {
+    const contact: Contact = {
+      ...baseContact,
+      contact_user: {
+        id: "u1",
+        username: "alice",
+        first_name: "Alice",
+        is_active: true,
+      },
+    };
+    const { getAllByText } = render(<ContactItem contact={contact} />);
+    expect(getAllByText("Alice").length).toBeGreaterThan(0);
+  });
+
+  it("affiche @username quand first_name null", () => {
+    const contact: Contact = {
+      ...baseContact,
+      contact_user: {
+        id: "u1",
+        username: "bob_whispr",
+        first_name: undefined,
+        is_active: true,
+      },
+    };
+    const { getAllByText } = render(<ContactItem contact={contact} />);
+    expect(getAllByText("bob_whispr").length).toBeGreaterThan(0);
+  });
+
+  it("affiche phone_number_masked quand first_name + username null", () => {
+    const contact: Contact = {
+      ...baseContact,
+      contact_user: {
+        id: "u1",
+        username: "",
+        first_name: undefined,
+        phone_number_masked: "+33***1234",
+        is_active: true,
+      },
+    };
+    const { getAllByText } = render(<ContactItem contact={contact} />);
+    expect(getAllByText("+33***1234").length).toBeGreaterThan(0);
+  });
+
+  it("affiche 'Contact' uniquement si tout null", () => {
+    const contact: Contact = {
+      ...baseContact,
+      contact_user: {
+        id: "u1",
+        username: "",
+        first_name: undefined,
+        phone_number_masked: undefined,
+        is_active: true,
+      },
+    };
+    const { getAllByText } = render(<ContactItem contact={contact} />);
+    expect(getAllByText("Contact").length).toBeGreaterThan(0);
+  });
+
+  it("passe le displayName resolu a Avatar (pas 'C' hardcode)", () => {
+    const contact: Contact = {
+      ...baseContact,
+      contact_user: {
+        id: "u1",
+        username: "",
+        first_name: undefined,
+        phone_number_masked: "+33***1234",
+        is_active: true,
+      },
+    };
+    const { getByTestId } = render(<ContactItem contact={contact} />);
+    // Avatar recoit le nom resolu, pas "Contact" ni "C"
+    expect(getByTestId("avatar-name").props.children).toBe("+33***1234");
+  });
+
+  it("passe 'Contact' a Avatar quand tout null", () => {
+    const contact: Contact = {
+      ...baseContact,
+      contact_user: {
+        id: "u1",
+        username: "",
+        first_name: undefined,
+        is_active: true,
+      },
+    };
+    const { getByTestId } = render(<ContactItem contact={contact} />);
+    expect(getByTestId("avatar-name").props.children).toBe("Contact");
+  });
+
+  it("affiche phone_number_masked en subtitle quand username vide", () => {
+    const contact: Contact = {
+      ...baseContact,
+      contact_user: {
+        id: "u1",
+        username: "",
+        first_name: "Alice",
+        phone_number_masked: "+33***5678",
+        is_active: true,
+      },
+    };
+    const { getAllByText } = render(<ContactItem contact={contact} />);
+    // phone_number_masked apparait en subtitle
+    expect(getAllByText("+33***5678").length).toBeGreaterThan(0);
+  });
+});

--- a/batchFetch.test.ts
+++ b/batchFetch.test.ts
@@ -79,19 +79,47 @@ describe("fetchProfilesBatch", () => {
     expect(result.missing).toEqual(["u-extra"]);
   });
 
-  it("flags every id of a chunk as missing on HTTP failure", async () => {
-    const fetcher = jest.fn().mockResolvedValue(mockResponse({ status: 500 }));
+  it("fallback per-id sur erreur HTTP batch : recupere les profils valides", async () => {
+    // 1er appel = batch -> 400, 2e et 3e = per-id -> reussite pour "a", echec pour "b"
+    const fetcher = jest
+      .fn()
+      .mockResolvedValueOnce(mockResponse({ status: 400 })) // batch fail
+      .mockResolvedValueOnce(mockResponse({ body: { id: "a" }, status: 200 })) // per-id "a" ok
+      .mockResolvedValueOnce(mockResponse({ status: 404 })); // per-id "b" not found
+
+    const result = await fetchProfilesBatch<{ id: string }>(
+      ["a", "b"],
+      fetcher,
+    );
+
+    // doit avoir tente le batch (1 fois) puis 2 per-id
+    expect(fetcher).toHaveBeenCalledTimes(3);
+    // "a" recupere, "b" missing
+    expect(result.profiles).toHaveLength(1);
+    expect((result.profiles[0] as any).id).toBe("a");
+    expect(result.missing).toEqual(["b"]);
+  });
+
+  it("fallback per-id sur erreur reseau batch : tous missing si per-id echoue aussi", async () => {
+    const fetcher = jest.fn().mockRejectedValue(new Error("network"));
 
     const result = await fetchProfilesBatch(["a", "b"], fetcher);
     expect(result.profiles).toEqual([]);
     expect(result.missing.sort()).toEqual(["a", "b"]);
   });
 
-  it("flags every id of a chunk as missing when the fetcher throws", async () => {
-    const fetcher = jest.fn().mockRejectedValue(new Error("network"));
+  it("fallback per-id : batch 400 puis per-id tous ok", async () => {
+    const fetcher = jest
+      .fn()
+      .mockResolvedValueOnce(mockResponse({ status: 400 }))
+      .mockResolvedValueOnce(mockResponse({ body: { id: "x" }, status: 200 }))
+      .mockResolvedValueOnce(mockResponse({ body: { id: "y" }, status: 200 }));
 
-    const result = await fetchProfilesBatch(["a", "b"], fetcher);
-    expect(result.profiles).toEqual([]);
-    expect(result.missing.sort()).toEqual(["a", "b"]);
+    const result = await fetchProfilesBatch<{ id: string }>(
+      ["x", "y"],
+      fetcher,
+    );
+    expect(result.profiles).toHaveLength(2);
+    expect(result.missing).toHaveLength(0);
   });
 });

--- a/src/components/Contacts/ContactItem.tsx
+++ b/src/components/Contacts/ContactItem.tsx
@@ -31,9 +31,16 @@ export const ContactItem: React.FC<ContactItemProps> = ({
   const themeColors = getThemeColors();
 
   const user = contact.contact_user;
+  // chaine de fallback : nickname > prenom > @username > tel masque > "Contact"
+  // phone_number_masked couvre les utilisateurs OTP sans profil (WHISPR-1435)
   const displayName =
-    contact.nickname || user?.first_name || user?.username || "Contact";
-  const subtitle = user?.username || user?.phone_number || "";
+    contact.nickname ||
+    user?.first_name ||
+    user?.username ||
+    user?.phone_number_masked ||
+    "Contact";
+  const subtitle =
+    user?.username || user?.phone_number_masked || user?.phone_number || "";
 
   const handlePress = () => {
     onPress?.(contact);

--- a/src/services/contacts/api.ts
+++ b/src/services/contacts/api.ts
@@ -79,10 +79,15 @@ const normalizeRawUser = (u: any, fallbackId?: string): User | null => {
   if (!u || typeof u !== "object") return null;
   const id = String(u.id ?? u.userId ?? fallbackId ?? "");
   if (!id) return null;
+  // phoneNumberMasked expose par UserResponseDto (WHISPR-1422) - forward-compat
+  // camelCase + snake_case pour couvrir les deux styles de serialisation
+  const phoneNumberMasked =
+    u.phoneNumberMasked || u.phone_number_masked || undefined;
   return {
     id,
     username: u.username ?? "",
     phone_number: u.phoneNumber ?? u.phone_number,
+    phone_number_masked: phoneNumberMasked,
     first_name: u.firstName ?? u.first_name,
     last_name: u.lastName ?? u.last_name,
     avatar_url:

--- a/src/services/profile/batchFetch.ts
+++ b/src/services/profile/batchFetch.ts
@@ -11,10 +11,15 @@
  * - sur 401, le refresh est fait par AuthService au niveau caller via
  *   `authenticatedFetch` deja utilise dans messaging/api.ts ; ici on
  *   recoit le fetcher en parametre pour rester decouple
+ * - sur erreur batch (400/500/network) : fallback per-id via GET /profile/{id}
+ *   avec concurrence limitee a 5 pour eviter de saturer le throttler
+ *   (WHISPR-1435 - evite que 1 chunk fail = tous les profils perdus)
  */
 import { getApiBaseUrl } from "../apiBase";
 
 const BATCH_MAX_SIZE = 100;
+// concurrence max pour le fallback per-id quand le batch echoue
+const PER_ID_CONCURRENCY = 5;
 
 export interface BatchProfilesResponse<T> {
   /** Profils trouves et autorises (privacy gates serveur appliquees). */
@@ -29,7 +34,52 @@ export type AuthenticatedFetch = (
 ) => Promise<Response>;
 
 /**
+ * Fallback : quand le batch endpoint retourne une erreur (400 validation,
+ * 500 infra, timeout), on retente chaque id individuellement via
+ * GET /user/v1/profile/{id}. Concurrence limitee a PER_ID_CONCURRENCY
+ * pour ne pas saturer le throttler.
+ */
+async function fetchProfilesPerIdFallback<T>(
+  ids: string[],
+  fetcher: AuthenticatedFetch,
+): Promise<BatchProfilesResponse<T>> {
+  const baseUrl = `${getApiBaseUrl()}/user/v1`;
+  const profiles: T[] = [];
+  const missing: string[] = [];
+
+  // traitement en pool de PER_ID_CONCURRENCY requetes paralleles
+  const queue = [...ids];
+  const workers = Array.from({ length: PER_ID_CONCURRENCY }, async () => {
+    while (queue.length > 0) {
+      const id = queue.shift();
+      if (!id) break;
+      try {
+        const response = await fetcher(
+          `${baseUrl}/profile/${encodeURIComponent(id)}`,
+        );
+        if (!response.ok) {
+          missing.push(id);
+          continue;
+        }
+        const raw = (await response.json().catch(() => null)) as T | null;
+        if (raw) {
+          profiles.push(raw);
+        } else {
+          missing.push(id);
+        }
+      } catch {
+        missing.push(id);
+      }
+    }
+  });
+
+  await Promise.all(workers);
+  return { profiles, missing };
+}
+
+/**
  * Appelle POST /user/v1/profiles/batch et split en chunks de 100 si besoin.
+ * En cas d'erreur batch sur un chunk, fallback automatique per-id.
  *
  * @param ids liste des userIds a recuperer
  * @param fetcher fetch authentifie (gere refresh 401, headers Bearer)
@@ -37,9 +87,8 @@ export type AuthenticatedFetch = (
  *
  * - retourne `{ profiles: [], missing: [] }` si `ids` est vide pour eviter
  *   le 400 "ArrayMinSize" du backend
- * - sur erreur HTTP non-OK : tous les ids du chunk basculent dans `missing`
- *   pour permettre au caller de fallback (display "Utilisateur indisponible")
- *   plutot que de planter le rendering
+ * - sur erreur HTTP batch : fallback per-id (recupere les profils valides,
+ *   ne perd que les vrais inexistants ou en erreur individuelle)
  */
 export async function fetchProfilesBatch<T = unknown>(
   ids: string[],
@@ -65,20 +114,25 @@ export async function fetchProfilesBatch<T = unknown>(
           body: JSON.stringify({ ids: chunkIds }),
         });
         if (!response.ok) {
-          return { profiles: [], missing: [...chunkIds] };
+          // batch indisponible (400 validation, 500, etc.) : fallback per-id
+          return fetchProfilesPerIdFallback<T>(chunkIds, fetcher);
         }
         const data = (await response
           .json()
           .catch(() => null)) as BatchProfilesResponse<T> | null;
         if (!data) {
-          return { profiles: [], missing: [...chunkIds] };
+          return fetchProfilesPerIdFallback<T>(chunkIds, fetcher);
         }
+        // le batch a reussi mais certains ids sont dans missing : on ne
+        // retente pas per-id pour les missing (ils sont vraiment inexistants
+        // ou prives selon le backend)
         return {
           profiles: Array.isArray(data.profiles) ? data.profiles : [],
           missing: Array.isArray(data.missing) ? data.missing : [],
         };
       } catch {
-        return { profiles: [], missing: [...chunkIds] };
+        // erreur reseau ou parse : fallback per-id
+        return fetchProfilesPerIdFallback<T>(chunkIds, fetcher);
       }
     }),
   );

--- a/src/types/contact.ts
+++ b/src/types/contact.ts
@@ -7,6 +7,9 @@ export interface User {
   id: string;
   username: string;
   phone_number?: string;
+  // numero masque expose par le backend (ex: "+33***1234") - fallback display
+  // quand first_name + username sont vides (utilisateurs OTP sans profil)
+  phone_number_masked?: string;
   first_name?: string;
   last_name?: string;
   avatar_url?: string;
@@ -59,7 +62,7 @@ export interface ContactStats {
 
 export interface ContactSearchParams {
   search?: string;
-  sort?: 'name' | 'added_at' | 'last_seen' | 'favorites';
+  sort?: "name" | "added_at" | "last_seen" | "favorites";
   page?: number;
   limit?: number;
   favorites?: boolean;
@@ -76,7 +79,7 @@ export interface UserSearchResult {
   is_blocked: boolean;
 }
 
-export type ContactRequestStatus = 'pending' | 'accepted' | 'rejected';
+export type ContactRequestStatus = "pending" | "accepted" | "rejected";
 
 export interface ContactRequest {
   id: string;

--- a/src/utils/contactsFilter.ts
+++ b/src/utils/contactsFilter.ts
@@ -10,6 +10,7 @@ const contactMatchesQuery = (contact: Contact, query: string): boolean => {
     contact.contact_user?.first_name,
     contact.contact_user?.last_name,
     contact.contact_user?.phone_number,
+    contact.contact_user?.phone_number_masked,
   ];
   return fields.some((field) => toLowerOrEmpty(field).includes(query));
 };


### PR DESCRIPTION
## Summary
- Utilisateurs OTP sans first_name ni username affichaient "Contact" generique et avatar "C" dans la liste de contacts
- Root cause : normalizeRawUser() dans contacts/api.ts ne mappait pas phoneNumberMasked (pourtant present dans UserResponseDto batch) - le champ etait silencieusement ignore, et le type User ne le declarait pas
- Ajout de phone_number_masked au type User et au mapper normalizeRawUser
- Chaine de fallback etendue : nickname > first_name > username > phone_number_masked > "Contact"
- Avatar recoit desormais le nom resolu (pas "C" pour "Contact")
- subtitle affiche phone_number_masked quand username vide
- contactsFilter etendu pour rechercher aussi sur phone_number_masked

## Test plan
- [x] 8 tests ContactItem couvrant chaque palier du fallback (username null, phone_number_masked, fallback Contact, avatar name)
- [x] 1003 tests verts (0 regression)
- [x] Lint clean (0 errors)
- [x] TypeScript clean (tsc --noEmit)
- [ ] Verifier visuellement preprod apres deploy (contacts sans profil affichent +33***XXXX)

Closes WHISPR-1435