### PR TITLE
feat(ui): demo polish - skeletons + BellIcon multi-screen

### DIFF
--- a/ContactsScreen.test.tsx
+++ b/ContactsScreen.test.tsx
@@ -93,14 +93,45 @@ jest.mock("./src/components/Contacts/EditContactModal", () => ({
 jest.mock("./src/components/Contacts/SyncContactsModal", () => ({
   SyncContactsModal: () => null,
 }));
+jest.mock("./src/components/Contacts/DeleteContactModal", () => ({
+  DeleteContactModal: () => null,
+}));
+jest.mock("expo-blur", () => ({
+  BlurView: ({ children }: any) => children,
+}));
 jest.mock("./src/theme/colors", () => ({
   colors: {
     background: { gradient: { app: ["#000", "#111"] } },
-    primary: { main: "#6200ee" },
+    primary: { main: "#6200ee", light: "#9c57ff" },
+    secondary: { main: "#ff4882" },
     text: { light: "#fff" },
     ui: { success: "#0f0", error: "#f00" },
   },
   withOpacity: (color: string) => color,
+}));
+jest.mock("./src/components/Chat/SkeletonLoader", () => ({
+  ContactItemSkeleton: () => null,
+  SkeletonLoader: () => null,
+  ConversationSkeleton: () => null,
+  MessageBubbleSkeleton: () => null,
+  InboxItemSkeleton: () => null,
+}));
+const mockBellIcon = jest.fn(() => null);
+jest.mock("./src/components/Common/BellIcon", () => ({
+  BellIcon: (props: any) => mockBellIcon(props),
+}));
+jest.mock("./src/components/Common/InboxPanel", () => ({
+  InboxPanel: () => null,
+}));
+jest.mock("./src/store/inboxStore", () => ({
+  useInboxStore: (sel: any) => sel({ unread_count: 0, hydrate: jest.fn() }),
+}));
+jest.mock("./src/services/contacts/favorites", () => ({
+  getFavoriteIds: jest.fn().mockResolvedValue(new Set()),
+  toggleFavorite: jest.fn().mockResolvedValue(false),
+}));
+jest.mock("./src/utils/contactsFilter", () => ({
+  filterAndSortContacts: (_contacts: any[]) => _contacts,
 }));
 
 const mockedContactsAPI = contactsAPI as jest.Mocked<typeof contactsAPI>;
@@ -109,6 +140,7 @@ const mockedMessagingAPI = messagingAPI as jest.Mocked<typeof messagingAPI>;
 describe("ContactsScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockBellIcon.mockClear();
     mockedContactsAPI.getContacts.mockResolvedValue({ contacts: [] });
     mockedContactsAPI.getContactRequests.mockResolvedValue([]);
   });
@@ -116,6 +148,11 @@ describe("ContactsScreen", () => {
   it("renders contacts header", async () => {
     const { getAllByText } = render(<ContactsScreen />);
     expect(getAllByText("Contacts").length).toBeGreaterThan(0);
+  });
+
+  it("affiche le BellIcon dans le header", () => {
+    render(<ContactsScreen />);
+    expect(mockBellIcon).toHaveBeenCalled();
   });
 
   it("shows empty state when no contacts", async () => {

--- a/SkeletonLoader.test.tsx
+++ b/SkeletonLoader.test.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import {
+  ConversationSkeleton,
+  ContactItemSkeleton,
+  MessageBubbleSkeleton,
+  InboxItemSkeleton,
+} from "./src/components/Chat/SkeletonLoader";
+
+// react-native-reanimated : stub minimal pour les tests
+jest.mock("react-native-reanimated", () => {
+  const { View } = require("react-native");
+  return {
+    __esModule: true,
+    default: { View },
+    useSharedValue: (init: any) => ({ value: init }),
+    useAnimatedStyle: (cb: any) => ({}),
+    withRepeat: (v: any) => v,
+    withTiming: (v: any) => v,
+    Easing: { inOut: () => null, ease: null },
+  };
+});
+
+describe("ConversationSkeleton", () => {
+  it("se monte sans erreur", () => {
+    const { toJSON } = render(<ConversationSkeleton />);
+    expect(toJSON()).not.toBeNull();
+  });
+});
+
+describe("ContactItemSkeleton", () => {
+  it("se monte sans erreur", () => {
+    const { toJSON } = render(<ContactItemSkeleton />);
+    expect(toJSON()).not.toBeNull();
+  });
+});
+
+describe("MessageBubbleSkeleton", () => {
+  it("se monte sans erreur avec align left par defaut", () => {
+    const { toJSON } = render(<MessageBubbleSkeleton />);
+    expect(toJSON()).not.toBeNull();
+  });
+
+  it("se monte sans erreur avec align right", () => {
+    const { toJSON } = render(<MessageBubbleSkeleton align="right" />);
+    expect(toJSON()).not.toBeNull();
+  });
+});
+
+describe("InboxItemSkeleton", () => {
+  it("se monte sans erreur", () => {
+    const { toJSON } = render(<InboxItemSkeleton />);
+    expect(toJSON()).not.toBeNull();
+  });
+});

--- a/src/components/Chat/SkeletonLoader.tsx
+++ b/src/components/Chat/SkeletonLoader.tsx
@@ -1,5 +1,7 @@
 /**
- * SkeletonLoader - Loading skeleton for conversation items
+ * SkeletonLoader - Placeholders animes pour les etats de chargement.
+ * Exports : SkeletonLoader (brique de base), ConversationSkeleton,
+ * ContactItemSkeleton, MessageBubbleSkeleton, InboxItemSkeleton.
  */
 
 import React from "react";
@@ -71,10 +73,71 @@ export const ConversationSkeleton: React.FC = () => {
   );
 };
 
+/** Skeleton d'un item contact : avatar rond + nom + badge optionnel. */
+export const ContactItemSkeleton: React.FC = () => (
+  <View style={styles.contactContainer}>
+    <SkeletonLoader width={52} height={52} borderRadius={26} />
+    <View style={styles.contactContent}>
+      <SkeletonLoader width="55%" height={15} style={styles.nameSkeleton} />
+      <SkeletonLoader width="35%" height={12} />
+    </View>
+    <SkeletonLoader width={24} height={24} borderRadius={12} />
+  </View>
+);
+
+/** Skeleton d'une bulle de message : bulle alignee a gauche ou droite. */
+export const MessageBubbleSkeleton: React.FC<{ align?: "left" | "right" }> = ({
+  align = "left",
+}) => (
+  <View
+    style={[
+      styles.bubbleRow,
+      align === "right" ? styles.bubbleRowRight : styles.bubbleRowLeft,
+    ]}
+  >
+    {align === "left" && (
+      <SkeletonLoader
+        width={32}
+        height={32}
+        borderRadius={16}
+        style={styles.bubbleAvatar}
+      />
+    )}
+    <View style={styles.bubbleLines}>
+      <SkeletonLoader
+        width={align === "right" ? "70%" : "65%"}
+        height={14}
+        borderRadius={10}
+        style={styles.bubbleLine}
+      />
+      <SkeletonLoader
+        width={align === "right" ? "45%" : "50%"}
+        height={14}
+        borderRadius={10}
+      />
+    </View>
+  </View>
+);
+
+/** Skeleton d'un item inbox : avatar + 2 lignes + timestamp. */
+export const InboxItemSkeleton: React.FC = () => (
+  <View style={styles.inboxContainer}>
+    <SkeletonLoader width={44} height={44} borderRadius={22} />
+    <View style={styles.inboxContent}>
+      <View style={styles.inboxTopRow}>
+        <SkeletonLoader width="50%" height={14} style={styles.nameSkeleton} />
+        <SkeletonLoader width={36} height={11} />
+      </View>
+      <SkeletonLoader width="80%" height={12} />
+    </View>
+  </View>
+);
+
 const styles = StyleSheet.create({
   skeleton: {
     backgroundColor: "rgba(255, 255, 255, 0.1)",
   },
+  // ConversationSkeleton
   container: {
     flexDirection: "row",
     alignItems: "center",
@@ -92,5 +155,59 @@ const styles = StyleSheet.create({
   },
   meta: {
     alignItems: "flex-end",
+  },
+  // ContactItemSkeleton
+  contactContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: "rgba(255, 255, 255, 0.08)",
+  },
+  contactContent: {
+    flex: 1,
+    marginLeft: 12,
+  },
+  // MessageBubbleSkeleton
+  bubbleRow: {
+    flexDirection: "row",
+    alignItems: "flex-end",
+    marginVertical: 6,
+    paddingHorizontal: 12,
+  },
+  bubbleRowLeft: {
+    justifyContent: "flex-start",
+  },
+  bubbleRowRight: {
+    justifyContent: "flex-end",
+  },
+  bubbleAvatar: {
+    marginRight: 8,
+  },
+  bubbleLines: {
+    maxWidth: "72%",
+  },
+  bubbleLine: {
+    marginBottom: 6,
+  },
+  // InboxItemSkeleton
+  inboxContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: "rgba(255, 255, 255, 0.08)",
+  },
+  inboxContent: {
+    flex: 1,
+    marginLeft: 12,
+  },
+  inboxTopRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 6,
   },
 });

--- a/src/components/Chat/index.ts
+++ b/src/components/Chat/index.ts
@@ -24,3 +24,10 @@ export { NewConversationModal } from "./NewConversationModal";
 export { CameraCapture } from "./CameraCapture";
 export type { CameraCaptureResult } from "./CameraCapture";
 export { BlockedImageAppealModal } from "./BlockedImageAppealModal";
+export {
+  SkeletonLoader,
+  ConversationSkeleton,
+  ContactItemSkeleton,
+  MessageBubbleSkeleton,
+  InboxItemSkeleton,
+} from "./SkeletonLoader";

--- a/src/components/Common/InboxPanel.tsx
+++ b/src/components/Common/InboxPanel.tsx
@@ -26,6 +26,7 @@ import type { AuthStackParamList } from "../../navigation/AuthNavigator";
 import { useInboxStore } from "../../store/inboxStore";
 import { colors, withOpacity } from "../../theme/colors";
 import { Avatar } from "../Chat/Avatar";
+import { InboxItemSkeleton } from "../Chat/SkeletonLoader";
 import type {
   InboxItem,
   MentionPayload,
@@ -217,13 +218,23 @@ export const InboxPanel: React.FC<InboxPanelProps> = ({ visible, onClose }) => {
   const keyExtractor = useCallback((item: InboxItem) => item.id, []);
 
   const renderFooter = () => {
-    if (!loading) return null;
+    // chargement de page supplementaire (pagination) : spinner discret
+    if (!loading || items.length === 0) return null;
     return (
       <View style={styles.footerLoader}>
         <ActivityIndicator size="small" color={colors.primary.main} />
       </View>
     );
   };
+
+  // chargement initial : afficher des skeletons plutot qu'un spinner centre
+  const renderInitialLoading = () => (
+    <View>
+      {[...Array(5)].map((_, i) => (
+        <InboxItemSkeleton key={i} />
+      ))}
+    </View>
+  );
 
   // Sur web on centre la modal, sur mobile on fait un bottom-sheet 75%
   const isWeb = Platform.OS === "web";
@@ -268,20 +279,24 @@ export const InboxPanel: React.FC<InboxPanelProps> = ({ visible, onClose }) => {
             </TouchableOpacity>
           </View>
 
-          {/* List */}
-          <FlatList
-            data={items}
-            keyExtractor={keyExtractor}
-            renderItem={renderItem}
-            onEndReached={handleLoadMore}
-            onEndReachedThreshold={0.3}
-            ListEmptyComponent={loading ? null : <EmptyState />}
-            ListFooterComponent={renderFooter}
-            contentContainerStyle={
-              items.length === 0 ? styles.listEmpty : undefined
-            }
-            showsVerticalScrollIndicator={false}
-          />
+          {/* List — skeletons sur le premier chargement */}
+          {loading && items.length === 0 ? (
+            renderInitialLoading()
+          ) : (
+            <FlatList
+              data={items}
+              keyExtractor={keyExtractor}
+              renderItem={renderItem}
+              onEndReached={handleLoadMore}
+              onEndReachedThreshold={0.3}
+              ListEmptyComponent={<EmptyState />}
+              ListFooterComponent={renderFooter}
+              contentContainerStyle={
+                items.length === 0 ? styles.listEmpty : undefined
+              }
+              showsVerticalScrollIndicator={false}
+            />
+          )}
 
           {/* Close button web */}
           {isWeb && (

--- a/src/screens/Contacts/ContactsScreen.tsx
+++ b/src/screens/Contacts/ContactsScreen.tsx
@@ -69,6 +69,10 @@ import {
   toggleFavorite,
 } from "../../services/contacts/favorites";
 import { filterAndSortContacts } from "../../utils/contactsFilter";
+import { ContactItemSkeleton } from "../../components/Chat/SkeletonLoader";
+import { BellIcon } from "../../components/Common/BellIcon";
+import { InboxPanel } from "../../components/Common/InboxPanel";
+import { useInboxStore } from "../../store/inboxStore";
 
 declare module "@expo/vector-icons";
 
@@ -98,6 +102,14 @@ export const ContactsScreen: React.FC = () => {
   const userId = rawUserId ?? "";
   const [token, setToken] = useState<string>("");
   const lastRefreshAtRef = useRef<number>(0);
+
+  const inboxUnreadCount = useInboxStore((s) => s.unread_count);
+  const hydrateInbox = useInboxStore((s) => s.hydrate);
+  const [inboxPanelOpen, setInboxPanelOpen] = useState(false);
+
+  useEffect(() => {
+    if (userId) hydrateInbox();
+  }, [userId, hydrateInbox]);
 
   useEffect(() => {
     if (!userId) {
@@ -326,6 +338,10 @@ export const ContactsScreen: React.FC = () => {
                 <Text style={styles.headerSubtitle}>Vos contact Whispr.</Text>
               </View>
               <View style={styles.headerActions}>
+                <BellIcon
+                  unreadCount={inboxUnreadCount}
+                  onPress={() => setInboxPanelOpen(true)}
+                />
                 <TouchableOpacity
                   style={styles.headerIconButton}
                   onPress={() => navigation.navigate("MyQRCode")}
@@ -535,15 +551,8 @@ export const ContactsScreen: React.FC = () => {
         </View>
 
         {/* Contact Requests */}
-        {loadingRequests && pendingRequests.length === 0 ? (
-          <View style={styles.emptyContainer}>
-            <Text
-              style={[styles.emptyText, { color: themeColors.text.secondary }]}
-            >
-              Chargement
-            </Text>
-          </View>
-        ) : pendingRequests.length > 0 ? (
+        {loadingRequests &&
+        pendingRequests.length === 0 ? null : pendingRequests.length > 0 ? (
           <BlurView intensity={34} tint="dark" style={styles.requestsBlur}>
             <View style={styles.requestsContainer}>
               <Text
@@ -625,12 +634,10 @@ export const ContactsScreen: React.FC = () => {
 
         {/* Contacts List */}
         {loading && contacts.length === 0 ? (
-          <View style={styles.emptyContainer}>
-            <Text
-              style={[styles.emptyText, { color: themeColors.text.secondary }]}
-            >
-              Chargement
-            </Text>
+          <View style={styles.skeletonContainer}>
+            {[...Array(6)].map((_, i) => (
+              <ContactItemSkeleton key={i} />
+            ))}
           </View>
         ) : filteredContacts.length === 0 ? (
           <View style={styles.emptyContainer}>
@@ -717,6 +724,11 @@ export const ContactsScreen: React.FC = () => {
           onContactsSynced={loadContacts}
         />
       </SafeAreaView>
+
+      <InboxPanel
+        visible={inboxPanelOpen}
+        onClose={() => setInboxPanelOpen(false)}
+      />
     </LinearGradient>
   );
 };
@@ -861,6 +873,10 @@ const styles = StyleSheet.create({
   },
   listContent: {
     paddingBottom: 16,
+  },
+  skeletonContainer: {
+    flex: 1,
+    paddingTop: 8,
   },
   emptyContainer: {
     flex: 1,


### PR DESCRIPTION
## Summary
- Ajout de 3 nouveaux skeletons : `ContactItemSkeleton`, `MessageBubbleSkeleton`, `InboxItemSkeleton` dans `SkeletonLoader.tsx`
- `ContactsScreen` : remplace le spinner/texte "Chargement" par 6x `ContactItemSkeleton` + ajoute `BellIcon` + `InboxPanel` dans le header (parite avec `ConversationsListScreen`)
- `InboxPanel` : affiche 5x `InboxItemSkeleton` au premier chargement au lieu d'une liste vide

## Test plan
- [x] `npm test -- --watchAll=false` : 1031 tests verts (109 suites)
- [x] Nouveau test `SkeletonLoader.test.tsx` (5 cas : ConversationSkeleton, ContactItemSkeleton, MessageBubbleSkeleton x2, InboxItemSkeleton)
- [x] `ContactsScreen.test.tsx` : assertion que BellIcon est present dans le header
- [x] `npm run lint:fix` clean (0 erreurs, warnings pre-existants)
- [x] `npx prettier --write` : pas de diff residuel
- [x] Aucune modification du `moderation-service`

Closes WHISPR-1445