### PR TITLE
fix(inbox): use singular notification path for nginx routing

### DIFF
--- a/src/services/inboxApi.ts
+++ b/src/services/inboxApi.ts
@@ -1,6 +1,6 @@
 /**
  * API client pour l'inbox de notifications (WHISPR-1437).
- * Endpoint : /notifications/api/v1/inbox
+ * Endpoint : /notification/api/v1/inbox  (singulier — nginx ingress)
  */
 
 import { getApiBaseUrl } from "./apiBase";
@@ -8,7 +8,9 @@ import { TokenService } from "./TokenService";
 import type { InboxResponse, MarkReadResponse } from "../types/inbox";
 
 function getBaseUrl(): string {
-  return `${getApiBaseUrl()}/notifications/api/v1`;
+  // /notification (singulier) — cf nginx ingress notif-service PR #69.
+  // Le pluriel /notifications tombe sur le SPA fallback et retourne du HTML.
+  return `${getApiBaseUrl()}/notification/api/v1`;
 }
 
 async function authHeaders(): Promise<Record<string, string>> {


### PR DESCRIPTION
## Summary
- `inboxApi.ts` : remplace `/notifications/api/v1` (pluriel) par `/notification/api/v1` (singulier)
- Le path pluriel ne matchait pas la route nginx ingress du notif-service (cf PR #69) et retournait le HTML du SPA, parsé silencieusement comme liste vide
- Consequence : le panel inbox etait toujours vide meme avec des donnees backend

## Test plan
- [x] Tests inbox (InboxPanel, inboxStore, BellIcon) : 15 verts
- [x] Lint clean
- [x] Verif route : `GET /notification/api/v1/inbox` retourne 401 JSON (route existe, protegee) vs `/notifications/api/v1/inbox` retournait HTML 200

Demo blocker P0 - Closes WHISPR-1445