### PR TITLE
feat(about): in-app privacy + terms pages and image classifier test entry

### DIFF
--- a/AboutContentScreen.test.tsx
+++ b/AboutContentScreen.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+import { AboutContentScreen } from "./src/screens/Settings/AboutContentScreen";
+
+const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({ navigate: mockNavigate, goBack: mockGoBack }),
+}));
+jest.mock("expo-linear-gradient", () => ({
+  LinearGradient: ({ children }: any) => children,
+}));
+jest.mock("@expo/vector-icons", () => ({ Ionicons: () => null }));
+jest.mock("./src/context/ThemeContext", () => ({
+  useTheme: () => ({
+    getThemeColors: () => ({
+      background: {
+        gradient: ["#000", "#111"],
+        primary: "#000",
+        secondary: "#111",
+        tertiary: "#222",
+      },
+      text: { primary: "#fff", secondary: "#aaa", tertiary: "#555" },
+      primary: "#6200ee",
+      secondary: "#444",
+    }),
+    getFontSize: () => 16,
+    getLocalizedText: (key: string) => key,
+  }),
+}));
+
+describe("AboutContentScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders without crashing", () => {
+    const { getByText } = render(<AboutContentScreen />);
+    expect(getByText("about.title")).toBeTruthy();
+  });
+
+  it("renders the three legal/test buttons + report CTA", () => {
+    const { getByLabelText, getByText } = render(<AboutContentScreen />);
+    expect(getByLabelText("about.privacyPolicy")).toBeTruthy();
+    expect(getByLabelText("about.termsOfUse")).toBeTruthy();
+    expect(getByLabelText("about.testImageAnalysis")).toBeTruthy();
+    expect(getByText("about.reportContent")).toBeTruthy();
+  });
+
+  it("navigates to PrivacyPolicy when the privacy button is pressed", () => {
+    const { getByLabelText } = render(<AboutContentScreen />);
+    fireEvent.press(getByLabelText("about.privacyPolicy"));
+    expect(mockNavigate).toHaveBeenCalledWith("PrivacyPolicy");
+  });
+
+  it("navigates to TermsOfUse when the terms button is pressed", () => {
+    const { getByLabelText } = render(<AboutContentScreen />);
+    fireEvent.press(getByLabelText("about.termsOfUse"));
+    expect(mockNavigate).toHaveBeenCalledWith("TermsOfUse");
+  });
+
+  it("navigates to ModerationTest when the image test button is pressed", () => {
+    const { getByLabelText } = render(<AboutContentScreen />);
+    fireEvent.press(getByLabelText("about.testImageAnalysis"));
+    expect(mockNavigate).toHaveBeenCalledWith("ModerationTest");
+  });
+});

--- a/PrivacyPolicyScreen.test.tsx
+++ b/PrivacyPolicyScreen.test.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { PrivacyPolicyScreen } from "./src/screens/Settings/PrivacyPolicyScreen";
+
+const mockGoBack = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({ navigate: jest.fn(), goBack: mockGoBack }),
+}));
+jest.mock("expo-linear-gradient", () => ({
+  LinearGradient: ({ children }: any) => children,
+}));
+jest.mock("@expo/vector-icons", () => ({ Ionicons: () => null }));
+jest.mock("./src/context/ThemeContext", () => ({
+  useTheme: () => ({
+    getThemeColors: () => ({
+      background: {
+        gradient: ["#000", "#111"],
+        primary: "#000",
+        secondary: "#111",
+        tertiary: "#222",
+      },
+      text: { primary: "#fff", secondary: "#aaa", tertiary: "#555" },
+      primary: "#6200ee",
+      secondary: "#444",
+    }),
+    getFontSize: () => 16,
+    getLocalizedText: (key: string) => key,
+  }),
+}));
+
+describe("PrivacyPolicyScreen", () => {
+  it("renders without crashing and shows the main sections", () => {
+    const { getByText } = render(<PrivacyPolicyScreen />);
+    expect(getByText("about.privacyPolicy")).toBeTruthy();
+    expect(getByText("DONNEES COLLECTEES")).toBeTruthy();
+    expect(getByText("VOS DROITS RGPD")).toBeTruthy();
+  });
+});

--- a/TermsOfUseScreen.test.tsx
+++ b/TermsOfUseScreen.test.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { TermsOfUseScreen } from "./src/screens/Settings/TermsOfUseScreen";
+
+const mockGoBack = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({ navigate: jest.fn(), goBack: mockGoBack }),
+}));
+jest.mock("expo-linear-gradient", () => ({
+  LinearGradient: ({ children }: any) => children,
+}));
+jest.mock("@expo/vector-icons", () => ({ Ionicons: () => null }));
+jest.mock("./src/context/ThemeContext", () => ({
+  useTheme: () => ({
+    getThemeColors: () => ({
+      background: {
+        gradient: ["#000", "#111"],
+        primary: "#000",
+        secondary: "#111",
+        tertiary: "#222",
+      },
+      text: { primary: "#fff", secondary: "#aaa", tertiary: "#555" },
+      primary: "#6200ee",
+      secondary: "#444",
+    }),
+    getFontSize: () => 16,
+    getLocalizedText: (key: string) => key,
+  }),
+}));
+
+describe("TermsOfUseScreen", () => {
+  it("renders without crashing and shows the main sections", () => {
+    const { getByText } = render(<TermsOfUseScreen />);
+    expect(getByText("about.termsOfUse")).toBeTruthy();
+    expect(getByText("ACCEPTATION")).toBeTruthy();
+    expect(getByText("COMPORTEMENT ATTENDU")).toBeTruthy();
+  });
+});

--- a/app.config.js
+++ b/app.config.js
@@ -44,10 +44,6 @@ module.exports = () => ({
   extra: {
     ...base.expo.extra,
     apiBaseUrl: process.env.API_BASE_URL || 'https://whispr.devzeyu.com',
-    legalPrivacyUrl:
-      process.env.EXPO_PUBLIC_LEGAL_PRIVACY_URL || 'https://whispr.example/privacy',
-    legalTermsUrl:
-      process.env.EXPO_PUBLIC_LEGAL_TERMS_URL || 'https://whispr.example/terms',
     appVersion: '1.0.0',
     eas: {
       projectId:

--- a/app.json
+++ b/app.json
@@ -6,8 +6,6 @@
     "version": "1.0.0",
     "extra": {
       "apiBaseUrl": "https://whispr.devzeyu.com",
-      "legalPrivacyUrl": "https://whispr.example/privacy",
-      "legalTermsUrl": "https://whispr.example/terms",
       "appVersion": "1.0.0",
       "eas": {
         "projectId": "203ca2cd-9035-489b-9c0d-ca4a1bfb2d36"

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -835,11 +835,10 @@ const localizedTexts: Record<Language, Record<string, string>> = {
       "Une modération automatique côté serveur peut également être appliquée pour protéger l'intégrité du réseau ; cela ne garantit pas une intervention humaine pour chaque signalement.",
     "about.privacyPolicy": "Politique de confidentialité",
     "about.termsOfUse": "Conditions d'utilisation",
+    "about.testImageAnalysis": "Tester l'analyse d'image",
     "about.reportContent": "Signaler un contenu",
     "about.reportComingSoon":
       "Le flux de signalement sera bientôt disponible. En attendant, utilisez le menu du message lorsque l'option sera proposée.",
-    "about.legalOpenError":
-      "Impossible d'ouvrir le lien. Vérifiez votre connexion ou l'URL configurée.",
 
     // Notifications
     "notif.success": "Succès",
@@ -1167,11 +1166,10 @@ const localizedTexts: Record<Language, Record<string, string>> = {
       "Automatic server-side moderation may also be used to protect the network; this does not guarantee human review for every report.",
     "about.privacyPolicy": "Privacy policy",
     "about.termsOfUse": "Terms of use",
+    "about.testImageAnalysis": "Test image analysis",
     "about.reportContent": "Report content",
     "about.reportComingSoon":
       "The reporting flow is coming soon. Until then, use the message menu when the option is available.",
-    "about.legalOpenError":
-      "Could not open the link. Check your connection or the configured URL.",
 
     // Notifications
     "notif.success": "Success",

--- a/src/navigation/AuthNavigator.tsx
+++ b/src/navigation/AuthNavigator.tsx
@@ -10,6 +10,8 @@ import { MyProfileScreen } from "../screens/Profile/MyProfileScreen";
 import { UserProfileScreen } from "../screens/Profile/UserProfileScreen";
 import { SettingsScreen } from "../screens/Settings/SettingsScreen";
 import { AboutContentScreen } from "../screens/Settings/AboutContentScreen";
+import { PrivacyPolicyScreen } from "../screens/Settings/PrivacyPolicyScreen";
+import { TermsOfUseScreen } from "../screens/Settings/TermsOfUseScreen";
 import { DevicesScreen } from "../screens/Settings/DevicesScreen";
 import { SecurityKeysScreen } from "../screens/Security/SecurityKeysScreen";
 import { TwoFactorAuthScreen } from "../screens/Security/TwoFactorAuthScreen";
@@ -87,6 +89,8 @@ export type AuthStackParamList = {
   UserProfile: { userId: string };
   Settings: undefined;
   AboutContent: undefined;
+  PrivacyPolicy: undefined;
+  TermsOfUse: undefined;
   SecurityKeys: undefined;
   Devices: undefined;
   TwoFactorAuth: undefined;
@@ -342,6 +346,8 @@ export const AuthNavigator: React.FC = () => {
         }}
       />
       <Stack.Screen name="AboutContent" component={AboutContentScreen} />
+      <Stack.Screen name="PrivacyPolicy" component={PrivacyPolicyScreen} />
+      <Stack.Screen name="TermsOfUse" component={TermsOfUseScreen} />
       <Stack.Screen name="SecurityKeys" component={SecurityKeysScreen} />
       <Stack.Screen name="Devices" component={DevicesScreen} />
       <Stack.Screen name="TwoFactorAuth" component={TwoFactorAuthScreen} />
@@ -472,9 +478,7 @@ export const AuthNavigator: React.FC = () => {
       <Stack.Screen name="AppealReview" component={AppealReviewScreen} />
       <Stack.Screen name="UserModeration" component={UserModerationScreen} />
       <Stack.Screen name="SanctionForm" component={SanctionFormScreen} />
-      {__DEV__ && (
-        <Stack.Screen name="ModerationTest" component={ModerationTestScreen} />
-      )}
+      <Stack.Screen name="ModerationTest" component={ModerationTestScreen} />
     </Stack.Navigator>
   );
 };

--- a/src/screens/Settings/AboutContentScreen.tsx
+++ b/src/screens/Settings/AboutContentScreen.tsx
@@ -1,5 +1,5 @@
 /**
- * AboutContentScreen — contenu, sécurité, liens légaux et CTA signalement (WHISPR).
+ * AboutContentScreen — contenu, securite, liens legaux et CTA signalement (WHISPR).
  */
 
 import React, { useCallback } from "react";
@@ -11,61 +11,20 @@ import {
   TouchableOpacity,
   Alert,
   Platform,
-  Linking,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { LinearGradient } from "expo-linear-gradient";
 import { useNavigation } from "@react-navigation/native";
 import type { StackNavigationProp } from "@react-navigation/stack";
-import Constants from "expo-constants";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "../../context/ThemeContext";
 import type { AuthStackParamList } from "../../navigation/AuthNavigator";
-
-type Extra = {
-  legalPrivacyUrl?: string;
-  legalTermsUrl?: string;
-};
-
-function getLegalExtra(): Extra {
-  const e = Constants.expoConfig?.extra as Extra | undefined;
-  return e ?? {};
-}
 
 export const AboutContentScreen: React.FC = () => {
   const navigation = useNavigation<StackNavigationProp<AuthStackParamList>>();
   const insets = useSafeAreaInsets();
   const { getThemeColors, getFontSize, getLocalizedText } = useTheme();
   const themeColors = getThemeColors();
-
-  const openLegalUrl = useCallback(
-    async (url: string | undefined) => {
-      if (!url?.trim()) {
-        Alert.alert(
-          getLocalizedText("notif.error"),
-          getLocalizedText("about.legalOpenError"),
-        );
-        return;
-      }
-      try {
-        const supported = await Linking.canOpenURL(url);
-        if (!supported) {
-          Alert.alert(
-            getLocalizedText("notif.error"),
-            getLocalizedText("about.legalOpenError"),
-          );
-          return;
-        }
-        await Linking.openURL(url);
-      } catch {
-        Alert.alert(
-          getLocalizedText("notif.error"),
-          getLocalizedText("about.legalOpenError"),
-        );
-      }
-    },
-    [getLocalizedText],
-  );
 
   const onReportPress = useCallback(() => {
     if (Platform.OS === "web") {
@@ -78,8 +37,6 @@ export const AboutContentScreen: React.FC = () => {
       [{ text: getLocalizedText("common.ok") }],
     );
   }, [getLocalizedText]);
-
-  const { legalPrivacyUrl, legalTermsUrl } = getLegalExtra();
 
   const bodyStyle = [
     styles.bodyText,
@@ -205,11 +162,12 @@ export const AboutContentScreen: React.FC = () => {
                 borderColor: themeColors.secondary,
               },
             ]}
-            onPress={() => openLegalUrl(legalPrivacyUrl)}
+            onPress={() => navigation.navigate("PrivacyPolicy")}
             accessibilityRole="button"
+            accessibilityLabel={getLocalizedText("about.privacyPolicy")}
           >
             <Ionicons
-              name="open-outline"
+              name="lock-closed-outline"
               size={20}
               color={themeColors.primary}
             />
@@ -234,11 +192,12 @@ export const AboutContentScreen: React.FC = () => {
                 borderColor: themeColors.secondary,
               },
             ]}
-            onPress={() => openLegalUrl(legalTermsUrl)}
+            onPress={() => navigation.navigate("TermsOfUse")}
             accessibilityRole="button"
+            accessibilityLabel={getLocalizedText("about.termsOfUse")}
           >
             <Ionicons
-              name="open-outline"
+              name="document-text-outline"
               size={20}
               color={themeColors.primary}
             />
@@ -252,6 +211,36 @@ export const AboutContentScreen: React.FC = () => {
               ]}
             >
               {getLocalizedText("about.termsOfUse")}
+            </Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[
+              styles.legalButton,
+              {
+                backgroundColor: themeColors.background.secondary,
+                borderColor: themeColors.secondary,
+              },
+            ]}
+            onPress={() => navigation.navigate("ModerationTest")}
+            accessibilityRole="button"
+            accessibilityLabel={getLocalizedText("about.testImageAnalysis")}
+          >
+            <Ionicons
+              name="scan-outline"
+              size={20}
+              color={themeColors.primary}
+            />
+            <Text
+              style={[
+                styles.legalButtonLabel,
+                {
+                  color: themeColors.text.primary,
+                  fontSize: getFontSize("base"),
+                },
+              ]}
+            >
+              {getLocalizedText("about.testImageAnalysis")}
             </Text>
           </TouchableOpacity>
 

--- a/src/screens/Settings/PrivacyPolicyScreen.tsx
+++ b/src/screens/Settings/PrivacyPolicyScreen.tsx
@@ -1,0 +1,165 @@
+/**
+ * PrivacyPolicyScreen — politique de confidentialite affichee in-app.
+ * Pattern visuel aligne sur AboutContentScreen (gradient + header + cards).
+ */
+
+import React from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { LinearGradient } from "expo-linear-gradient";
+import { useNavigation } from "@react-navigation/native";
+import type { StackNavigationProp } from "@react-navigation/stack";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "../../context/ThemeContext";
+import type { AuthStackParamList } from "../../navigation/AuthNavigator";
+
+type Section = {
+  title: string;
+  body: string;
+};
+
+const SECTIONS_FR: Section[] = [
+  {
+    title: "Donnees collectees",
+    body: "Whispr collecte le numero de telephone necessaire a la creation du compte (stocke chiffre cote serveur), un profil minimal (pseudo, avatar optionnel) renseigne par vos soins, et des metadonnees techniques liees aux messages (horodatage, identifiants de conversation, statut de remise). Le contenu des messages texte est chiffre de bout en bout : nos serveurs n'y ont pas acces.",
+  },
+  {
+    title: "Stockage",
+    body: "Les messages sont chiffres bout-en-bout (Signal Protocol) et seul leur enveloppe metadata est conservee cote serveur le temps de la remise. Les medias passent par un stockage temporaire chiffre puis sont effaces apres telechargement par les destinataires. Les profils sont stockes en base de donnees sur notre infrastructure auto-hebergee (Kubernetes sur VPS dedie).",
+  },
+  {
+    title: "Partage",
+    body: "Whispr ne revend ni ne partage vos donnees avec des tiers. Aucun cookie publicitaire, aucun tracker analytics tiers. L'hebergement est assure par notre infrastructure k8s sur VPS personnel ; aucun fournisseur cloud commercial (AWS, GCP, Azure) ne reside dans le flux de donnees.",
+  },
+  {
+    title: "Vos droits RGPD",
+    body: "Vous disposez d'un droit d'acces, de rectification, de suppression et de portabilite sur vos donnees. La suppression de compte (via Reglages > Compte > Supprimer mon compte) efface profil, contacts, sanctions et invalide les sessions. Pour toute demande specifique RGPD ou question, utilisez le menu Signalement ou contactez l'equipe via la page A propos.",
+  },
+  {
+    title: "Mineurs",
+    body: "Whispr n'est pas destine aux mineurs de moins de 13 ans. Si nous detectons qu'un compte appartient a un mineur sans consentement parental, il sera supprime.",
+  },
+  {
+    title: "Modifications",
+    body: "Cette politique peut evoluer pour refleter des changements techniques ou legaux. La version a jour est toujours accessible depuis Reglages > A propos > Politique de confidentialite.",
+  },
+];
+
+export const PrivacyPolicyScreen: React.FC = () => {
+  const navigation = useNavigation<StackNavigationProp<AuthStackParamList>>();
+  const insets = useSafeAreaInsets();
+  const { getThemeColors, getFontSize, getLocalizedText } = useTheme();
+  const themeColors = getThemeColors();
+
+  const bodyStyle = [
+    styles.bodyText,
+    {
+      color: themeColors.text.secondary,
+      fontSize: getFontSize("base"),
+      lineHeight: Math.round(getFontSize("base") * 1.45),
+    },
+  ];
+
+  return (
+    <LinearGradient
+      colors={themeColors.background.gradient}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 1 }}
+      style={styles.container}
+    >
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={[
+          styles.scrollContent,
+          { paddingBottom: 32 + insets.bottom },
+        ]}
+        showsVerticalScrollIndicator={__DEV__}
+      >
+        <View style={[styles.header, { paddingTop: 56 + insets.top }]}>
+          <TouchableOpacity
+            style={styles.backButton}
+            onPress={() => navigation.goBack()}
+            accessibilityRole="button"
+            accessibilityLabel={getLocalizedText("settings.title")}
+          >
+            <Ionicons
+              name="arrow-back"
+              size={24}
+              color={themeColors.text.primary}
+            />
+          </TouchableOpacity>
+          <Text
+            style={[
+              styles.headerTitle,
+              {
+                color: themeColors.text.primary,
+                fontSize: getFontSize("xxl"),
+              },
+            ]}
+          >
+            {getLocalizedText("about.privacyPolicy")}
+          </Text>
+        </View>
+
+        <Text style={[bodyStyle, styles.intro]}>
+          Derniere mise a jour : mai 2026. Whispr est un projet etudiant Epitech
+          : ce service est fourni en l'etat, sans garantie commerciale.
+        </Text>
+
+        {SECTIONS_FR.map((section) => (
+          <View key={section.title} style={styles.section}>
+            <Text
+              style={[
+                styles.sectionTitle,
+                {
+                  color: themeColors.text.primary,
+                  fontSize: getFontSize("sm"),
+                  letterSpacing: 0.8,
+                },
+              ]}
+            >
+              {section.title.toUpperCase()}
+            </Text>
+            <View
+              style={[
+                styles.card,
+                { backgroundColor: themeColors.background.secondary },
+              ]}
+            >
+              <Text style={bodyStyle}>{section.body}</Text>
+            </View>
+          </View>
+        ))}
+      </ScrollView>
+    </LinearGradient>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  scroll: { flex: 1 },
+  scrollContent: { paddingHorizontal: 20 },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 16,
+  },
+  backButton: { marginRight: 12 },
+  headerTitle: { fontWeight: "700", flex: 1 },
+  intro: { marginBottom: 20, fontStyle: "italic" },
+  section: { marginTop: 16 },
+  sectionTitle: { fontWeight: "700", marginBottom: 8 },
+  card: {
+    borderRadius: 14,
+    padding: 18,
+  },
+  bodyText: {},
+});
+
+export default PrivacyPolicyScreen;

--- a/src/screens/Settings/TermsOfUseScreen.tsx
+++ b/src/screens/Settings/TermsOfUseScreen.tsx
@@ -1,0 +1,165 @@
+/**
+ * TermsOfUseScreen — conditions d'utilisation affichees in-app.
+ * Pattern visuel aligne sur AboutContentScreen (gradient + header + cards).
+ */
+
+import React from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { LinearGradient } from "expo-linear-gradient";
+import { useNavigation } from "@react-navigation/native";
+import type { StackNavigationProp } from "@react-navigation/stack";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "../../context/ThemeContext";
+import type { AuthStackParamList } from "../../navigation/AuthNavigator";
+
+type Section = {
+  title: string;
+  body: string;
+};
+
+const SECTIONS_FR: Section[] = [
+  {
+    title: "Acceptation",
+    body: "En creant un compte Whispr et en utilisant l'application, vous acceptez ces conditions. Si vous n'etes pas d'accord avec un point, n'utilisez pas le service. L'inscription vaut acceptation.",
+  },
+  {
+    title: "Compte utilisateur",
+    body: "Un compte est associe a un numero de telephone unique, valide par code OTP. Vous etes responsable de la confiance de vos appareils lies et de la confidentialite de votre cle de recuperation 2FA si activee. Le partage de compte est interdit.",
+  },
+  {
+    title: "Comportement attendu",
+    body: "Sont interdits : spam, harcelement, contenu illegal (notamment CSAM, incitation a la haine, menaces), usurpation d'identite, diffusion non consentie de donnees personnelles. La moderation cote serveur peut analyser les signalements et appliquer des sanctions automatiques ou manuelles.",
+  },
+  {
+    title: "Suspension",
+    body: "Une violation des regles peut entrainer un avertissement, une suspension temporaire, ou une suppression definitive du compte. Vous pouvez contester une sanction via Reglages > Modes & moderation > Mes sanctions, qui ouvre un dossier d'appel revu par l'equipe.",
+  },
+  {
+    title: "Responsabilite",
+    body: 'Whispr est un projet etudiant Epitech fourni en l\'etat ("as is"), sans garantie de disponibilite ni de continuite de service. Nous declinons toute responsabilite pour les pertes de donnees, dommages indirects, ou utilisation faite des messages par leurs destinataires. Vous restez seul responsable du contenu que vous envoyez.',
+  },
+  {
+    title: "Modifications",
+    body: "Ces conditions peuvent etre mises a jour. La version courante est toujours accessible via Reglages > A propos > Conditions d'utilisation. La poursuite d'utilisation apres modification vaut acceptation de la nouvelle version.",
+  },
+];
+
+export const TermsOfUseScreen: React.FC = () => {
+  const navigation = useNavigation<StackNavigationProp<AuthStackParamList>>();
+  const insets = useSafeAreaInsets();
+  const { getThemeColors, getFontSize, getLocalizedText } = useTheme();
+  const themeColors = getThemeColors();
+
+  const bodyStyle = [
+    styles.bodyText,
+    {
+      color: themeColors.text.secondary,
+      fontSize: getFontSize("base"),
+      lineHeight: Math.round(getFontSize("base") * 1.45),
+    },
+  ];
+
+  return (
+    <LinearGradient
+      colors={themeColors.background.gradient}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 1 }}
+      style={styles.container}
+    >
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={[
+          styles.scrollContent,
+          { paddingBottom: 32 + insets.bottom },
+        ]}
+        showsVerticalScrollIndicator={__DEV__}
+      >
+        <View style={[styles.header, { paddingTop: 56 + insets.top }]}>
+          <TouchableOpacity
+            style={styles.backButton}
+            onPress={() => navigation.goBack()}
+            accessibilityRole="button"
+            accessibilityLabel={getLocalizedText("settings.title")}
+          >
+            <Ionicons
+              name="arrow-back"
+              size={24}
+              color={themeColors.text.primary}
+            />
+          </TouchableOpacity>
+          <Text
+            style={[
+              styles.headerTitle,
+              {
+                color: themeColors.text.primary,
+                fontSize: getFontSize("xxl"),
+              },
+            ]}
+          >
+            {getLocalizedText("about.termsOfUse")}
+          </Text>
+        </View>
+
+        <Text style={[bodyStyle, styles.intro]}>
+          Derniere mise a jour : mai 2026. Projet etudiant Epitech, service
+          fourni en l'etat.
+        </Text>
+
+        {SECTIONS_FR.map((section) => (
+          <View key={section.title} style={styles.section}>
+            <Text
+              style={[
+                styles.sectionTitle,
+                {
+                  color: themeColors.text.primary,
+                  fontSize: getFontSize("sm"),
+                  letterSpacing: 0.8,
+                },
+              ]}
+            >
+              {section.title.toUpperCase()}
+            </Text>
+            <View
+              style={[
+                styles.card,
+                { backgroundColor: themeColors.background.secondary },
+              ]}
+            >
+              <Text style={bodyStyle}>{section.body}</Text>
+            </View>
+          </View>
+        ))}
+      </ScrollView>
+    </LinearGradient>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  scroll: { flex: 1 },
+  scrollContent: { paddingHorizontal: 20 },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 16,
+  },
+  backButton: { marginRight: 12 },
+  headerTitle: { fontWeight: "700", flex: 1 },
+  intro: { marginBottom: 20, fontStyle: "italic" },
+  section: { marginTop: 16 },
+  sectionTitle: { fontWeight: "700", marginBottom: 8 },
+  card: {
+    borderRadius: 14,
+    padding: 18,
+  },
+  bodyText: {},
+});
+
+export default TermsOfUseScreen;


### PR DESCRIPTION
## Summary
- Replace broken external Linking buttons on About screen with two new in-app screens (PrivacyPolicy + TermsOfUse) in plain FR.
- Add a third button on About that opens the on-device TFJS image classifier test screen (previously gated behind __DEV__).
- Clean up unused `legalPrivacyUrl` / `legalTermsUrl` extras from app.json + app.config.js and the matching `about.legalOpenError` i18n keys.

## Test plan
- [x] Unit tests added for AboutContent, PrivacyPolicy, TermsOfUse (7 tests, all green)
- [x] tsc --noEmit clean
- [x] eslint clean on touched files (no new warnings)
- [ ] Live preprod: open Reglages > A propos -> 3 buttons navigate to Privacy / Terms / ModerationTest