### PR TITLE
fix(ci): point mobile-app cd preprod bump to infra main branch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -121,7 +121,7 @@ jobs:
         with:
           repository: whispr-messenger/infrastructure
           path: infrastructure
-          ref: ${{ (github.event.workflow_run.head_branch == 'deploy/preprod' || github.ref == 'refs/heads/deploy/preprod') && 'deploy/preprod' || 'main' }}
+          ref: main
           token: ${{ steps.generate_token.outputs.token }}
           fetch-depth: 0
 
@@ -157,7 +157,7 @@ jobs:
           COMMIT_SHA: ${{ steps.validate_commit.outputs.commit_sha }}
           EVENT_NAME: ${{ github.event_name }}
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
-          INFRA_BRANCH: ${{ (github.event.workflow_run.head_branch == 'deploy/preprod' || github.ref == 'refs/heads/deploy/preprod') && 'deploy/preprod' || 'main' }}
+          INFRA_BRANCH: main
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary
- Le workflow CD tentait de checkout et push sur la branche `deploy/preprod` du repo `infrastructure`, qui n'existe pas. Les bumps preprod n'ont jamais fonctionne automatiquement.
- Force `ref` et `INFRA_BRANCH` a `main` (la branche cible reelle des manifests preprod, idem prod).
- Path manifest `infrastructure/k8s/whispr/preprod/mobile-web/deployment.yaml` inchange.

## Test plan
- [x] Diff revu, seul `.github/workflows/cd.yml` change (4 lignes)
- [ ] CI lint workflow vert
- [ ] Prochain merge sur deploy/preprod -> CD bump auto sur infra/main verifie

Closes WHISPR-1459