### PR TITLE
feat(waitlist): Brevo integration, emails et lien Medium

### DIFF
--- a/public/legal/privacy.html
+++ b/public/legal/privacy.html
@@ -834,7 +834,7 @@
     <section id="qui">
       <h2><span class="h2-num">01</span> Qui sommes-nous</h2>
       <p>Whispr est une application mobile de messagerie chiffrée. En tant que responsable du traitement de vos données personnelles, nous nous engageons à les traiter avec transparence et dans le strict respect du RGPD.</p>
-      <p>Contact : <a href="mailto:privacy@whispr.app">privacy@whispr.app</a></p>
+      <p>Contact : <a href="mailto:groupwhispr@gmail.com">groupwhispr@gmail.com</a></p>
     </section>
 
     <section id="collecte">
@@ -985,7 +985,7 @@
         <div class="g-card"><div class="g-label">Opposition</div><p>Vous opposer aux traitements sur intérêt légitime.</p></div>
         <div class="g-card"><div class="g-label">Limitation</div><p>Suspendre un traitement pendant un litige.</p></div>
       </div>
-      <p style="margin-top:18px;">Pour exercer vos droits : <a href="mailto:privacy@whispr.app">privacy@whispr.app</a> — Réponse sous 30 jours ouvrés.</p>
+      <p style="margin-top:18px;">Pour exercer vos droits : <a href="mailto:groupwhispr@gmail.com">groupwhispr@gmail.com</a> — Réponse sous 30 jours ouvrés.</p>
       <p>Vous pouvez aussi déposer une réclamation auprès de la <a href="https://www.cnil.fr" target="_blank" rel="noopener">CNIL</a>.</p>
     </section>
 
@@ -1016,7 +1016,7 @@
       <p class="contact-intro">Une question sur cette politique, vos données ou vos droits ? On vous répond.</p>
       <div class="contact-grid">
 
-        <a href="mailto:privacy@whispr.app" class="contact-card">
+        <a href="mailto:groupwhispr@gmail.com" class="contact-card">
           <div class="contact-card-icon violet">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="rgba(103,116,189,0.9)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
               <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/>
@@ -1024,7 +1024,7 @@
           </div>
           <div class="contact-card-title">Équipe confidentialité</div>
           <div class="contact-card-desc">Questions sur le traitement de vos données, demandes d'accès ou de suppression, exercice de vos droits RGPD.</div>
-          <span class="contact-card-link">privacy@whispr.app →</span>
+          <span class="contact-card-link">groupwhispr@gmail.com →</span>
         </a>
 
         <a href="terms.html" class="contact-card">
@@ -1099,7 +1099,7 @@
     <ul class="footer-links">
       <li><a href="privacy.html">Confidentialité</a></li>
       <li><a href="terms.html">CGU</a></li>
-      <li><a href="mailto:privacy@whispr.app">Contact</a></li>
+      <li><a href="mailto:groupwhispr@gmail.com">Contact</a></li>
     </ul>
   </div>
 </footer>

--- a/public/legal/terms.html
+++ b/public/legal/terms.html
@@ -973,7 +973,7 @@
       <ul>
         <li>Protéger l'accès à votre compte (code PIN, biométrie)</li>
         <li>Ne pas partager votre session avec un tiers</li>
-        <li>Signaler tout accès suspect à <a href="mailto:security@whispr.app">security@whispr.app</a></li>
+        <li>Signaler tout accès suspect à <a href="mailto:groupwhispr@gmail.com">groupwhispr@gmail.com</a></li>
         <li>Ne créer qu'un seul compte personnel</li>
         <li>Fournir des informations exactes à l'inscription</li>
       </ul>
@@ -1067,7 +1067,7 @@
           </div>
         </div>
       </div>
-      <p>Contact : <a href="mailto:moderation@whispr.app">moderation@whispr.app</a></p>
+      <p>Contact : <a href="mailto:groupwhispr@gmail.com">groupwhispr@gmail.com</a></p>
     </section>
 
     <section id="resiliation">
@@ -1125,7 +1125,7 @@
       <p class="contact-intro">Une question, un litige ou un signalement ? On vous répond directement.</p>
       <div class="contact-grid">
 
-        <a href="mailto:hello@whispr.app" class="contact-card">
+        <a href="mailto:groupwhispr@gmail.com" class="contact-card">
           <div class="contact-card-icon coral">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="rgba(254,122,92,0.9)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
               <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/>
@@ -1133,10 +1133,10 @@
           </div>
           <div class="contact-card-title">Nous contacter</div>
           <div class="contact-card-desc">Questions générales, aide à l'utilisation ou toute demande relative aux CGU.</div>
-          <span class="contact-card-link">hello@whispr.app →</span>
+          <span class="contact-card-link">groupwhispr@gmail.com →</span>
         </a>
 
-        <a href="mailto:moderation@whispr.app" class="contact-card">
+        <a href="mailto:groupwhispr@gmail.com" class="contact-card">
           <div class="contact-card-icon violet">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="rgba(103,116,189,0.9)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
               <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
@@ -1144,7 +1144,7 @@
           </div>
           <div class="contact-card-title">Signaler un abus</div>
           <div class="contact-card-desc">Contenu inapproprié, harcèlement ou violation des règles de conduite de la communauté.</div>
-          <span class="contact-card-link">moderation@whispr.app →</span>
+          <span class="contact-card-link">groupwhispr@gmail.com →</span>
         </a>
 
         <a href="privacy.html" class="contact-card">
@@ -1219,7 +1219,7 @@
     <ul class="footer-links">
       <li><a href="privacy.html">Confidentialité</a></li>
       <li><a href="terms.html">CGU</a></li>
-      <li><a href="mailto:hello@whispr.app">Contact</a></li>
+      <li><a href="mailto:groupwhispr@gmail.com">Contact</a></li>
     </ul>
   </div>
 </footer>

--- a/public/waitlist.html
+++ b/public/waitlist.html
@@ -950,7 +950,7 @@
   <div class="social-grid">
 
     <!-- MEDIUM -->
-    <a href="https://medium.com/@whispr" target="_blank" rel="noopener noreferrer"
+    <a href="https://medium.com/@whisprr" target="_blank" rel="noopener noreferrer"
        class="social-card medium-card tilt">
       <div class="card-top">
         <div class="s-icon m">
@@ -1009,7 +1009,7 @@
     <ul class="footer-links">
       <li><a href="legal/privacy.html">Politique de confidentialité</a></li>
       <li><a href="legal/terms.html">Conditions d'utilisation</a></li>
-      <li><a href="mailto:hello@whispr.app">Contact</a></li>
+      <li><a href="mailto:groupwhispr@gmail.com">Contact</a></li>
     </ul>
   </div>
 </footer>
@@ -1140,10 +1140,26 @@ function copyRef(inputId, btnId) {
 }
 
 /* ── FORM SUBMIT ── */
-function handleForm(e, toastId, refBoxId) {
+async function handleForm(e, toastId, refBoxId) {
   e.preventDefault();
   const form = e.target;
   const email = form.querySelector('input[type="email"]').value;
+  const btn = form.querySelector('button[type="submit"]');
+  const originalText = btn.textContent;
+  btn.disabled = true;
+  btn.textContent = '...';
+  try {
+    const res = await fetch('/api/newsletter/subscribe', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email })
+    });
+    if (!res.ok) throw new Error('api_error');
+  } catch (_) {
+    btn.disabled = false;
+    btn.textContent = originalText;
+    return;
+  }
   const toast = document.getElementById(toastId);
   form.style.opacity = '0'; form.style.transition = 'opacity .3s';
   setTimeout(() => {


### PR DESCRIPTION
## Résumé
- Formulaire waitlist branché sur l'endpoint `/api/newsletter/subscribe` (Brevo list #3)
- Gestion d'erreur : bouton ré-activé si l'appel échoue, vérification `res.ok`
- Remplacement de toutes les adresses email par `groupwhispr@gmail.com` (waitlist, CGU, confidentialité)
- Correction du lien Medium vers `@whisprr`
- Barre de progression envoi média (WHISPR-267)

## Test
- [ ] Soumettre un email sur waitlist.html → vérifier dans Brevo > Contacts > Waitlist
- [ ] Vérifier boutons CGU et Confidentialité dans l'app
- [ ] Vérifier affichage du toast de confirmation