### PR TITLE
fix(legal): render iframe on web instead of WebView

### DIFF
--- a/src/screens/Settings/LegalDocumentView.tsx
+++ b/src/screens/Settings/LegalDocumentView.tsx
@@ -1,7 +1,3 @@
-/**
- * In-app WebView for `public/legal/*.html` (privacy, terms).
- */
-
 import React, { useMemo, useState } from "react";
 import {
   View,
@@ -11,7 +7,6 @@ import {
   ActivityIndicator,
   Platform,
 } from "react-native";
-import { WebView } from "react-native-webview";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { LinearGradient } from "expo-linear-gradient";
 import { useNavigation } from "@react-navigation/native";
@@ -40,6 +35,59 @@ export const LegalDocumentView: React.FC<LegalDocumentViewProps> = ({
   const uri = useMemo(() => getLegalDocumentUrl(slug), [slug]);
   const [loading, setLoading] = useState(true);
 
+  const header = (
+    <View style={[styles.header, { paddingTop: 56 + insets.top }]}>
+      <TouchableOpacity
+        style={styles.backButton}
+        onPress={() => navigation.goBack()}
+        accessibilityRole="button"
+        accessibilityLabel={getLocalizedText("settings.title")}
+      >
+        <Ionicons
+          name="arrow-back"
+          size={24}
+          color={themeColors.text.primary}
+        />
+      </TouchableOpacity>
+      <Text
+        style={[
+          styles.headerTitle,
+          { color: themeColors.text.primary, fontSize: getFontSize("xxl") },
+        ]}
+      >
+        {getLocalizedText(titleKey)}
+      </Text>
+    </View>
+  );
+
+  if (Platform.OS === "web") {
+    return (
+      <LinearGradient
+        colors={themeColors.background.gradient}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={styles.container}
+      >
+        {header}
+        <View style={styles.webWrap}>
+          {loading && (
+            <View style={styles.loading}>
+              <ActivityIndicator size="large" color={themeColors.primary} />
+            </View>
+          )}
+          {/* @ts-ignore — iframe is valid in React Native Web */}
+          <iframe
+            src={uri}
+            style={{ flex: 1, width: "100%", height: "100%", border: "none" }}
+            onLoad={() => setLoading(false)}
+          />
+        </View>
+      </LinearGradient>
+    );
+  }
+
+  const { WebView } = require("react-native-webview");
+
   return (
     <LinearGradient
       colors={themeColors.background.gradient}
@@ -47,38 +95,13 @@ export const LegalDocumentView: React.FC<LegalDocumentViewProps> = ({
       end={{ x: 1, y: 1 }}
       style={styles.container}
     >
-      <View style={[styles.header, { paddingTop: 56 + insets.top }]}>
-        <TouchableOpacity
-          style={styles.backButton}
-          onPress={() => navigation.goBack()}
-          accessibilityRole="button"
-          accessibilityLabel={getLocalizedText("settings.title")}
-        >
-          <Ionicons
-            name="arrow-back"
-            size={24}
-            color={themeColors.text.primary}
-          />
-        </TouchableOpacity>
-        <Text
-          style={[
-            styles.headerTitle,
-            {
-              color: themeColors.text.primary,
-              fontSize: getFontSize("xxl"),
-            },
-          ]}
-        >
-          {getLocalizedText(titleKey)}
-        </Text>
-      </View>
-
+      {header}
       <View style={styles.webWrap}>
-        {loading ? (
+        {loading && (
           <View style={styles.loading}>
             <ActivityIndicator size="large" color={themeColors.primary} />
           </View>
-        ) : null}
+        )}
         <WebView
           source={{ uri }}
           style={styles.webview}


### PR DESCRIPTION
## Résumé
- `react-native-webview` ne fonctionne pas sur plateforme web (PWA/browser)
- Les écrans PrivacyPolicy et TermsOfUse affichaient "React Native WebView does not support this platform" sur preprod
- Fix : détection `Platform.OS === "web"` → rendu d'une `<iframe>` à la place
- Sur iOS/Android : aucun changement, WebView natif conservé

## Test
- [ ] `whispr-preprod.roadmvn.com/PrivacyPolicy` affiche la page HTML
- [ ] `whispr-preprod.roadmvn.com/TermsOfUse` affiche la page HTML
- [ ] Sur iOS/Android : comportement inchangé