### PR TITLE
feat(calls): show user-facing feedback for call error states

### DIFF
--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -221,7 +221,7 @@ export const useWebSocket = (options: UseWebSocketOptions) => {
       // WHISPR-1203 : reset() disconnect la Room LiveKit + clear active +
       // clear incoming. setIncoming(null) seul laissait l'autre côté
       // bloqué sur InCallScreen avec micro/caméra encore actifs. On
-      // navigue aussi hors de InCall vers ConversationsList si on y est.
+      // navigue aussi hors de InCall / IncomingCall vers ConversationsList.
       onCallEnded: () => {
         const callId =
           useCallsStore.getState().active?.callId ??
@@ -230,12 +230,23 @@ export const useWebSocket = (options: UseWebSocketOptions) => {
           void systemCallProvider.endCall(callId, 2);
         }
         useCallsStore.getState().reset();
-        if (
-          navigationRef.isReady() &&
-          navigationRef.getCurrentRoute()?.name === "InCall"
-        ) {
-          navigate("ConversationsList");
+        if (navigationRef.isReady()) {
+          const route = navigationRef.getCurrentRoute()?.name;
+          if (route === "InCall" || route === "IncomingCall") {
+            navigate("ConversationsList");
+          }
         }
+      },
+      // call_declined: callee refused — show "Appel refusé" toast to caller
+      // then let InCallScreen handle navigation after the toast.
+      onCallDeclined: () => {
+        useCallsStore.getState().reset();
+        useCallsStore.getState().setCallEndReason("declined");
+      },
+      // call_missed: no answer timeout — show "Pas de réponse" toast to caller.
+      onCallMissed: () => {
+        useCallsStore.getState().reset();
+        useCallsStore.getState().setCallEndReason("missed");
       },
     }),
     [],
@@ -260,6 +271,8 @@ export const useWebSocket = (options: UseWebSocketOptions) => {
     userChannel.off("conversation_archived", userHandlers.onConvArchived);
     userChannel.off("incoming_call", userHandlers.onIncomingCall);
     userChannel.off("call_ended", userHandlers.onCallEnded);
+    userChannel.off("call_declined", userHandlers.onCallDeclined);
+    userChannel.off("call_missed", userHandlers.onCallMissed);
     userChannel.off("inbox:new", userHandlers.onInboxNew);
 
     userChannel.on("new_message", userHandlers.onMsg);
@@ -271,6 +284,8 @@ export const useWebSocket = (options: UseWebSocketOptions) => {
     userChannel.on("conversation_archived", userHandlers.onConvArchived);
     userChannel.on("incoming_call", userHandlers.onIncomingCall);
     userChannel.on("call_ended", userHandlers.onCallEnded);
+    userChannel.on("call_declined", userHandlers.onCallDeclined);
+    userChannel.on("call_missed", userHandlers.onCallMissed);
     userChannel.on("inbox:new", userHandlers.onInboxNew);
 
     return () => {
@@ -283,6 +298,8 @@ export const useWebSocket = (options: UseWebSocketOptions) => {
       userChannel.off("conversation_archived", userHandlers.onConvArchived);
       userChannel.off("incoming_call", userHandlers.onIncomingCall);
       userChannel.off("call_ended", userHandlers.onCallEnded);
+      userChannel.off("call_declined", userHandlers.onCallDeclined);
+      userChannel.off("call_missed", userHandlers.onCallMissed);
       userChannel.off("inbox:new", userHandlers.onInboxNew);
     };
   }, [options.userId, options.token, userHandlers]);

--- a/src/screens/Calls/InCallScreen.tsx
+++ b/src/screens/Calls/InCallScreen.tsx
@@ -1,12 +1,15 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { View, Text, StyleSheet, FlatList } from "react-native";
 import { useNavigation } from "@react-navigation/native";
-import { RoomEvent, type Participant } from "livekit-client";
+import { RoomEvent, DisconnectReason, type Participant } from "livekit-client";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { BlurView } from "expo-blur";
 import { LinearGradient } from "expo-linear-gradient";
 import { Ionicons } from "@expo/vector-icons";
 import { useCallsStore } from "../../store/callsStore";
+import type { CallEndReason } from "../../store/callsStore";
+import Toast from "../../components/Toast/Toast";
+import type { ToastType } from "../../components/Toast/Toast";
 import { callsLiveKit } from "../../services/calls/liveKitProvider";
 import { systemCallProvider } from "../../services/calls/systemCallProvider";
 import { CallParticipantTile } from "../../components/Calls/CallParticipantTile";
@@ -22,9 +25,20 @@ import { TokenService } from "../../services/TokenService";
  * Syncs participants from the LiveKit Room whenever connections or track
  * subscriptions change.
  */
+const CALL_END_REASON_CONFIG: Record<
+  CallEndReason,
+  { message: string; type: ToastType }
+> = {
+  declined: { message: "Appel refusé", type: "warning" },
+  missed: { message: "Pas de réponse", type: "warning" },
+  network_error: { message: "Connexion perdue", type: "error" },
+};
+
 export const InCallScreen: React.FC = () => {
   const active = useCallsStore((s) => s.active);
   const end = useCallsStore((s) => s.end);
+  const callEndReason = useCallsStore((s) => s.callEndReason);
+  const setCallEndReason = useCallsStore((s) => s.setCallEndReason);
   const navigation = useNavigation();
   const insets = useSafeAreaInsets();
   const [participants, setParticipants] = useState<Participant[]>([]);
@@ -34,10 +48,36 @@ export const InCallScreen: React.FC = () => {
   const [now, setNow] = useState(Date.now());
   const [selfDisplayName, setSelfDisplayName] = useState<string>("");
   const [selfAvatarUrl, setSelfAvatarUrl] = useState<string | undefined>();
+  const [toast, setToast] = useState<{
+    visible: boolean;
+    message: string;
+    type: ToastType;
+  }>({ visible: false, message: "", type: "error" });
+
+  useEffect(() => {
+    if (!callEndReason) return;
+    const { message, type } = CALL_END_REASON_CONFIG[callEndReason];
+    setToast({ visible: true, message, type });
+    setCallEndReason(null);
+    const timer = setTimeout(() => {
+      if (navigation.canGoBack()) {
+        navigation.goBack();
+      } else {
+        (navigation as any).navigate("ConversationsList");
+      }
+    }, 3000);
+    return () => clearTimeout(timer);
+  }, [callEndReason]);
 
   useEffect(() => {
     const room = active?.room;
     if (!room) return;
+
+    const onDisconnected = (reason?: DisconnectReason) => {
+      if (reason === DisconnectReason.CLIENT_INITIATED) return;
+      useCallsStore.getState().reset();
+      useCallsStore.getState().setCallEndReason("network_error");
+    };
 
     const sync = () => {
       const remote = Array.from(room.remoteParticipants.values());
@@ -55,6 +95,7 @@ export const InCallScreen: React.FC = () => {
     room.on(RoomEvent.TrackMuted, sync);
     room.on(RoomEvent.TrackUnmuted, sync);
     room.on(RoomEvent.LocalTrackPublished, sync);
+    room.on(RoomEvent.Disconnected, onDisconnected);
 
     return () => {
       room.off(RoomEvent.ParticipantConnected, sync);
@@ -64,6 +105,7 @@ export const InCallScreen: React.FC = () => {
       room.off(RoomEvent.TrackMuted, sync);
       room.off(RoomEvent.TrackUnmuted, sync);
       room.off(RoomEvent.LocalTrackPublished, sync);
+      room.off(RoomEvent.Disconnected, onDisconnected);
     };
   }, [active, connectedAt]);
 
@@ -271,6 +313,13 @@ export const InCallScreen: React.FC = () => {
           onFlip={onFlip}
           onEnd={onEnd}
           bottomInset={insets.bottom}
+        />
+        <Toast
+          visible={toast.visible}
+          message={toast.message}
+          type={toast.type}
+          duration={2800}
+          onHide={() => setToast((t) => ({ ...t, visible: false }))}
         />
       </View>
     </LinearGradient>

--- a/src/screens/Calls/__tests__/InCallScreen.test.tsx
+++ b/src/screens/Calls/__tests__/InCallScreen.test.tsx
@@ -9,12 +9,24 @@ jest.mock("@react-navigation/native", () => ({
 }));
 
 const mockEnd = jest.fn().mockResolvedValue(undefined);
+const mockSetCallEndReason = jest.fn();
 let mockActive: any = null;
+let mockCallEndReason: any = null;
 
 jest.mock("../../../store/callsStore", () => {
   const fn: any = (selector: any) =>
-    selector({ active: mockActive, end: mockEnd });
-  fn.getState = () => ({ active: mockActive, end: mockEnd });
+    selector({
+      active: mockActive,
+      end: mockEnd,
+      callEndReason: mockCallEndReason,
+      setCallEndReason: mockSetCallEndReason,
+    });
+  fn.getState = () => ({
+    active: mockActive,
+    end: mockEnd,
+    callEndReason: mockCallEndReason,
+    setCallEndReason: mockSetCallEndReason,
+  });
   return { useCallsStore: fn };
 });
 
@@ -35,6 +47,10 @@ jest.mock("livekit-client", () => ({
     TrackMuted: "trackMuted",
     TrackUnmuted: "trackUnmuted",
     LocalTrackPublished: "localTrackPublished",
+    Disconnected: "disconnected",
+  },
+  DisconnectReason: {
+    CLIENT_INITIATED: 1,
   },
 }));
 
@@ -46,12 +62,18 @@ jest.mock("../../../components/Calls/CallControls", () => ({
   CallControls: () => null,
 }));
 
+jest.mock("../../../components/Toast/Toast", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
 import { InCallScreen } from "../InCallScreen";
 
 describe("InCallScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockActive = null;
+    mockCallEndReason = null;
   });
 
   it("matches snapshot when no active call", () => {
@@ -81,9 +103,9 @@ describe("InCallScreen", () => {
     };
     mockActive = { callId: "c1", status: "connected", room };
     const { unmount } = render(<InCallScreen />);
-    expect(room.on).toHaveBeenCalledTimes(7);
+    expect(room.on).toHaveBeenCalledTimes(8);
     unmount();
-    expect(room.off).toHaveBeenCalledTimes(7);
+    expect(room.off).toHaveBeenCalledTimes(8);
   });
 
   it("ends the active call on unmount when user navigates away mid-call", () => {

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -2237,7 +2237,11 @@ export const ChatScreen: React.FC = () => {
         }
         navigation.navigate("InCall");
       } catch (err) {
-        console.error("Failed to initiate call", err);
+        setCallsToast({
+          visible: true,
+          message: "Impossible de démarrer l'appel. Vérifiez votre connexion.",
+          type: "error",
+        });
       }
     },
     [

--- a/src/store/callsStore.ts
+++ b/src/store/callsStore.ts
@@ -39,9 +39,12 @@ export interface IncomingCallInfo {
   avatarUrl?: string;
 }
 
+export type CallEndReason = "declined" | "missed" | "network_error";
+
 interface CallsState {
   active: ActiveCall | null;
   incoming: IncomingCallInfo | null;
+  callEndReason: CallEndReason | null;
   initiate: (
     conversationId: string,
     type: CallType,
@@ -53,12 +56,14 @@ interface CallsState {
   declineIncoming: () => Promise<void>;
   end: () => Promise<void>;
   setIncoming: (incoming: IncomingCallInfo | null) => void;
+  setCallEndReason: (reason: CallEndReason | null) => void;
   reset: () => void;
 }
 
 export const useCallsStore = create<CallsState>((set, get) => ({
   active: null,
   incoming: null,
+  callEndReason: null,
 
   initiate: async (
     conversationId,
@@ -162,6 +167,8 @@ export const useCallsStore = create<CallsState>((set, get) => ({
 
   setIncoming: (incoming) => set({ incoming }),
 
+  setCallEndReason: (reason) => set({ callEndReason: reason }),
+
   // WHISPR-1198: appelé par AuthContext.signOut pour empêcher l'état d'appel
   // (token LiveKit, callId, ringer fantôme) de fuir d'un compte vers le
   // suivant sur le même device. Best-effort sur la déconnexion LiveKit : la
@@ -175,6 +182,6 @@ export const useCallsStore = create<CallsState>((set, get) => ({
         // ignore — best-effort cleanup pendant le signOut
       }
     }
-    set({ active: null, incoming: null });
+    set({ active: null, incoming: null, callEndReason: null });
   },
 }));


### PR DESCRIPTION
## Summary
- Affiche un toast **\"Appel refusé\"** quand le destinataire refuse l'appel
- Affiche un toast **\"Pas de réponse\"** en cas de timeout sans réponse
- Affiche **\"Connexion perdue\"** si LiveKit se déconnecte de façon inattendue pendant l'appel
- Affiche **\"Impossible de démarrer l'appel\"** si l'initiation échoue côté réseau
- Corrige `call_ended` : navigue aussi depuis `IncomingCall` (pas seulement `InCall`)

## Test plan
- [ ] Tests unitaires verts (148/149 suites — SafariPWABanner pre-existing failure)
- [ ] Lint clean (0 erreurs)
- [ ] Tester sur simulateur iOS : appel refusé → toast + retour conversation
- [ ] Tester sur simulateur iOS : coupure réseau en appel → toast "Connexion perdue"
- [ ] Tester sur simulateur iOS : erreur réseau au démarrage → toast dans ChatScreen

Closes WHISPR-281