### PR TITLE
feat(tour): add contextual product tour across 5 screens

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -43,7 +43,7 @@ module.exports = () => ({
   },
   extra: {
     ...base.expo.extra,
-    apiBaseUrl: process.env.API_BASE_URL || 'https://whispr.devzeyu.com',
+    apiBaseUrl: process.env.API_BASE_URL || 'https://whispr-preprod.roadmvn.com',
     appVersion: '1.0.0',
     eas: {
       projectId:

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "react-native-reanimated": "4.1.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
+        "react-native-spotlight-tour": "^4.0.0",
         "react-native-svg": "15.12.1",
         "react-native-web": "^0.21.2",
         "react-native-webview": "13.15.0",
@@ -2383,6 +2384,19 @@
       "dependencies": {
         "@floating-ui/core": "^1.7.3",
         "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/react-native": {
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-native/-/react-native-0.10.9.tgz",
+      "integrity": "sha512-8lLF/hrfCLPSeMljMbFi/cxVjtFTZyg1XHFiuZtXirbBiEfTvCgD0a1YUo2fpG4wa9Fa8Nz4HSq4TmdV+JuxwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-native": ">=0.64.0"
       }
     },
     "node_modules/@floating-ui/utils": {
@@ -14698,6 +14712,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/react-native-responsive-dimensions": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-native-responsive-dimensions/-/react-native-responsive-dimensions-3.1.1.tgz",
+      "integrity": "sha512-Vo2OhWsphq0HgKsmeZOeyW+c+vsFn1ZaCFkGDgdeCEEiLriT76jGA1JlUjtrj27hvyo/xzeTlBZ+vBso1A84fw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-native": ">=0.44.1"
+      }
+    },
     "node_modules/react-native-safe-area-context": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
@@ -14721,6 +14744,40 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-spotlight-tour": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-spotlight-tour/-/react-native-spotlight-tour-4.0.0.tgz",
+      "integrity": "sha512-mrbIbOvA9YnalIQLyHVHgtpYXodYsigf69MOtE7thw+MwyC8HZkgZYf9eXDasYJi7R4QlVBK6ix3rdMnExdm7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-native": "^0.10.7",
+        "react-fast-compare": "^3.2.2",
+        "react-native-responsive-dimensions": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
+        "react-native": ">=0.50.0",
+        "react-native-svg": ">=12.1.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": false
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": false
+        },
+        "react-native-svg": {
+          "optional": false
+        }
       }
     },
     "node_modules/react-native-svg": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "react-native-reanimated": "4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
+    "react-native-spotlight-tour": "^4.0.0",
     "react-native-svg": "15.12.1",
     "react-native-web": "^0.21.2",
     "react-native-webview": "13.15.0",

--- a/src/components/Tour/TourAutoStart.tsx
+++ b/src/components/Tour/TourAutoStart.tsx
@@ -1,0 +1,19 @@
+import React, { useCallback } from "react";
+import { useFocusEffect } from "@react-navigation/native";
+import { useSpotlightTour } from "react-native-spotlight-tour";
+import { useTour } from "../../context/TourContext";
+
+export const TourAutoStart: React.FC = () => {
+  const { start } = useSpotlightTour();
+  const { isTourActive } = useTour();
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!isTourActive) return;
+      const timer = setTimeout(start, 700);
+      return () => clearTimeout(timer);
+    }, [isTourActive, start]),
+  );
+
+  return null;
+};

--- a/src/components/Tour/TourTooltip.tsx
+++ b/src/components/Tour/TourTooltip.tsx
@@ -8,6 +8,7 @@ import {
 } from "react-native";
 import { BlurView } from "expo-blur";
 import { Ionicons } from "@expo/vector-icons";
+import { useSpotlightTour } from "react-native-spotlight-tour";
 import type { RenderProps } from "react-native-spotlight-tour";
 import { useTour } from "../../context/TourContext";
 import { colors } from "../../theme/colors";
@@ -27,9 +28,9 @@ export const TourTooltip: React.FC<TourTooltipProps> = ({
   current,
   isLast,
   next,
-  stop,
   total,
 }) => {
+  const { stop } = useSpotlightTour();
   const { skipTour } = useTour();
 
   const handleSkip = () => {
@@ -99,11 +100,11 @@ const styles = StyleSheet.create({
     minWidth: 260,
     maxWidth: 300,
     borderWidth: 1,
-    borderColor: "rgba(254,122,92,0.22)",
+    borderColor: "rgba(254,122,92,0.40)",
   },
   container: {
     padding: 18,
-    backgroundColor: "rgba(11,17,36,0.55)",
+    backgroundColor: "rgba(26,14,60,0.88)",
     borderRadius: 20,
   },
   header: {
@@ -129,13 +130,15 @@ const styles = StyleSheet.create({
     fontFamily: "Inter_600SemiBold",
   },
   counter: {
-    backgroundColor: "rgba(255,255,255,0.08)",
+    backgroundColor: "rgba(103,116,189,0.25)",
     paddingHorizontal: 8,
     paddingVertical: 3,
     borderRadius: 99,
+    borderWidth: 1,
+    borderColor: "rgba(103,116,189,0.35)",
   },
   counterText: {
-    color: "rgba(255,255,255,0.55)",
+    color: "rgba(255,255,255,0.75)",
     fontSize: 11,
     fontFamily: "Inter_500Medium",
   },
@@ -153,7 +156,7 @@ const styles = StyleSheet.create({
   },
   divider: {
     height: 1,
-    backgroundColor: "rgba(254,122,92,0.18)",
+    backgroundColor: "rgba(103,116,189,0.30)",
     marginVertical: 14,
   },
   actions: {
@@ -166,7 +169,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
   },
   skipText: {
-    color: "rgba(255,255,255,0.45)",
+    color: "rgba(255,255,255,0.60)",
     fontSize: 13,
     fontFamily: "Inter_500Medium",
   },

--- a/src/components/Tour/TourTooltip.tsx
+++ b/src/components/Tour/TourTooltip.tsx
@@ -1,0 +1,186 @@
+import React from "react";
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  Platform,
+} from "react-native";
+import { BlurView } from "expo-blur";
+import { Ionicons } from "@expo/vector-icons";
+import type { RenderProps } from "react-native-spotlight-tour";
+import { useTour } from "../../context/TourContext";
+import { colors } from "../../theme/colors";
+
+const CORAL = colors.primary.main;
+const NAVY = "#0B1124";
+
+interface TourTooltipProps extends RenderProps {
+  title: string;
+  description: string;
+  total: number;
+}
+
+export const TourTooltip: React.FC<TourTooltipProps> = ({
+  title,
+  description,
+  current,
+  isLast,
+  next,
+  stop,
+  total,
+}) => {
+  const { skipTour } = useTour();
+
+  const handleSkip = () => {
+    stop();
+    skipTour();
+  };
+
+  const handleNext = () => {
+    if (isLast) {
+      stop();
+    } else {
+      next();
+    }
+  };
+
+  return (
+    <BlurView
+      intensity={Platform.OS === "ios" ? 60 : 80}
+      tint="dark"
+      style={styles.blur}
+    >
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <View style={styles.badge}>
+            <Ionicons name="compass-outline" size={13} color={CORAL} />
+            <Text style={styles.badgeText}>Tour guidé</Text>
+          </View>
+          <View style={styles.counter}>
+            <Text style={styles.counterText}>
+              {current + 1} / {total}
+            </Text>
+          </View>
+        </View>
+
+        <Text style={styles.title}>{title}</Text>
+        <Text style={styles.description}>{description}</Text>
+
+        <View style={styles.divider} />
+
+        <View style={styles.actions}>
+          <TouchableOpacity onPress={handleSkip} style={styles.skipBtn}>
+            <Text style={styles.skipText}>Passer</Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={handleNext} style={styles.nextBtn}>
+            <Text style={styles.nextText}>
+              {isLast ? "Terminer" : "Suivant"}
+            </Text>
+            {!isLast && (
+              <Ionicons
+                name="arrow-forward"
+                size={14}
+                color={NAVY}
+                style={{ marginLeft: 4 }}
+              />
+            )}
+          </TouchableOpacity>
+        </View>
+      </View>
+    </BlurView>
+  );
+};
+
+const styles = StyleSheet.create({
+  blur: {
+    borderRadius: 20,
+    overflow: "hidden",
+    minWidth: 260,
+    maxWidth: 300,
+    borderWidth: 1,
+    borderColor: "rgba(254,122,92,0.22)",
+  },
+  container: {
+    padding: 18,
+    backgroundColor: "rgba(11,17,36,0.55)",
+    borderRadius: 20,
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 12,
+  },
+  badge: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 5,
+    backgroundColor: "rgba(254,122,92,0.12)",
+    borderWidth: 1,
+    borderColor: "rgba(254,122,92,0.28)",
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 99,
+  },
+  badgeText: {
+    color: CORAL,
+    fontSize: 11,
+    fontFamily: "Inter_600SemiBold",
+  },
+  counter: {
+    backgroundColor: "rgba(255,255,255,0.08)",
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 99,
+  },
+  counterText: {
+    color: "rgba(255,255,255,0.55)",
+    fontSize: 11,
+    fontFamily: "Inter_500Medium",
+  },
+  title: {
+    color: "#fff",
+    fontSize: 16,
+    fontFamily: "Inter_700Bold",
+    marginBottom: 6,
+  },
+  description: {
+    color: "rgba(255,255,255,0.72)",
+    fontSize: 13,
+    fontFamily: "Inter_400Regular",
+    lineHeight: 19,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: "rgba(254,122,92,0.18)",
+    marginVertical: 14,
+  },
+  actions: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  skipBtn: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+  },
+  skipText: {
+    color: "rgba(255,255,255,0.45)",
+    fontSize: 13,
+    fontFamily: "Inter_500Medium",
+  },
+  nextBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: CORAL,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    borderRadius: 99,
+  },
+  nextText: {
+    color: NAVY,
+    fontSize: 13,
+    fontFamily: "Inter_700Bold",
+  },
+});

--- a/src/context/TourContext.tsx
+++ b/src/context/TourContext.tsx
@@ -1,0 +1,45 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const TOUR_DONE_KEY = "whispr_tour_done";
+
+type TourContextType = {
+  isTourActive: boolean;
+  skipTour: () => void;
+};
+
+const TourContext = createContext<TourContextType>({
+  isTourActive: false,
+  skipTour: () => {},
+});
+
+export const TourProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [isTourActive, setIsTourActive] = useState(false);
+
+  useEffect(() => {
+    AsyncStorage.getItem(TOUR_DONE_KEY).then((v) => {
+      setIsTourActive(v !== "1");
+    });
+  }, []);
+
+  const skipTour = useCallback(() => {
+    setIsTourActive(false);
+    AsyncStorage.setItem(TOUR_DONE_KEY, "1");
+  }, []);
+
+  return (
+    <TourContext.Provider value={{ isTourActive, skipTour }}>
+      {children}
+    </TourContext.Provider>
+  );
+};
+
+export const useTour = () => useContext(TourContext);

--- a/src/context/TourContext.tsx
+++ b/src/context/TourContext.tsx
@@ -25,9 +25,12 @@ export const TourProvider: React.FC<{ children: React.ReactNode }> = ({
   const [isTourActive, setIsTourActive] = useState(false);
 
   useEffect(() => {
-    AsyncStorage.getItem(TOUR_DONE_KEY).then((v) => {
+    const load = async () => {
+      if (__DEV__) await AsyncStorage.removeItem(TOUR_DONE_KEY);
+      const v = await AsyncStorage.getItem(TOUR_DONE_KEY);
       setIsTourActive(v !== "1");
-    });
+    };
+    load();
   }, []);
 
   const skipTour = useCallback(() => {

--- a/src/navigation/AuthNavigator.tsx
+++ b/src/navigation/AuthNavigator.tsx
@@ -57,6 +57,7 @@ import { profileSetupFlag } from "../services/profileSetupFlag";
 import { SplashScreen } from "../screens/SplashScreen/SplashScreen";
 import { OnboardingScreen } from "../screens/Auth/OnboardingScreen";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { TourProvider } from "../context/TourContext";
 import { contactsAPI } from "../services/contacts/api";
 import { TokenService } from "../services/TokenService";
 import { UserService } from "../services/UserService";
@@ -331,78 +332,16 @@ export const AuthNavigator: React.FC = () => {
       : "ConversationsList";
 
   return (
-    <Stack.Navigator
-      initialRouteName={initialRouteName}
-      screenOptions={{
-        headerShown: false,
-        gestureEnabled: true,
-        gestureDirection: "horizontal",
-        cardStyle: {
-          backgroundColor: "transparent",
-        },
-        cardStyleInterpolator: ({ current, layouts }) => ({
+    <TourProvider>
+      <Stack.Navigator
+        initialRouteName={initialRouteName}
+        screenOptions={{
+          headerShown: false,
+          gestureEnabled: true,
+          gestureDirection: "horizontal",
           cardStyle: {
             backgroundColor: "transparent",
-            transform: [
-              {
-                translateX: current.progress.interpolate({
-                  inputRange: [0, 1],
-                  outputRange: [layouts.screen.width, 0],
-                }),
-              },
-            ],
           },
-        }),
-      }}
-    >
-      <Stack.Screen
-        name="Onboarding"
-        component={OnboardingScreen}
-        options={{ gestureEnabled: false }}
-      />
-      <Stack.Screen name="Welcome" component={WelcomeScreen} />
-      <Stack.Screen name="PhoneInput" component={PhoneInputScreen} />
-      <Stack.Screen name="Otp" component={OtpScreen} />
-      <Stack.Screen name="ProfileSetup" component={ProfileSetupScreen} />
-      <Stack.Screen name="MyProfile" component={MyProfileScreen} />
-      <Stack.Screen name="UserProfile" component={UserProfileScreen} />
-      <Stack.Screen
-        name="Settings"
-        component={SettingsScreen}
-        options={{
-          // Le swipe-back horizontal capturait les gestes verticaux sur iOS ; le retour reste via la flèche.
-          gestureEnabled: false,
-        }}
-      />
-      <Stack.Screen name="AboutContent" component={AboutContentScreen} />
-      <Stack.Screen name="PrivacyPolicy" component={PrivacyPolicyScreen} />
-      <Stack.Screen name="TermsOfUse" component={TermsOfUseScreen} />
-      <Stack.Screen name="SecurityKeys" component={SecurityKeysScreen} />
-      <Stack.Screen name="Devices" component={DevicesScreen} />
-      <Stack.Screen name="TwoFactorAuth" component={TwoFactorAuthScreen} />
-      <Stack.Screen
-        name="TwoFactorSetup"
-        component={TwoFactorSetupScreen}
-        options={{ gestureEnabled: false }}
-      />
-      <Stack.Screen
-        name="TwoFactorVerify"
-        component={TwoFactorVerifyScreen}
-        options={{ gestureEnabled: false }}
-      />
-      <Stack.Screen
-        name="TwoFactorBackupCodes"
-        component={TwoFactorBackupCodesScreen}
-        options={{ gestureEnabled: false }}
-      />
-      <Stack.Screen
-        name="ConversationsList"
-        component={ConversationsListScreen}
-      />
-      <Stack.Screen
-        name="ArchivedConversations"
-        component={ArchivedConversationsScreen}
-        options={{
           cardStyleInterpolator: ({ current, layouts }) => ({
             cardStyle: {
               backgroundColor: "transparent",
@@ -417,98 +356,167 @@ export const AuthNavigator: React.FC = () => {
             },
           }),
         }}
-      />
-      <Stack.Screen name="Chat" component={ChatScreen} />
-      <Stack.Screen name="Contacts" component={ContactsScreen} />
-      <Stack.Screen name="MyQRCode" component={MyQRCodeScreen} />
-      <Stack.Screen
-        name="QRCodeScanner"
-        getComponent={() =>
-          require("../screens/Contacts/QRCodeScannerScreen").QRCodeScannerScreen
-        }
-      />
-      <Stack.Screen name="BlockedUsers" component={BlockedUsersScreen} />
-      <Stack.Screen name="GroupDetails" component={GroupDetailsScreen} />
-      <Stack.Screen name="GroupManagement" component={GroupManagementScreen} />
-      <Stack.Screen
-        name="ScheduledMessages"
-        component={ScheduledMessagesScreen}
-      />
-      <Stack.Screen
-        name="Calls"
-        getComponent={() =>
-          hasCallsSupport
-            ? require("../screens/Calls/CallsScreen").CallsScreen
-            : CallsUnavailableScreen
-        }
-      />
-      <Stack.Screen
-        name="IncomingCall"
-        getComponent={() =>
-          hasCallsSupport
-            ? require("../screens/Calls/IncomingCallScreen").IncomingCallScreen
-            : CallsUnavailableScreen
-        }
-        options={{
-          presentation: "modal",
-          headerShown: false,
-          gestureEnabled: false,
-        }}
-      />
-      <Stack.Screen
-        name="InCall"
-        getComponent={() =>
-          hasCallsSupport
-            ? require("../screens/Calls/InCallScreen").InCallScreen
-            : CallsUnavailableScreen
-        }
-        options={{ headerShown: false, gestureEnabled: false }}
-      />
-      <Stack.Screen
-        name="CallHistory"
-        getComponent={() =>
-          hasCallsSupport
-            ? require("../screens/Calls/CallHistoryScreen").CallHistoryScreen
-            : CallsUnavailableScreen
-        }
-        options={{ title: "Appels" }}
-      />
-      <Stack.Screen
-        name="ModerationDecision"
-        component={ModerationDecisionScreen}
-      />
-      <Stack.Screen
-        name="ModerationAppealForm"
-        component={ModerationAppealFormScreen}
-      />
-      <Stack.Screen
-        name="ModerationAppealSubmitted"
-        component={ModerationAppealSubmittedScreen}
-      />
-      {/* Moderation — user-facing */}
-      <Stack.Screen name="ReportHistory" component={ReportHistoryScreen} />
-      <Stack.Screen name="ReportDetail" component={ReportDetailScreen} />
-      <Stack.Screen name="MySanctions" component={MySanctionsScreen} />
-      <Stack.Screen
-        name="SanctionNotice"
-        component={SanctionNoticeScreen}
-        options={{ gestureEnabled: false }}
-      />
-      <Stack.Screen name="AppealForm" component={AppealFormScreen} />
-      <Stack.Screen name="AppealStatus" component={AppealStatusScreen} />
-      {/* Moderation — admin */}
-      <Stack.Screen
-        name="ModerationDashboard"
-        component={ModerationDashboardScreen}
-      />
-      <Stack.Screen name="ReportQueue" component={ReportQueueScreen} />
-      <Stack.Screen name="ReportReview" component={ReportReviewScreen} />
-      <Stack.Screen name="AppealQueue" component={AppealQueueScreen} />
-      <Stack.Screen name="AppealReview" component={AppealReviewScreen} />
-      <Stack.Screen name="UserModeration" component={UserModerationScreen} />
-      <Stack.Screen name="SanctionForm" component={SanctionFormScreen} />
-      <Stack.Screen name="ModerationTest" component={ModerationTestScreen} />
-    </Stack.Navigator>
+      >
+        <Stack.Screen
+          name="Onboarding"
+          component={OnboardingScreen}
+          options={{ gestureEnabled: false }}
+        />
+        <Stack.Screen name="Welcome" component={WelcomeScreen} />
+        <Stack.Screen name="PhoneInput" component={PhoneInputScreen} />
+        <Stack.Screen name="Otp" component={OtpScreen} />
+        <Stack.Screen name="ProfileSetup" component={ProfileSetupScreen} />
+        <Stack.Screen name="MyProfile" component={MyProfileScreen} />
+        <Stack.Screen name="UserProfile" component={UserProfileScreen} />
+        <Stack.Screen
+          name="Settings"
+          component={SettingsScreen}
+          options={{
+            // Le swipe-back horizontal capturait les gestes verticaux sur iOS ; le retour reste via la flèche.
+            gestureEnabled: false,
+          }}
+        />
+        <Stack.Screen name="AboutContent" component={AboutContentScreen} />
+        <Stack.Screen name="PrivacyPolicy" component={PrivacyPolicyScreen} />
+        <Stack.Screen name="TermsOfUse" component={TermsOfUseScreen} />
+        <Stack.Screen name="SecurityKeys" component={SecurityKeysScreen} />
+        <Stack.Screen name="Devices" component={DevicesScreen} />
+        <Stack.Screen name="TwoFactorAuth" component={TwoFactorAuthScreen} />
+        <Stack.Screen
+          name="TwoFactorSetup"
+          component={TwoFactorSetupScreen}
+          options={{ gestureEnabled: false }}
+        />
+        <Stack.Screen
+          name="TwoFactorVerify"
+          component={TwoFactorVerifyScreen}
+          options={{ gestureEnabled: false }}
+        />
+        <Stack.Screen
+          name="TwoFactorBackupCodes"
+          component={TwoFactorBackupCodesScreen}
+          options={{ gestureEnabled: false }}
+        />
+        <Stack.Screen
+          name="ConversationsList"
+          component={ConversationsListScreen}
+        />
+        <Stack.Screen
+          name="ArchivedConversations"
+          component={ArchivedConversationsScreen}
+          options={{
+            cardStyleInterpolator: ({ current, layouts }) => ({
+              cardStyle: {
+                backgroundColor: "transparent",
+                transform: [
+                  {
+                    translateX: current.progress.interpolate({
+                      inputRange: [0, 1],
+                      outputRange: [layouts.screen.width, 0],
+                    }),
+                  },
+                ],
+              },
+            }),
+          }}
+        />
+        <Stack.Screen name="Chat" component={ChatScreen} />
+        <Stack.Screen name="Contacts" component={ContactsScreen} />
+        <Stack.Screen name="MyQRCode" component={MyQRCodeScreen} />
+        <Stack.Screen
+          name="QRCodeScanner"
+          getComponent={() =>
+            require("../screens/Contacts/QRCodeScannerScreen")
+              .QRCodeScannerScreen
+          }
+        />
+        <Stack.Screen name="BlockedUsers" component={BlockedUsersScreen} />
+        <Stack.Screen name="GroupDetails" component={GroupDetailsScreen} />
+        <Stack.Screen
+          name="GroupManagement"
+          component={GroupManagementScreen}
+        />
+        <Stack.Screen
+          name="ScheduledMessages"
+          component={ScheduledMessagesScreen}
+        />
+        <Stack.Screen
+          name="Calls"
+          getComponent={() =>
+            hasCallsSupport
+              ? require("../screens/Calls/CallsScreen").CallsScreen
+              : CallsUnavailableScreen
+          }
+        />
+        <Stack.Screen
+          name="IncomingCall"
+          getComponent={() =>
+            hasCallsSupport
+              ? require("../screens/Calls/IncomingCallScreen")
+                  .IncomingCallScreen
+              : CallsUnavailableScreen
+          }
+          options={{
+            presentation: "modal",
+            headerShown: false,
+            gestureEnabled: false,
+          }}
+        />
+        <Stack.Screen
+          name="InCall"
+          getComponent={() =>
+            hasCallsSupport
+              ? require("../screens/Calls/InCallScreen").InCallScreen
+              : CallsUnavailableScreen
+          }
+          options={{ headerShown: false, gestureEnabled: false }}
+        />
+        <Stack.Screen
+          name="CallHistory"
+          getComponent={() =>
+            hasCallsSupport
+              ? require("../screens/Calls/CallHistoryScreen").CallHistoryScreen
+              : CallsUnavailableScreen
+          }
+          options={{ title: "Appels" }}
+        />
+        <Stack.Screen
+          name="ModerationDecision"
+          component={ModerationDecisionScreen}
+        />
+        <Stack.Screen
+          name="ModerationAppealForm"
+          component={ModerationAppealFormScreen}
+        />
+        <Stack.Screen
+          name="ModerationAppealSubmitted"
+          component={ModerationAppealSubmittedScreen}
+        />
+        {/* Moderation — user-facing */}
+        <Stack.Screen name="ReportHistory" component={ReportHistoryScreen} />
+        <Stack.Screen name="ReportDetail" component={ReportDetailScreen} />
+        <Stack.Screen name="MySanctions" component={MySanctionsScreen} />
+        <Stack.Screen
+          name="SanctionNotice"
+          component={SanctionNoticeScreen}
+          options={{ gestureEnabled: false }}
+        />
+        <Stack.Screen name="AppealForm" component={AppealFormScreen} />
+        <Stack.Screen name="AppealStatus" component={AppealStatusScreen} />
+        {/* Moderation — admin */}
+        <Stack.Screen
+          name="ModerationDashboard"
+          component={ModerationDashboardScreen}
+        />
+        <Stack.Screen name="ReportQueue" component={ReportQueueScreen} />
+        <Stack.Screen name="ReportReview" component={ReportReviewScreen} />
+        <Stack.Screen name="AppealQueue" component={AppealQueueScreen} />
+        <Stack.Screen name="AppealReview" component={AppealReviewScreen} />
+        <Stack.Screen name="UserModeration" component={UserModerationScreen} />
+        <Stack.Screen name="SanctionForm" component={SanctionFormScreen} />
+        <Stack.Screen name="ModerationTest" component={ModerationTestScreen} />
+      </Stack.Navigator>
+    </TourProvider>
   );
 };
 

--- a/src/screens/Calls/CallHistoryScreen.tsx
+++ b/src/screens/Calls/CallHistoryScreen.tsx
@@ -1,4 +1,40 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  AttachStep,
+  SpotlightTourProvider,
+  type TourStep,
+} from "react-native-spotlight-tour";
+import { TourTooltip } from "../../components/Tour/TourTooltip";
+import { TourAutoStart } from "../../components/Tour/TourAutoStart";
+
+const CALLS_STEPS_COUNT = 2;
+
+const CALLS_TOUR_STEPS: TourStep[] = [
+  {
+    placement: "bottom",
+    offset: 10,
+    render: (props) => (
+      <TourTooltip
+        {...props}
+        title="Centre d'appels"
+        description="Retrouve ici tous tes appels audio et vidéo passés avec leur statut."
+        total={CALLS_STEPS_COUNT}
+      />
+    ),
+  },
+  {
+    placement: "bottom",
+    offset: 10,
+    render: (props) => (
+      <TourTooltip
+        {...props}
+        title="Statistiques"
+        description="Un aperçu de tes appels : total, manqués et connectés en un coup d'œil."
+        total={CALLS_STEPS_COUNT}
+      />
+    ),
+  },
+];
 import { Text, FlatList, StyleSheet, RefreshControl, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { BlurView } from "expo-blur";
@@ -60,204 +96,238 @@ export const CallHistoryScreen: React.FC = () => {
   }, [load]);
 
   return (
-    <FlatList
-      data={calls}
-      keyExtractor={(c) => c.id}
-      refreshControl={
-        <RefreshControl
-          refreshing={loading}
-          onRefresh={load}
-          tintColor={colors.text.light}
-        />
-      }
-      contentContainerStyle={{
-        paddingHorizontal: 16,
-        paddingTop: 8,
-        paddingBottom: insets.bottom + FLOATING_TAB_BAR_RESERVED_SPACE + 16,
-      }}
-      ItemSeparatorComponent={() => <View style={{ height: 12 }} />}
-      ListHeaderComponent={
-        <View style={styles.headerBlock}>
-          <BlurView intensity={45} tint="dark" style={styles.topHeaderBlur}>
-            <View style={styles.topHeaderCard}>
-              <View style={styles.topHeaderBadge}>
-                <Ionicons
-                  name="call-outline"
-                  size={14}
-                  color={colors.primary.main}
-                />
-                <Text style={styles.topHeaderBadgeText}>Centre d'appels</Text>
-              </View>
-              <Text style={styles.topHeaderTitle}>Appels</Text>
-              <Text style={styles.topHeaderSubtitle}>
-                Historique audio et vidéo.
-              </Text>
-            </View>
-          </BlurView>
-          <BlurView intensity={45} tint="dark" style={styles.heroBlur}>
-            <View style={styles.heroCard}>
-              <View style={styles.heroBadge}>
-                <Ionicons
-                  name="sparkles-outline"
-                  size={14}
-                  color={colors.primary.main}
-                />
-                <Text style={styles.heroBadgeText}>Historique récent</Text>
-              </View>
-              <Text style={styles.heroTitle}>Vos appels</Text>
-              <Text style={styles.heroSubtitle}>
-                Retrouvez les appels récents avec un aperçu rapide des statuts
-                et durées.
-              </Text>
-              <View style={styles.statsRow}>
-                <StatPill
-                  icon="call-outline"
-                  label="Total"
-                  value={String(stats.total)}
-                />
-                <StatPill
-                  icon="checkmark-done-outline"
-                  label="Terminés"
-                  value={String(stats.connected)}
-                />
-                <StatPill
-                  icon="alert-circle-outline"
-                  label="Manqués"
-                  value={String(stats.missed)}
-                />
-              </View>
-            </View>
-          </BlurView>
-        </View>
-      }
-      renderItem={({ item }) => {
-        const meta = getStatusMeta(item.status);
-        return (
-          <BlurView intensity={35} tint="dark" style={styles.cardBlur}>
-            <View style={styles.card}>
-              <View style={styles.avatarBlock}>
-                <Avatar uri={item.avatarUrl} name={item.title} size={54} />
-                <View
-                  style={[
-                    styles.typeFloatingBadge,
-                    {
-                      backgroundColor:
-                        item.type === "video"
-                          ? withOpacity(colors.secondary.main, 0.9)
-                          : withOpacity(colors.primary.main, 0.88),
-                    },
-                  ]}
-                >
-                  <Ionicons
-                    name={
-                      item.type === "video"
-                        ? "videocam-outline"
-                        : "call-outline"
-                    }
-                    size={12}
-                    color={colors.text.light}
-                  />
-                </View>
-              </View>
-
-              <View style={styles.cardBody}>
-                <View style={styles.titleRow}>
-                  <Text style={styles.title} numberOfLines={1}>
-                    {item.title}
-                  </Text>
-                  <View
-                    style={[
-                      styles.statusBadge,
-                      { backgroundColor: meta.backgroundColor },
-                    ]}
+    <SpotlightTourProvider
+      steps={CALLS_TOUR_STEPS}
+      overlayColor="#0B1124"
+      overlayOpacity={0.82}
+      placement="bottom"
+      offset={10}
+    >
+      {() => (
+        <>
+          <TourAutoStart />
+          <FlatList
+            data={calls}
+            keyExtractor={(c) => c.id}
+            refreshControl={
+              <RefreshControl
+                refreshing={loading}
+                onRefresh={load}
+                tintColor={colors.text.light}
+              />
+            }
+            contentContainerStyle={{
+              paddingHorizontal: 16,
+              paddingTop: 8,
+              paddingBottom:
+                insets.bottom + FLOATING_TAB_BAR_RESERVED_SPACE + 16,
+            }}
+            ItemSeparatorComponent={() => <View style={{ height: 12 }} />}
+            ListHeaderComponent={
+              <View style={styles.headerBlock}>
+                <AttachStep index={0}>
+                  <BlurView
+                    intensity={45}
+                    tint="dark"
+                    style={styles.topHeaderBlur}
                   >
-                    <Ionicons
-                      name={meta.icon}
-                      size={12}
-                      color={meta.textColor}
-                    />
-                    <Text
-                      style={[
-                        styles.statusBadgeText,
-                        { color: meta.textColor },
-                      ]}
-                    >
-                      {meta.label}
-                    </Text>
-                  </View>
-                </View>
-
-                {!!item.subtitle && (
-                  <Text style={styles.subtitle} numberOfLines={1}>
-                    {item.subtitle}
-                  </Text>
-                )}
-
-                <Text style={styles.dateText}>
-                  {formatDate(item.started_at)}
-                </Text>
-
-                <View style={styles.metaInfoRow}>
-                  <View style={styles.metaInfoPill}>
-                    <Ionicons
-                      name={
-                        item.type === "video"
-                          ? "videocam-outline"
-                          : "call-outline"
-                      }
-                      size={13}
-                      color="rgba(255,255,255,0.7)"
-                    />
-                    <Text style={styles.metaText}>
-                      {item.type === "video" ? "Appel vidéo" : "Appel audio"}
-                    </Text>
-                  </View>
-                  <View style={styles.metaInfoPill}>
-                    <Ionicons
-                      name="calendar-outline"
-                      size={13}
-                      color="rgba(255,255,255,0.7)"
-                    />
-                    <Text style={styles.metaText}>
-                      {relativeDayLabel(item.started_at)}
-                    </Text>
-                  </View>
-                  {item.duration_seconds != null && (
-                    <View style={styles.metaInfoPill}>
-                      <Ionicons
-                        name="time-outline"
-                        size={13}
-                        color="rgba(255,255,255,0.7)"
-                      />
-                      <Text style={styles.metaText}>
-                        Durée {formatDuration(item.duration_seconds)}
+                    <View style={styles.topHeaderCard}>
+                      <View style={styles.topHeaderBadge}>
+                        <Ionicons
+                          name="call-outline"
+                          size={14}
+                          color={colors.primary.main}
+                        />
+                        <Text style={styles.topHeaderBadgeText}>
+                          Centre d'appels
+                        </Text>
+                      </View>
+                      <Text style={styles.topHeaderTitle}>Appels</Text>
+                      <Text style={styles.topHeaderSubtitle}>
+                        Historique audio et vidéo.
                       </Text>
                     </View>
-                  )}
-                </View>
+                  </BlurView>
+                </AttachStep>
+                <AttachStep index={1}>
+                  <BlurView intensity={45} tint="dark" style={styles.heroBlur}>
+                    <View style={styles.heroCard}>
+                      <View style={styles.heroBadge}>
+                        <Ionicons
+                          name="sparkles-outline"
+                          size={14}
+                          color={colors.primary.main}
+                        />
+                        <Text style={styles.heroBadgeText}>
+                          Historique récent
+                        </Text>
+                      </View>
+                      <Text style={styles.heroTitle}>Vos appels</Text>
+                      <Text style={styles.heroSubtitle}>
+                        Retrouvez les appels récents avec un aperçu rapide des
+                        statuts et durées.
+                      </Text>
+                      <View style={styles.statsRow}>
+                        <StatPill
+                          icon="call-outline"
+                          label="Total"
+                          value={String(stats.total)}
+                        />
+                        <StatPill
+                          icon="checkmark-done-outline"
+                          label="Terminés"
+                          value={String(stats.connected)}
+                        />
+                        <StatPill
+                          icon="alert-circle-outline"
+                          label="Manqués"
+                          value={String(stats.missed)}
+                        />
+                      </View>
+                    </View>
+                  </BlurView>
+                </AttachStep>
               </View>
-            </View>
-          </BlurView>
-        );
-      }}
-      ListEmptyComponent={
-        <BlurView intensity={35} tint="dark" style={styles.emptyBlur}>
-          <View style={styles.emptyCard}>
-            <View style={styles.emptyIcon}>
-              <Ionicons
-                name="call-outline"
-                size={24}
-                color="rgba(255,255,255,0.82)"
-              />
-            </View>
-            <Text style={styles.emptyTitle}>Aucun appel pour le moment</Text>
-            <Text style={styles.emptySubtitle}>
-              Vos appels audio et vidéo apparaîtront ici.
-            </Text>
-          </View>
-        </BlurView>
-      }
-    />
+            }
+            renderItem={({ item }) => {
+              const meta = getStatusMeta(item.status);
+              return (
+                <BlurView intensity={35} tint="dark" style={styles.cardBlur}>
+                  <View style={styles.card}>
+                    <View style={styles.avatarBlock}>
+                      <Avatar
+                        uri={item.avatarUrl}
+                        name={item.title}
+                        size={54}
+                      />
+                      <View
+                        style={[
+                          styles.typeFloatingBadge,
+                          {
+                            backgroundColor:
+                              item.type === "video"
+                                ? withOpacity(colors.secondary.main, 0.9)
+                                : withOpacity(colors.primary.main, 0.88),
+                          },
+                        ]}
+                      >
+                        <Ionicons
+                          name={
+                            item.type === "video"
+                              ? "videocam-outline"
+                              : "call-outline"
+                          }
+                          size={12}
+                          color={colors.text.light}
+                        />
+                      </View>
+                    </View>
+
+                    <View style={styles.cardBody}>
+                      <View style={styles.titleRow}>
+                        <Text style={styles.title} numberOfLines={1}>
+                          {item.title}
+                        </Text>
+                        <View
+                          style={[
+                            styles.statusBadge,
+                            { backgroundColor: meta.backgroundColor },
+                          ]}
+                        >
+                          <Ionicons
+                            name={meta.icon}
+                            size={12}
+                            color={meta.textColor}
+                          />
+                          <Text
+                            style={[
+                              styles.statusBadgeText,
+                              { color: meta.textColor },
+                            ]}
+                          >
+                            {meta.label}
+                          </Text>
+                        </View>
+                      </View>
+
+                      {!!item.subtitle && (
+                        <Text style={styles.subtitle} numberOfLines={1}>
+                          {item.subtitle}
+                        </Text>
+                      )}
+
+                      <Text style={styles.dateText}>
+                        {formatDate(item.started_at)}
+                      </Text>
+
+                      <View style={styles.metaInfoRow}>
+                        <View style={styles.metaInfoPill}>
+                          <Ionicons
+                            name={
+                              item.type === "video"
+                                ? "videocam-outline"
+                                : "call-outline"
+                            }
+                            size={13}
+                            color="rgba(255,255,255,0.7)"
+                          />
+                          <Text style={styles.metaText}>
+                            {item.type === "video"
+                              ? "Appel vidéo"
+                              : "Appel audio"}
+                          </Text>
+                        </View>
+                        <View style={styles.metaInfoPill}>
+                          <Ionicons
+                            name="calendar-outline"
+                            size={13}
+                            color="rgba(255,255,255,0.7)"
+                          />
+                          <Text style={styles.metaText}>
+                            {relativeDayLabel(item.started_at)}
+                          </Text>
+                        </View>
+                        {item.duration_seconds != null && (
+                          <View style={styles.metaInfoPill}>
+                            <Ionicons
+                              name="time-outline"
+                              size={13}
+                              color="rgba(255,255,255,0.7)"
+                            />
+                            <Text style={styles.metaText}>
+                              Durée {formatDuration(item.duration_seconds)}
+                            </Text>
+                          </View>
+                        )}
+                      </View>
+                    </View>
+                  </View>
+                </BlurView>
+              );
+            }}
+            ListEmptyComponent={
+              <BlurView intensity={35} tint="dark" style={styles.emptyBlur}>
+                <View style={styles.emptyCard}>
+                  <View style={styles.emptyIcon}>
+                    <Ionicons
+                      name="call-outline"
+                      size={24}
+                      color="rgba(255,255,255,0.82)"
+                    />
+                  </View>
+                  <Text style={styles.emptyTitle}>
+                    Aucun appel pour le moment
+                  </Text>
+                  <Text style={styles.emptySubtitle}>
+                    Vos appels audio et vidéo apparaîtront ici.
+                  </Text>
+                </View>
+              </BlurView>
+            }
+          />
+        </>
+      )}
+    </SpotlightTourProvider>
   );
 };
 

--- a/src/screens/Calls/__tests__/CallHistoryScreen.test.tsx
+++ b/src/screens/Calls/__tests__/CallHistoryScreen.test.tsx
@@ -33,6 +33,20 @@ jest.mock("../../../services/TokenService", () => ({
 }));
 
 jest.mock("../../../components/Chat/Avatar", () => ({ Avatar: () => null }));
+jest.mock("@react-navigation/native", () => ({
+  useFocusEffect: jest.fn(),
+}));
+jest.mock("react-native-spotlight-tour", () => ({
+  SpotlightTourProvider: ({ children }: any) =>
+    typeof children === "function" ? children({}) : children,
+  AttachStep: ({ children }: any) => children,
+}));
+jest.mock("../../../components/Tour/TourAutoStart", () => ({
+  TourAutoStart: () => null,
+}));
+jest.mock("../../../context/TourContext", () => ({
+  useTour: () => ({ isTourActive: false, skipTour: jest.fn() }),
+}));
 
 import { CallHistoryScreen } from "../CallHistoryScreen";
 

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -77,6 +77,42 @@ import { MessageSearch } from "../../components/Chat/MessageSearch";
 import { PinnedMessagesBar } from "../../components/Chat/PinnedMessagesBar";
 import { EmptyChatState } from "../../components/Chat/EmptyChatState";
 import { ChatHeader } from "./ChatHeader";
+import {
+  AttachStep,
+  SpotlightTourProvider,
+  type TourStep,
+} from "react-native-spotlight-tour";
+import { TourTooltip } from "../../components/Tour/TourTooltip";
+import { TourAutoStart } from "../../components/Tour/TourAutoStart";
+
+const CHAT_STEPS_COUNT = 2;
+
+const CHAT_TOUR_STEPS: TourStep[] = [
+  {
+    placement: "bottom",
+    offset: 10,
+    render: (props) => (
+      <TourTooltip
+        {...props}
+        title="Appels chiffrés"
+        description="Lance un appel audio ou vidéo sécurisé directement depuis cette conversation."
+        total={CHAT_STEPS_COUNT}
+      />
+    ),
+  },
+  {
+    placement: "top",
+    offset: 10,
+    render: (props) => (
+      <TourTooltip
+        {...props}
+        title="Messages E2E"
+        description="Écris ton message ici. Chaque mot est chiffré de bout en bout avant d'être envoyé."
+        total={CHAT_STEPS_COUNT}
+      />
+    ),
+  },
+];
 import { getConversationDisplayName } from "../../utils";
 import { generateClientRandom } from "../../utils/crypto";
 import { usePresenceStore } from "../../store/presenceStore";
@@ -2969,538 +3005,568 @@ export const ChatScreen: React.FC = () => {
   }, [conversation, conversationMembers, userId]);
 
   return (
-    <View
-      style={[
-        styles.screenRoot,
-        hasCustomBackground && styles.screenRootWithCustomBackground,
-        Platform.OS === "web" && { minHeight: 0, height: "100%" },
-      ]}
+    <SpotlightTourProvider
+      steps={CHAT_TOUR_STEPS}
+      overlayColor="#0B1124"
+      overlayOpacity={0.82}
+      placement="bottom"
+      offset={10}
     >
-      {hasCustomBackground && customBackgroundUri ? (
-        <ImageBackground
-          key={`${customBackgroundUri}:${customBackgroundVersion}`}
-          source={{ uri: customBackgroundUri }}
-          resizeMode="cover"
-          style={styles.customBackground}
-        />
-      ) : null}
-      {!hasCustomBackground ? (
-        <LinearGradient
-          colors={colors.background.gradient.app}
-          start={{ x: 0, y: 0 }}
-          end={{ x: 1, y: 1 }}
-          style={styles.gradientBackground}
-        />
-      ) : null}
-      <View
-        pointerEvents="none"
-        style={[
-          styles.backgroundScrim,
-          hasCustomBackground
-            ? styles.backgroundScrimWithCustomImage
-            : styles.backgroundScrimDefault,
-        ]}
-      />
-      <SafeAreaView
-        style={[
-          styles.container,
-          Platform.OS === "web" && { minHeight: 0, height: "100%" },
-        ]}
-        // bottom inset is consumed by MessageInput itself (applySafeAreaBottom)
-        // so the BlurView/overlay extends fully to the screen edge instead of
-        // leaving an empty band between the composer and the home indicator.
-        edges={["top"]}
-      >
-        <OfflineBanner connectionState={connectionState} />
-        <ChatHeader
-          conversationName={
-            conversation
-              ? getConversationDisplayName(conversation)
-              : "Conversation"
-          }
-          avatarUrl={headerAvatarUrl}
-          conversationType={conversation?.type || "direct"}
-          groupAvatars={
-            conversation?.type === "group"
-              ? conversationMembers
-                  .filter((m) => m.id && m.id !== userId)
-                  .slice(0, 2)
-                  .map((m) => ({
-                    uri: m.avatar_url,
-                    name: m.display_name || m.username || "Utilisateur",
-                  }))
-              : undefined
-          }
-          isOnline={isOtherOnline}
-          lastSeenAt={otherLastSeenAt}
-          onlineMemberCount={onlineMemberCount}
-          typingNames={typingUsers
-            .map((id) => typingUsersNames[id])
-            .filter(Boolean)}
-          onTitlePress={handleInfoPress}
-          onAudioCallPress={() => handleInitiateCall("audio")}
-          onVideoCallPress={() => handleInitiateCall("video")}
-          callsAvailable={callsAvailability.available}
-        />
-        {isOtherUserContact === false && (
-          <View style={styles.notContactBanner}>
-            <Ionicons
-              name="information-circle-outline"
-              size={16}
-              color={colors.text.light}
-              style={{ marginRight: 6 }}
-            />
-            <Text style={styles.notContactBannerText} numberOfLines={1}>
-              Cette personne n'est pas dans vos contacts
-            </Text>
-            <TouchableOpacity
-              onPress={handleAddContactFromChat}
-              disabled={addingContact}
-              style={styles.notContactBannerButton}
-            >
-              {addingContact ? (
-                // wrapper pour annoncer l'etat busy au screen reader
-                <View
-                  accessibilityState={{ busy: true }}
-                  accessibilityLiveRegion="polite"
-                >
-                  <ActivityIndicator size="small" color={colors.text.light} />
-                </View>
-              ) : (
-                <Text style={styles.notContactBannerButtonText}>Ajouter</Text>
-              )}
-            </TouchableOpacity>
-          </View>
-        )}
-        {showPinnedBar && pinnedMessages.length > 0 && (
-          <PinnedMessagesBar
-            pinnedMessages={pinnedMessages}
-            onMessagePress={handlePinnedMessagePress}
-            onClose={() => setShowPinnedBar(false)}
-          />
-        )}
-        {(() => {
-          // Contenu partagé web / natif — extrait pour que le wrapper soit
-          // branché conditionnellement sans dupliquer le JSX.
-          const messageList = (
-            <FlatList
-              ref={flatListRef}
-              data={messagesWithSeparators}
-              renderItem={renderItem}
-              keyExtractor={keyExtractor}
-              inverted
-              contentContainerStyle={styles.listContent}
-              removeClippedSubviews={true}
-              maxToRenderPerBatch={10}
-              updateCellsBatchingPeriod={50}
-              initialNumToRender={15}
-              windowSize={10}
-              onEndReached={loadMoreMessages}
-              onEndReachedThreshold={0.3}
-              maintainVisibleContentPosition={{
-                minIndexForVisible: 0,
-              }}
-              viewabilityConfig={viewabilityConfig}
-              onViewableItemsChanged={handleViewableItemsChanged}
-              keyboardShouldPersistTaps="handled"
-              // Dismiss the keyboard as the user drags the message list. iOS
-              // gets the interactive variant (clavier qui descend avec le doigt) ;
-              // Android n'a pas d'équivalent natif, on reste sur "on-drag".
-              keyboardDismissMode={
-                Platform.OS === "ios" ? "interactive" : "on-drag"
-              }
-              // Web : on absolute-positionne la FlatList à l'intérieur du
-              // wrapper `webListViewport` (qui est `position: relative`). Ça
-              // donne à la VirtualizedList une boîte de taille définie sans
-              // dépendre du flex layout, indispensable pour que Chrome accepte
-              // de scroller sur la molette quand `inverted` est actif.
-              style={
-                Platform.OS === "web" ? styles.webFlatListAbsolute : undefined
-              }
-              ListEmptyComponent={
-                !loading ? (
-                  <View style={{ transform: [{ scaleY: -1 }], flex: 1 }}>
-                    <EmptyChatState />
-                  </View>
-                ) : null
-              }
-              ListFooterComponent={
-                loadingMore ? (
-                  <View
-                    style={styles.loadingMore}
-                    accessibilityState={{ busy: true }}
-                    accessibilityLiveRegion="polite"
-                  >
-                    <ActivityIndicator
-                      size="small"
-                      color={themeColors.primary}
-                    />
-                  </View>
-                ) : null
-              }
-            />
-          );
-          // Sur web, on emballe la FlatList dans un viewport à overflow borné :
-          // ainsi Chrome garde le wheel sur la ScrollView interne (scrollable)
-          // sans qu'un overflow:hidden sur un ancêtre bloque l'event en amont.
-          // Tap on an empty area of the message list dismisses the keyboard.
-          // onStartShouldSetResponder only fires when no child grabs the touch
-          // first (message bubbles, action handlers, etc.), so this won't
-          // hijack interactions on actual content.
-          const dismissKeyboardResponderProps = {
-            onStartShouldSetResponder: () => true,
-            onResponderRelease: () => Keyboard.dismiss(),
-          };
-          const wrappedList =
-            Platform.OS === "web" ? (
-              <View
-                style={styles.webListViewport}
-                {...dismissKeyboardResponderProps}
-              >
-                {messageList}
-              </View>
-            ) : (
-              <GestureDetector gesture={swipeGesture}>
-                <View style={{ flex: 1 }} {...dismissKeyboardResponderProps}>
-                  {messageList}
-                </View>
-              </GestureDetector>
-            );
-          const chatBody = (
-            <>
-              <MessageSwipeProvider translateX={swipeTranslateX}>
-                {wrappedList}
-              </MessageSwipeProvider>
-
-              {typingUsers.length > 0 && (
-                <View style={styles.typingContainer}>
-                  <TypingIndicator
-                    userNames={typingUsers.map(
-                      (id) => typingUsersNames[id] || "Quelqu'un",
-                    )}
-                  />
-                </View>
-              )}
-              <MessageInput
-                onSend={handleSendMessage}
-                onSendMedia={handleSendMedia}
-                onScheduleSend={handleScheduleSend}
-                onTyping={(typing) => sendTyping(conversationId, typing)}
-                replyingTo={replyingTo}
-                onCancelReply={() => setReplyingTo(null)}
-                editingMessage={editingMessage}
-                onCancelEdit={() => setEditingMessage(null)}
-                conversationType={conversation?.type || "direct"}
-                members={conversationMembers}
-                applySafeAreaBottom
-              />
-            </>
-          );
-
-          // Web : KeyboardAvoidingView (behavior="height") recalcule la hauteur
-          // en fonction du clavier virtuel inexistant en navigateur, ce qui
-          // finit par réduire le container à 0 px → MessageInput invisible et
-          // chat non scrollable. On remplace par un simple View flex:1.
-          // Natif (iOS/Android) : comportement inchangé, KeyboardAvoidingView
-          // reste nécessaire pour le clavier physique.
-          if (Platform.OS === "web") {
-            // Web layout : on garde `overflow:hidden` sur un wrapper dédié
-            // autour de la FlatList (et plus sur le conteneur externe), pour
-            // borner le viewport de scroll sans capturer l'event wheel en
-            // amont. Mettre overflow:hidden sur le wrapper extérieur faisait
-            // que Chrome routait la molette vers cet élément non-scrollable,
-            // bloquant totalement le scroll sur l'inverted FlatList.
-            return (
-              <View
-                style={[
-                  styles.keyboardView,
-                  {
-                    minHeight: 0,
-                    flexDirection: "column",
-                  },
-                ]}
-              >
-                {chatBody}
-              </View>
-            );
-          }
-          return (
-            <KeyboardAvoidingView
-              style={styles.keyboardView}
-              behavior={Platform.OS === "ios" ? "padding" : "height"}
-              keyboardVerticalOffset={Platform.OS === "ios" ? 0 : 0}
-            >
-              {chatBody}
-            </KeyboardAvoidingView>
-          );
-        })()}
-        <MessageActionsMenu
-          visible={showActionsMenu}
-          message={selectedMessage}
-          isSent={selectedMessage?.sender_id === userId}
-          isPinned={pinnedMessages.some(
-            (m) => (m.messageId ?? m.message?.id) === selectedMessage?.id,
-          )}
-          onClose={() => {
-            setShowActionsMenu(false);
-            setSelectedMessage(null);
-          }}
-          onReply={handleStartReply}
-          onEdit={handleEditMessage}
-          onDelete={handleDeleteMessage}
-          onReact={handleStartReaction}
-          onPin={handlePinMessage}
-          onForward={handleForwardMessage}
-          onReport={handleOpenReportSheet}
-        />
-        <ReportMessageSheet
-          visible={showReportSheet}
-          message={reportSheetMessage}
-          conversationId={conversationId}
-          conversationTitle={
-            conversation
-              ? getConversationDisplayName(conversation)
-              : "Conversation"
-          }
-          onClose={() => {
-            setShowReportSheet(false);
-            setReportSheetMessage(null);
-          }}
-        />
-        <ForwardMessageModal
-          visible={showForwardModal}
-          conversations={allConversations}
-          currentConversationId={conversationId}
-          sending={forwardSending}
-          onClose={() => {
-            setShowForwardModal(false);
-            setForwardingMessage(null);
-          }}
-          onSelect={handleForwardSelect}
-        />
-        {showReactionPicker && (
-          <ReactionPicker
-            visible={showReactionPicker}
-            onClose={() => {
-              setShowReactionPicker(false);
-              setReactionPickerMessageId(null);
-            }}
-            onReactionSelect={handleReactionSelectFromPicker}
-          />
-        )}
-        <ReactionReactorsModal
-          visible={reactionReactorsModal !== null}
-          emoji={reactionReactorsModal?.emoji ?? ""}
-          reactors={reactionModalList}
-          resolveName={resolveReactorDisplayName}
-          onClose={() => setReactionReactorsModal(null)}
-        />
-        {appealModal ? (
-          <BlockedImageAppealModal
-            visible={appealModal.visible}
-            onClose={() =>
-              setAppealModal((prev) =>
-                prev ? { ...prev, visible: false } : prev,
-              )
-            }
-            imageUri={appealModal.imageUri}
-            blockReason={appealModal.blockReason}
-            scores={appealModal.scores}
-            messageTempId={appealModal.messageTempId}
-            conversationId={conversationId}
-            recipientId={
-              conversation?.type === "direct"
-                ? (
-                    conversation.member_user_ids ||
-                    conversation.members?.map(
-                      (m: { user_id: string }) => m.user_id,
-                    )
-                  )?.find((id: string) => id !== userId)
-                : undefined
-            }
-          />
-        ) : null}
-        <MessageSearch
-          visible={showSearch}
-          onClose={() => {
-            setShowSearch(false);
-            setSearchQuery("");
-            setSearchResults([]);
-          }}
-          onSearch={handleSearch}
-          resultsCount={searchResults.length}
-          currentIndex={currentSearchIndex}
-          onNext={handleSearchNext}
-          onPrevious={handleSearchPrevious}
-        />
-        <ScheduleDateTimePicker
-          visible={showSchedulePicker}
-          onClose={() => {
-            setShowSchedulePicker(false);
-            setScheduleMessageText("");
-          }}
-          onConfirm={handleScheduleConfirm}
-        />
-        <Modal
-          visible={showInfoModal && conversation?.type !== "group"}
-          transparent
-          animationType="slide"
-          statusBarTranslucent
-          onRequestClose={() => {
-            setShowInfoModal(false);
-          }}
+      {() => (
+        <View
+          style={[
+            styles.screenRoot,
+            hasCustomBackground && styles.screenRootWithCustomBackground,
+            Platform.OS === "web" && { minHeight: 0, height: "100%" },
+          ]}
         >
-          <View style={styles.modalOverlay}>
-            <View style={styles.modalContent}>
-              <LinearGradient
-                colors={colors.background.gradient.app}
-                start={{ x: 0, y: 0 }}
-                end={{ x: 1, y: 1 }}
-                style={styles.modalGradient}
-              >
-                <View style={styles.modalHeader}>
-                  <Text style={styles.modalTitle}>
-                    Informations de la conversation
-                  </Text>
-                  <TouchableOpacity
-                    onPress={() => {
-                      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                      setShowInfoModal(false);
-                    }}
-                    style={styles.closeButton}
-                    activeOpacity={0.7}
-                  >
-                    <Ionicons
-                      name="close"
-                      size={24}
-                      color={colors.text.light}
-                    />
-                  </TouchableOpacity>
-                </View>
-                <ScrollView
-                  style={styles.modalBody}
-                  showsVerticalScrollIndicator={false}
+          <TourAutoStart />
+          {hasCustomBackground && customBackgroundUri ? (
+            <ImageBackground
+              key={`${customBackgroundUri}:${customBackgroundVersion}`}
+              source={{ uri: customBackgroundUri }}
+              resizeMode="cover"
+              style={styles.customBackground}
+            />
+          ) : null}
+          {!hasCustomBackground ? (
+            <LinearGradient
+              colors={colors.background.gradient.app}
+              start={{ x: 0, y: 0 }}
+              end={{ x: 1, y: 1 }}
+              style={styles.gradientBackground}
+            />
+          ) : null}
+          <View
+            pointerEvents="none"
+            style={[
+              styles.backgroundScrim,
+              hasCustomBackground
+                ? styles.backgroundScrimWithCustomImage
+                : styles.backgroundScrimDefault,
+            ]}
+          />
+          <SafeAreaView
+            style={[
+              styles.container,
+              Platform.OS === "web" && { minHeight: 0, height: "100%" },
+            ]}
+            // bottom inset is consumed by MessageInput itself (applySafeAreaBottom)
+            // so the BlurView/overlay extends fully to the screen edge instead of
+            // leaving an empty band between the composer and the home indicator.
+            edges={["top"]}
+          >
+            <OfflineBanner connectionState={connectionState} />
+            <AttachStep index={0}>
+              <ChatHeader
+                conversationName={
+                  conversation
+                    ? getConversationDisplayName(conversation)
+                    : "Conversation"
+                }
+                avatarUrl={headerAvatarUrl}
+                conversationType={conversation?.type || "direct"}
+                groupAvatars={
+                  conversation?.type === "group"
+                    ? conversationMembers
+                        .filter((m) => m.id && m.id !== userId)
+                        .slice(0, 2)
+                        .map((m) => ({
+                          uri: m.avatar_url,
+                          name: m.display_name || m.username || "Utilisateur",
+                        }))
+                    : undefined
+                }
+                isOnline={isOtherOnline}
+                lastSeenAt={otherLastSeenAt}
+                onlineMemberCount={onlineMemberCount}
+                typingNames={typingUsers
+                  .map((id) => typingUsersNames[id])
+                  .filter(Boolean)}
+                onTitlePress={handleInfoPress}
+                onAudioCallPress={() => handleInitiateCall("audio")}
+                onVideoCallPress={() => handleInitiateCall("video")}
+                callsAvailable={callsAvailability.available}
+              />
+            </AttachStep>
+            {isOtherUserContact === false && (
+              <View style={styles.notContactBanner}>
+                <Ionicons
+                  name="information-circle-outline"
+                  size={16}
+                  color={colors.text.light}
+                  style={{ marginRight: 6 }}
+                />
+                <Text style={styles.notContactBannerText} numberOfLines={1}>
+                  Cette personne n'est pas dans vos contacts
+                </Text>
+                <TouchableOpacity
+                  onPress={handleAddContactFromChat}
+                  disabled={addingContact}
+                  style={styles.notContactBannerButton}
                 >
-                  <View style={styles.infoSectionMain}>
-                    <Avatar
-                      size={80}
-                      uri={conversation?.avatar_url}
-                      name={
-                        conversation
-                          ? getConversationDisplayName(conversation)
-                          : "Contact"
-                      }
-                      showOnlineBadge={conversation?.type === "direct"}
-                      isOnline={false}
-                    />
-                    <Text style={styles.infoName}>
-                      {conversation
-                        ? getConversationDisplayName(conversation)
-                        : "Contact"}
+                  {addingContact ? (
+                    // wrapper pour annoncer l'etat busy au screen reader
+                    <View
+                      accessibilityState={{ busy: true }}
+                      accessibilityLiveRegion="polite"
+                    >
+                      <ActivityIndicator
+                        size="small"
+                        color={colors.text.light}
+                      />
+                    </View>
+                  ) : (
+                    <Text style={styles.notContactBannerButtonText}>
+                      Ajouter
                     </Text>
-                    {conversation?.type === "direct" && (
-                      <Text style={styles.infoStatus}>Hors ligne</Text>
-                    )}
-                  </View>
-                  <View style={styles.infoSection}>
-                    <Text style={styles.infoLabel}>TYPE</Text>
-                    <Text style={styles.infoValue}>
-                      {conversation?.type === "group"
-                        ? "Groupe"
-                        : "Conversation directe"}
-                    </Text>
-                  </View>
-                  {conversation?.type === "direct" ? (
-                    <View style={styles.infoSection}>
-                      <Text style={styles.infoLabel}>CONFIDENTIALITÉ</Text>
-                      <View style={styles.infoToggleRow}>
-                        <Text style={styles.infoValue}>Chiffrement E2E</Text>
-                        <Switch
-                          value={e2eeEnabled}
-                          onValueChange={handleToggleE2EE}
-                          disabled={e2eeToggleBusy}
-                          trackColor={{
-                            false: "rgba(255, 255, 255, 0.15)",
-                            true: colors.primary.main,
-                          }}
-                          thumbColor={colors.text.light}
+                  )}
+                </TouchableOpacity>
+              </View>
+            )}
+            {showPinnedBar && pinnedMessages.length > 0 && (
+              <PinnedMessagesBar
+                pinnedMessages={pinnedMessages}
+                onMessagePress={handlePinnedMessagePress}
+                onClose={() => setShowPinnedBar(false)}
+              />
+            )}
+            {(() => {
+              // Contenu partagé web / natif — extrait pour que le wrapper soit
+              // branché conditionnellement sans dupliquer le JSX.
+              const messageList = (
+                <FlatList
+                  ref={flatListRef}
+                  data={messagesWithSeparators}
+                  renderItem={renderItem}
+                  keyExtractor={keyExtractor}
+                  inverted
+                  contentContainerStyle={styles.listContent}
+                  removeClippedSubviews={true}
+                  maxToRenderPerBatch={10}
+                  updateCellsBatchingPeriod={50}
+                  initialNumToRender={15}
+                  windowSize={10}
+                  onEndReached={loadMoreMessages}
+                  onEndReachedThreshold={0.3}
+                  maintainVisibleContentPosition={{
+                    minIndexForVisible: 0,
+                  }}
+                  viewabilityConfig={viewabilityConfig}
+                  onViewableItemsChanged={handleViewableItemsChanged}
+                  keyboardShouldPersistTaps="handled"
+                  // Dismiss the keyboard as the user drags the message list. iOS
+                  // gets the interactive variant (clavier qui descend avec le doigt) ;
+                  // Android n'a pas d'équivalent natif, on reste sur "on-drag".
+                  keyboardDismissMode={
+                    Platform.OS === "ios" ? "interactive" : "on-drag"
+                  }
+                  // Web : on absolute-positionne la FlatList à l'intérieur du
+                  // wrapper `webListViewport` (qui est `position: relative`). Ça
+                  // donne à la VirtualizedList une boîte de taille définie sans
+                  // dépendre du flex layout, indispensable pour que Chrome accepte
+                  // de scroller sur la molette quand `inverted` est actif.
+                  style={
+                    Platform.OS === "web"
+                      ? styles.webFlatListAbsolute
+                      : undefined
+                  }
+                  ListEmptyComponent={
+                    !loading ? (
+                      <View style={{ transform: [{ scaleY: -1 }], flex: 1 }}>
+                        <EmptyChatState />
+                      </View>
+                    ) : null
+                  }
+                  ListFooterComponent={
+                    loadingMore ? (
+                      <View
+                        style={styles.loadingMore}
+                        accessibilityState={{ busy: true }}
+                        accessibilityLiveRegion="polite"
+                      >
+                        <ActivityIndicator
+                          size="small"
+                          color={themeColors.primary}
                         />
                       </View>
+                    ) : null
+                  }
+                />
+              );
+              // Sur web, on emballe la FlatList dans un viewport à overflow borné :
+              // ainsi Chrome garde le wheel sur la ScrollView interne (scrollable)
+              // sans qu'un overflow:hidden sur un ancêtre bloque l'event en amont.
+              // Tap on an empty area of the message list dismisses the keyboard.
+              // onStartShouldSetResponder only fires when no child grabs the touch
+              // first (message bubbles, action handlers, etc.), so this won't
+              // hijack interactions on actual content.
+              const dismissKeyboardResponderProps = {
+                onStartShouldSetResponder: () => true,
+                onResponderRelease: () => Keyboard.dismiss(),
+              };
+              const wrappedList =
+                Platform.OS === "web" ? (
+                  <View
+                    style={styles.webListViewport}
+                    {...dismissKeyboardResponderProps}
+                  >
+                    {messageList}
+                  </View>
+                ) : (
+                  <GestureDetector gesture={swipeGesture}>
+                    <View
+                      style={{ flex: 1 }}
+                      {...dismissKeyboardResponderProps}
+                    >
+                      {messageList}
                     </View>
-                  ) : null}
-                  <View style={styles.infoSection}>
-                    <Text style={styles.infoLabel}>MESSAGES</Text>
-                    <Text style={styles.infoValue}>
-                      {messages.length} message{messages.length > 1 ? "s" : ""}
-                    </Text>
+                  </GestureDetector>
+                );
+              const chatBody = (
+                <>
+                  <MessageSwipeProvider translateX={swipeTranslateX}>
+                    {wrappedList}
+                  </MessageSwipeProvider>
+
+                  {typingUsers.length > 0 && (
+                    <View style={styles.typingContainer}>
+                      <TypingIndicator
+                        userNames={typingUsers.map(
+                          (id) => typingUsersNames[id] || "Quelqu'un",
+                        )}
+                      />
+                    </View>
+                  )}
+                  <AttachStep index={1}>
+                    <MessageInput
+                      onSend={handleSendMessage}
+                      onSendMedia={handleSendMedia}
+                      onScheduleSend={handleScheduleSend}
+                      onTyping={(typing) => sendTyping(conversationId, typing)}
+                      replyingTo={replyingTo}
+                      onCancelReply={() => setReplyingTo(null)}
+                      editingMessage={editingMessage}
+                      onCancelEdit={() => setEditingMessage(null)}
+                      conversationType={conversation?.type || "direct"}
+                      members={conversationMembers}
+                      applySafeAreaBottom
+                    />
+                  </AttachStep>
+                </>
+              );
+
+              // Web : KeyboardAvoidingView (behavior="height") recalcule la hauteur
+              // en fonction du clavier virtuel inexistant en navigateur, ce qui
+              // finit par réduire le container à 0 px → MessageInput invisible et
+              // chat non scrollable. On remplace par un simple View flex:1.
+              // Natif (iOS/Android) : comportement inchangé, KeyboardAvoidingView
+              // reste nécessaire pour le clavier physique.
+              if (Platform.OS === "web") {
+                // Web layout : on garde `overflow:hidden` sur un wrapper dédié
+                // autour de la FlatList (et plus sur le conteneur externe), pour
+                // borner le viewport de scroll sans capturer l'event wheel en
+                // amont. Mettre overflow:hidden sur le wrapper extérieur faisait
+                // que Chrome routait la molette vers cet élément non-scrollable,
+                // bloquant totalement le scroll sur l'inverted FlatList.
+                return (
+                  <View
+                    style={[
+                      styles.keyboardView,
+                      {
+                        minHeight: 0,
+                        flexDirection: "column",
+                      },
+                    ]}
+                  >
+                    {chatBody}
                   </View>
-                  <View style={styles.infoSectionActions}>
-                    <Text style={styles.infoLabel}>ACTIONS</Text>
-                    <TouchableOpacity
-                      style={styles.infoActionRow}
-                      onPress={() => {
-                        setShowInfoModal(false);
-                        setShowSearch(true);
-                      }}
-                      activeOpacity={0.7}
-                      accessibilityRole="button"
-                      accessibilityLabel="Rechercher dans la conversation"
-                    >
-                      <Ionicons
-                        name="search"
-                        size={20}
-                        color={colors.text.light}
-                        style={styles.infoActionIcon}
-                      />
-                      <Text style={styles.infoActionLabel}>
-                        Rechercher des messages
+                );
+              }
+              return (
+                <KeyboardAvoidingView
+                  style={styles.keyboardView}
+                  behavior={Platform.OS === "ios" ? "padding" : "height"}
+                  keyboardVerticalOffset={Platform.OS === "ios" ? 0 : 0}
+                >
+                  {chatBody}
+                </KeyboardAvoidingView>
+              );
+            })()}
+            <MessageActionsMenu
+              visible={showActionsMenu}
+              message={selectedMessage}
+              isSent={selectedMessage?.sender_id === userId}
+              isPinned={pinnedMessages.some(
+                (m) => (m.messageId ?? m.message?.id) === selectedMessage?.id,
+              )}
+              onClose={() => {
+                setShowActionsMenu(false);
+                setSelectedMessage(null);
+              }}
+              onReply={handleStartReply}
+              onEdit={handleEditMessage}
+              onDelete={handleDeleteMessage}
+              onReact={handleStartReaction}
+              onPin={handlePinMessage}
+              onForward={handleForwardMessage}
+              onReport={handleOpenReportSheet}
+            />
+            <ReportMessageSheet
+              visible={showReportSheet}
+              message={reportSheetMessage}
+              conversationId={conversationId}
+              conversationTitle={
+                conversation
+                  ? getConversationDisplayName(conversation)
+                  : "Conversation"
+              }
+              onClose={() => {
+                setShowReportSheet(false);
+                setReportSheetMessage(null);
+              }}
+            />
+            <ForwardMessageModal
+              visible={showForwardModal}
+              conversations={allConversations}
+              currentConversationId={conversationId}
+              sending={forwardSending}
+              onClose={() => {
+                setShowForwardModal(false);
+                setForwardingMessage(null);
+              }}
+              onSelect={handleForwardSelect}
+            />
+            {showReactionPicker && (
+              <ReactionPicker
+                visible={showReactionPicker}
+                onClose={() => {
+                  setShowReactionPicker(false);
+                  setReactionPickerMessageId(null);
+                }}
+                onReactionSelect={handleReactionSelectFromPicker}
+              />
+            )}
+            <ReactionReactorsModal
+              visible={reactionReactorsModal !== null}
+              emoji={reactionReactorsModal?.emoji ?? ""}
+              reactors={reactionModalList}
+              resolveName={resolveReactorDisplayName}
+              onClose={() => setReactionReactorsModal(null)}
+            />
+            {appealModal ? (
+              <BlockedImageAppealModal
+                visible={appealModal.visible}
+                onClose={() =>
+                  setAppealModal((prev) =>
+                    prev ? { ...prev, visible: false } : prev,
+                  )
+                }
+                imageUri={appealModal.imageUri}
+                blockReason={appealModal.blockReason}
+                scores={appealModal.scores}
+                messageTempId={appealModal.messageTempId}
+                conversationId={conversationId}
+                recipientId={
+                  conversation?.type === "direct"
+                    ? (
+                        conversation.member_user_ids ||
+                        conversation.members?.map(
+                          (m: { user_id: string }) => m.user_id,
+                        )
+                      )?.find((id: string) => id !== userId)
+                    : undefined
+                }
+              />
+            ) : null}
+            <MessageSearch
+              visible={showSearch}
+              onClose={() => {
+                setShowSearch(false);
+                setSearchQuery("");
+                setSearchResults([]);
+              }}
+              onSearch={handleSearch}
+              resultsCount={searchResults.length}
+              currentIndex={currentSearchIndex}
+              onNext={handleSearchNext}
+              onPrevious={handleSearchPrevious}
+            />
+            <ScheduleDateTimePicker
+              visible={showSchedulePicker}
+              onClose={() => {
+                setShowSchedulePicker(false);
+                setScheduleMessageText("");
+              }}
+              onConfirm={handleScheduleConfirm}
+            />
+            <Modal
+              visible={showInfoModal && conversation?.type !== "group"}
+              transparent
+              animationType="slide"
+              statusBarTranslucent
+              onRequestClose={() => {
+                setShowInfoModal(false);
+              }}
+            >
+              <View style={styles.modalOverlay}>
+                <View style={styles.modalContent}>
+                  <LinearGradient
+                    colors={colors.background.gradient.app}
+                    start={{ x: 0, y: 0 }}
+                    end={{ x: 1, y: 1 }}
+                    style={styles.modalGradient}
+                  >
+                    <View style={styles.modalHeader}>
+                      <Text style={styles.modalTitle}>
+                        Informations de la conversation
                       </Text>
-                      <Ionicons
-                        name="chevron-forward"
-                        size={20}
-                        color={withOpacity(colors.text.light, 0.4)}
-                      />
-                    </TouchableOpacity>
-                    <TouchableOpacity
-                      style={styles.infoActionRow}
-                      onPress={() => {
-                        setShowInfoModal(false);
-                        handleScheduledPress();
-                      }}
-                      activeOpacity={0.7}
-                      accessibilityRole="button"
-                      accessibilityLabel="Messages programmés"
+                      <TouchableOpacity
+                        onPress={() => {
+                          Haptics.impactAsync(
+                            Haptics.ImpactFeedbackStyle.Light,
+                          );
+                          setShowInfoModal(false);
+                        }}
+                        style={styles.closeButton}
+                        activeOpacity={0.7}
+                      >
+                        <Ionicons
+                          name="close"
+                          size={24}
+                          color={colors.text.light}
+                        />
+                      </TouchableOpacity>
+                    </View>
+                    <ScrollView
+                      style={styles.modalBody}
+                      showsVerticalScrollIndicator={false}
                     >
-                      <Ionicons
-                        name="timer-outline"
-                        size={20}
-                        color={colors.text.light}
-                        style={styles.infoActionIcon}
-                      />
-                      <Text style={styles.infoActionLabel}>
-                        Messages programmés
-                      </Text>
-                      <Ionicons
-                        name="chevron-forward"
-                        size={20}
-                        color={withOpacity(colors.text.light, 0.4)}
-                      />
-                    </TouchableOpacity>
-                  </View>
-                </ScrollView>
-              </LinearGradient>
-            </View>
-          </View>
-        </Modal>
-        <Toast
-          visible={callsToast.visible}
-          message={callsToast.message}
-          type={callsToast.type}
-          duration={4000}
-          onHide={() => setCallsToast((t) => ({ ...t, visible: false }))}
-        />
-      </SafeAreaView>
-    </View>
+                      <View style={styles.infoSectionMain}>
+                        <Avatar
+                          size={80}
+                          uri={conversation?.avatar_url}
+                          name={
+                            conversation
+                              ? getConversationDisplayName(conversation)
+                              : "Contact"
+                          }
+                          showOnlineBadge={conversation?.type === "direct"}
+                          isOnline={false}
+                        />
+                        <Text style={styles.infoName}>
+                          {conversation
+                            ? getConversationDisplayName(conversation)
+                            : "Contact"}
+                        </Text>
+                        {conversation?.type === "direct" && (
+                          <Text style={styles.infoStatus}>Hors ligne</Text>
+                        )}
+                      </View>
+                      <View style={styles.infoSection}>
+                        <Text style={styles.infoLabel}>TYPE</Text>
+                        <Text style={styles.infoValue}>
+                          {conversation?.type === "group"
+                            ? "Groupe"
+                            : "Conversation directe"}
+                        </Text>
+                      </View>
+                      {conversation?.type === "direct" ? (
+                        <View style={styles.infoSection}>
+                          <Text style={styles.infoLabel}>CONFIDENTIALITÉ</Text>
+                          <View style={styles.infoToggleRow}>
+                            <Text style={styles.infoValue}>
+                              Chiffrement E2E
+                            </Text>
+                            <Switch
+                              value={e2eeEnabled}
+                              onValueChange={handleToggleE2EE}
+                              disabled={e2eeToggleBusy}
+                              trackColor={{
+                                false: "rgba(255, 255, 255, 0.15)",
+                                true: colors.primary.main,
+                              }}
+                              thumbColor={colors.text.light}
+                            />
+                          </View>
+                        </View>
+                      ) : null}
+                      <View style={styles.infoSection}>
+                        <Text style={styles.infoLabel}>MESSAGES</Text>
+                        <Text style={styles.infoValue}>
+                          {messages.length} message
+                          {messages.length > 1 ? "s" : ""}
+                        </Text>
+                      </View>
+                      <View style={styles.infoSectionActions}>
+                        <Text style={styles.infoLabel}>ACTIONS</Text>
+                        <TouchableOpacity
+                          style={styles.infoActionRow}
+                          onPress={() => {
+                            setShowInfoModal(false);
+                            setShowSearch(true);
+                          }}
+                          activeOpacity={0.7}
+                          accessibilityRole="button"
+                          accessibilityLabel="Rechercher dans la conversation"
+                        >
+                          <Ionicons
+                            name="search"
+                            size={20}
+                            color={colors.text.light}
+                            style={styles.infoActionIcon}
+                          />
+                          <Text style={styles.infoActionLabel}>
+                            Rechercher des messages
+                          </Text>
+                          <Ionicons
+                            name="chevron-forward"
+                            size={20}
+                            color={withOpacity(colors.text.light, 0.4)}
+                          />
+                        </TouchableOpacity>
+                        <TouchableOpacity
+                          style={styles.infoActionRow}
+                          onPress={() => {
+                            setShowInfoModal(false);
+                            handleScheduledPress();
+                          }}
+                          activeOpacity={0.7}
+                          accessibilityRole="button"
+                          accessibilityLabel="Messages programmés"
+                        >
+                          <Ionicons
+                            name="timer-outline"
+                            size={20}
+                            color={colors.text.light}
+                            style={styles.infoActionIcon}
+                          />
+                          <Text style={styles.infoActionLabel}>
+                            Messages programmés
+                          </Text>
+                          <Ionicons
+                            name="chevron-forward"
+                            size={20}
+                            color={withOpacity(colors.text.light, 0.4)}
+                          />
+                        </TouchableOpacity>
+                      </View>
+                    </ScrollView>
+                  </LinearGradient>
+                </View>
+              </View>
+            </Modal>
+            <Toast
+              visible={callsToast.visible}
+              message={callsToast.message}
+              type={callsToast.type}
+              duration={4000}
+              onHide={() => setCallsToast((t) => ({ ...t, visible: false }))}
+            />
+          </SafeAreaView>
+        </View>
+      )}
+    </SpotlightTourProvider>
   );
 };
 

--- a/src/screens/Chat/ConversationsListScreen.tsx
+++ b/src/screens/Chat/ConversationsListScreen.tsx
@@ -23,6 +23,13 @@
 
 import React, { useState, useEffect, useCallback, useMemo } from "react";
 import {
+  AttachStep,
+  SpotlightTourProvider,
+  type TourStep,
+} from "react-native-spotlight-tour";
+import { TourTooltip } from "../../components/Tour/TourTooltip";
+import { TourAutoStart } from "../../components/Tour/TourAutoStart";
+import {
   View,
   StyleSheet,
   FlatList,
@@ -75,6 +82,47 @@ import { useInboxStore } from "../../store/inboxStore";
 type NavigationProp = StackNavigationProp<AuthStackParamList, "Chat">;
 
 const AUTO_REFRESH_INTERVAL_MS = 2500;
+
+const CONVERSATIONS_STEPS_COUNT = 3;
+
+const CONVERSATIONS_TOUR_STEPS: TourStep[] = [
+  {
+    placement: "bottom",
+    offset: 10,
+    render: (props) => (
+      <TourTooltip
+        {...props}
+        title="Nouvelle conversation"
+        description="Appuie ici pour démarrer un nouveau chat chiffré de bout en bout."
+        total={CONVERSATIONS_STEPS_COUNT}
+      />
+    ),
+  },
+  {
+    placement: "bottom",
+    offset: 10,
+    render: (props) => (
+      <TourTooltip
+        {...props}
+        title="Notifications"
+        description="Retrouve tes demandes de contact et toutes tes alertes ici."
+        total={CONVERSATIONS_STEPS_COUNT}
+      />
+    ),
+  },
+  {
+    placement: "bottom",
+    offset: 10,
+    render: (props) => (
+      <TourTooltip
+        {...props}
+        title="Recherche"
+        description="Filtre tes conversations par nom ou par message pour les retrouver rapidement."
+        total={CONVERSATIONS_STEPS_COUNT}
+      />
+    ),
+  },
+];
 
 export const ConversationsListScreen: React.FC = () => {
   const navigation = useNavigation<NavigationProp>();
@@ -585,287 +633,309 @@ export const ConversationsListScreen: React.FC = () => {
   };
 
   return (
-    <LinearGradient
-      colors={colors.background.gradient.app}
-      start={{ x: 0, y: 0 }}
-      end={{ x: 1, y: 1 }}
-      style={styles.gradientContainer}
+    <SpotlightTourProvider
+      steps={CONVERSATIONS_TOUR_STEPS}
+      overlayColor="#0B1124"
+      overlayOpacity={0.82}
+      placement="bottom"
+      offset={10}
     >
-      <SafeAreaView style={styles.container} edges={["top"]}>
-        <OfflineBanner connectionState={connectionState} />
-        {/* Header */}
-        <View
-          style={[
-            styles.header,
-            { borderBottomColor: "rgba(255, 255, 255, 0.1)" },
-          ]}
+      {() => (
+        <LinearGradient
+          colors={colors.background.gradient.app}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 1 }}
+          style={styles.gradientContainer}
         >
-          <View style={styles.headerLeftGroup}>
-            <TouchableOpacity
-              onPress={() => {
-                Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                setEditMode(!editMode);
-                if (editMode) {
-                  setSelectedConversations(new Set());
-                }
-              }}
-              style={[styles.headerButton, styles.editButtonPill]}
+          <TourAutoStart />
+          <SafeAreaView style={styles.container} edges={["top"]}>
+            <OfflineBanner connectionState={connectionState} />
+            {/* Header */}
+            <View
+              style={[
+                styles.header,
+                { borderBottomColor: "rgba(255, 255, 255, 0.1)" },
+              ]}
             >
-              <Text style={[styles.editButton, { color: colors.text.light }]}>
-                {editMode ? "Annuler" : "Modifier"}
-              </Text>
-            </TouchableOpacity>
-            {!editMode && (
-              <TouchableOpacity
-                onPress={() => {
-                  Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                  navigation.navigate("ArchivedConversations");
-                }}
-                style={[styles.headerButton, styles.archiveIconButton]}
-                accessibilityLabel={
-                  archivedUnreadCount > 0
-                    ? `Voir les conversations archivées (${archivedUnreadCount} non lues)`
-                    : "Voir les conversations archivées"
-                }
-              >
-                <Ionicons
-                  name="archive-outline"
-                  size={20}
-                  color={colors.text.light}
-                />
-                {archivedUnreadCount > 0 && (
-                  <View style={styles.archiveBadge}>
-                    <Text style={styles.archiveBadgeText}>
-                      {archivedUnreadCount > 99 ? "99+" : archivedUnreadCount}
-                    </Text>
-                  </View>
-                )}
-              </TouchableOpacity>
-            )}
-          </View>
-          <Text
-            style={[styles.headerTitle, { color: colors.text.light }]}
-          ></Text>
-          <View style={styles.headerRightGroup}>
-            <BellIcon
-              unreadCount={inboxUnreadCount}
-              onPress={() => setInboxPanelOpen(true)}
-            />
-            <TouchableOpacity
-              onPress={() => {
-                Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                setShowNewConversationModal(true);
-              }}
-              style={styles.headerButton}
-            >
-              <LinearGradient
-                colors={["#FFB07B", "#F04882"]}
-                start={{ x: 0, y: 0 }}
-                end={{ x: 1, y: 1 }}
-                style={styles.composeButton}
-              >
-                <Ionicons
-                  name="create-outline"
-                  size={20}
-                  color={colors.text.light}
-                />
-              </LinearGradient>
-            </TouchableOpacity>
-          </View>
-        </View>
-
-        {/* Search Bar */}
-        <View style={styles.searchContainer}>
-          <View
-            style={[
-              styles.searchBar,
-              { backgroundColor: "rgba(255, 255, 255, 0.15)" },
-            ]}
-          >
-            <Ionicons
-              name="search-outline"
-              size={20}
-              color="rgba(255, 255, 255, 0.7)"
-              style={styles.searchIcon}
-            />
-            <TextInput
-              style={[styles.searchInput, { color: colors.text.light }]}
-              placeholder="Rechercher des messages ou utilisateurs"
-              placeholderTextColor="rgba(255, 255, 255, 0.6)"
-              value={searchQuery}
-              onChangeText={(text) => {
-                setSearchQuery(text);
-                if (searchTimeoutRef.current) {
-                  clearTimeout(searchTimeoutRef.current);
-                }
-                if (!text.trim()) {
-                  setMessageSearchConvIds(new Set());
-                  return;
-                }
-                searchTimeoutRef.current = setTimeout(async () => {
-                  try {
-                    const results = await messagingAPI.searchMessagesGlobal(
-                      text.trim(),
-                      { limit: 50 },
-                    );
-                    if (results) {
-                      const convIds = new Set(
-                        results.map((msg) => msg.conversation_id),
-                      );
-                      setMessageSearchConvIds(convIds);
-                    } else {
-                      setMessageSearchConvIds(new Set());
+              <View style={styles.headerLeftGroup}>
+                <TouchableOpacity
+                  onPress={() => {
+                    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                    setEditMode(!editMode);
+                    if (editMode) {
+                      setSelectedConversations(new Set());
                     }
-                  } catch {
-                    setMessageSearchConvIds(new Set());
-                  }
-                }, 300);
-              }}
-            />
-            {searchQuery.length > 0 && (
-              <TouchableOpacity
-                onPress={() => {
-                  setSearchQuery("");
-                  setMessageSearchConvIds(new Set());
-                  if (searchTimeoutRef.current) {
-                    clearTimeout(searchTimeoutRef.current);
-                  }
-                }}
-                style={styles.clearButton}
-              >
-                <Ionicons
-                  name="close-circle"
-                  size={20}
-                  color="rgba(255, 255, 255, 0.7)"
-                />
-              </TouchableOpacity>
-            )}
-          </View>
-        </View>
-
-        {renderContent()}
-
-        <Toast
-          visible={toast.visible}
-          message={toast.message}
-          type={toast.type}
-          onHide={() => setToast({ ...toast, visible: false })}
-        />
-      </SafeAreaView>
-
-      {editMode && (
-        <View
-          pointerEvents="box-none"
-          style={[
-            styles.editActionsFloating,
-            { bottom: FLOATING_TAB_BAR_BOTTOM_OFFSET + insets.bottom },
-          ]}
-        >
-          <View style={styles.editActionsShadow}>
-            <View style={styles.editActionsClip}>
-              <BlurView
-                intensity={Platform.OS === "ios" ? 60 : 80}
-                tint="dark"
-                style={styles.editActionsBlur}
-              >
-                <View style={styles.editActionsOverlay}>
-                  <View style={styles.editActionsRow}>
-                    <TouchableOpacity
-                      style={styles.editActionButton}
-                      onPress={handleBulkDelete}
-                      disabled={selectedConversations.size === 0}
+                  }}
+                  style={[styles.headerButton, styles.editButtonPill]}
+                >
+                  <Text
+                    style={[styles.editButton, { color: colors.text.light }]}
+                  >
+                    {editMode ? "Annuler" : "Modifier"}
+                  </Text>
+                </TouchableOpacity>
+                {!editMode && (
+                  <TouchableOpacity
+                    onPress={() => {
+                      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                      navigation.navigate("ArchivedConversations");
+                    }}
+                    style={[styles.headerButton, styles.archiveIconButton]}
+                    accessibilityLabel={
+                      archivedUnreadCount > 0
+                        ? `Voir les conversations archivées (${archivedUnreadCount} non lues)`
+                        : "Voir les conversations archivées"
+                    }
+                  >
+                    <Ionicons
+                      name="archive-outline"
+                      size={20}
+                      color={colors.text.light}
+                    />
+                    {archivedUnreadCount > 0 && (
+                      <View style={styles.archiveBadge}>
+                        <Text style={styles.archiveBadgeText}>
+                          {archivedUnreadCount > 99
+                            ? "99+"
+                            : archivedUnreadCount}
+                        </Text>
+                      </View>
+                    )}
+                  </TouchableOpacity>
+                )}
+              </View>
+              <Text
+                style={[styles.headerTitle, { color: colors.text.light }]}
+              ></Text>
+              <View style={styles.headerRightGroup}>
+                <AttachStep index={1}>
+                  <BellIcon
+                    unreadCount={inboxUnreadCount}
+                    onPress={() => setInboxPanelOpen(true)}
+                  />
+                </AttachStep>
+                <AttachStep index={0}>
+                  <TouchableOpacity
+                    onPress={() => {
+                      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                      setShowNewConversationModal(true);
+                    }}
+                    style={styles.headerButton}
+                  >
+                    <LinearGradient
+                      colors={["#FFB07B", "#F04882"]}
+                      start={{ x: 0, y: 0 }}
+                      end={{ x: 1, y: 1 }}
+                      style={styles.composeButton}
                     >
                       <Ionicons
-                        name="trash-outline"
-                        size={24}
-                        color={
-                          selectedConversations.size === 0
-                            ? "rgba(255, 80, 80, 0.4)"
-                            : colors.ui.error
-                        }
+                        name="create-outline"
+                        size={20}
+                        color={colors.text.light}
                       />
-                      <Text
-                        style={[
-                          styles.editActionText,
-                          selectedConversations.size === 0 &&
-                            styles.editActionTextDisabled,
-                        ]}
-                      >
-                        Supprimer
-                      </Text>
-                    </TouchableOpacity>
-                    <TouchableOpacity
-                      style={styles.editActionButton}
-                      onPress={handleBulkArchive}
-                      disabled={selectedConversations.size === 0}
-                    >
-                      <Ionicons
-                        name="archive-outline"
-                        size={24}
-                        color={
-                          selectedConversations.size === 0
-                            ? "rgba(255, 255, 255, 0.4)"
-                            : colors.text.light
-                        }
-                      />
-                      <Text
-                        style={[
-                          styles.editActionText,
-                          selectedConversations.size === 0 &&
-                            styles.editActionTextDisabled,
-                        ]}
-                      >
-                        Archiver
-                      </Text>
-                    </TouchableOpacity>
-                    <TouchableOpacity
-                      style={styles.editActionButton}
-                      onPress={handleSelectAll}
-                    >
-                      <Ionicons
-                        name={
-                          selectedConversations.size ===
-                          filteredAndSortedConversations.length
-                            ? "checkmark-done-outline"
-                            : "checkmark-outline"
-                        }
-                        size={24}
-                        color={colors.primary.main}
-                      />
-                      <Text style={styles.editActionText}>
-                        {selectedConversations.size ===
-                        filteredAndSortedConversations.length
-                          ? "Désélec."
-                          : "Tout sélec."}
-                      </Text>
-                    </TouchableOpacity>
-                  </View>
-                </View>
-              </BlurView>
+                    </LinearGradient>
+                  </TouchableOpacity>
+                </AttachStep>
+              </View>
             </View>
-          </View>
-        </View>
+
+            {/* Search Bar */}
+            <AttachStep index={2}>
+              <View style={styles.searchContainer}>
+                <View
+                  style={[
+                    styles.searchBar,
+                    { backgroundColor: "rgba(255, 255, 255, 0.15)" },
+                  ]}
+                >
+                  <Ionicons
+                    name="search-outline"
+                    size={20}
+                    color="rgba(255, 255, 255, 0.7)"
+                    style={styles.searchIcon}
+                  />
+                  <TextInput
+                    style={[styles.searchInput, { color: colors.text.light }]}
+                    placeholder="Rechercher des messages ou utilisateurs"
+                    placeholderTextColor="rgba(255, 255, 255, 0.6)"
+                    value={searchQuery}
+                    onChangeText={(text) => {
+                      setSearchQuery(text);
+                      if (searchTimeoutRef.current) {
+                        clearTimeout(searchTimeoutRef.current);
+                      }
+                      if (!text.trim()) {
+                        setMessageSearchConvIds(new Set());
+                        return;
+                      }
+                      searchTimeoutRef.current = setTimeout(async () => {
+                        try {
+                          const results =
+                            await messagingAPI.searchMessagesGlobal(
+                              text.trim(),
+                              { limit: 50 },
+                            );
+                          if (results) {
+                            const convIds = new Set(
+                              results.map((msg) => msg.conversation_id),
+                            );
+                            setMessageSearchConvIds(convIds);
+                          } else {
+                            setMessageSearchConvIds(new Set());
+                          }
+                        } catch {
+                          setMessageSearchConvIds(new Set());
+                        }
+                      }, 300);
+                    }}
+                  />
+                  {searchQuery.length > 0 && (
+                    <TouchableOpacity
+                      onPress={() => {
+                        setSearchQuery("");
+                        setMessageSearchConvIds(new Set());
+                        if (searchTimeoutRef.current) {
+                          clearTimeout(searchTimeoutRef.current);
+                        }
+                      }}
+                      style={styles.clearButton}
+                    >
+                      <Ionicons
+                        name="close-circle"
+                        size={20}
+                        color="rgba(255, 255, 255, 0.7)"
+                      />
+                    </TouchableOpacity>
+                  )}
+                </View>
+              </View>
+            </AttachStep>
+
+            {renderContent()}
+
+            <Toast
+              visible={toast.visible}
+              message={toast.message}
+              type={toast.type}
+              onHide={() => setToast({ ...toast, visible: false })}
+            />
+          </SafeAreaView>
+
+          {editMode && (
+            <View
+              pointerEvents="box-none"
+              style={[
+                styles.editActionsFloating,
+                { bottom: FLOATING_TAB_BAR_BOTTOM_OFFSET + insets.bottom },
+              ]}
+            >
+              <View style={styles.editActionsShadow}>
+                <View style={styles.editActionsClip}>
+                  <BlurView
+                    intensity={Platform.OS === "ios" ? 60 : 80}
+                    tint="dark"
+                    style={styles.editActionsBlur}
+                  >
+                    <View style={styles.editActionsOverlay}>
+                      <View style={styles.editActionsRow}>
+                        <TouchableOpacity
+                          style={styles.editActionButton}
+                          onPress={handleBulkDelete}
+                          disabled={selectedConversations.size === 0}
+                        >
+                          <Ionicons
+                            name="trash-outline"
+                            size={24}
+                            color={
+                              selectedConversations.size === 0
+                                ? "rgba(255, 80, 80, 0.4)"
+                                : colors.ui.error
+                            }
+                          />
+                          <Text
+                            style={[
+                              styles.editActionText,
+                              selectedConversations.size === 0 &&
+                                styles.editActionTextDisabled,
+                            ]}
+                          >
+                            Supprimer
+                          </Text>
+                        </TouchableOpacity>
+                        <TouchableOpacity
+                          style={styles.editActionButton}
+                          onPress={handleBulkArchive}
+                          disabled={selectedConversations.size === 0}
+                        >
+                          <Ionicons
+                            name="archive-outline"
+                            size={24}
+                            color={
+                              selectedConversations.size === 0
+                                ? "rgba(255, 255, 255, 0.4)"
+                                : colors.text.light
+                            }
+                          />
+                          <Text
+                            style={[
+                              styles.editActionText,
+                              selectedConversations.size === 0 &&
+                                styles.editActionTextDisabled,
+                            ]}
+                          >
+                            Archiver
+                          </Text>
+                        </TouchableOpacity>
+                        <TouchableOpacity
+                          style={styles.editActionButton}
+                          onPress={handleSelectAll}
+                        >
+                          <Ionicons
+                            name={
+                              selectedConversations.size ===
+                              filteredAndSortedConversations.length
+                                ? "checkmark-done-outline"
+                                : "checkmark-outline"
+                            }
+                            size={24}
+                            color={colors.primary.main}
+                          />
+                          <Text style={styles.editActionText}>
+                            {selectedConversations.size ===
+                            filteredAndSortedConversations.length
+                              ? "Désélec."
+                              : "Tout sélec."}
+                          </Text>
+                        </TouchableOpacity>
+                      </View>
+                    </View>
+                  </BlurView>
+                </View>
+              </View>
+            </View>
+          )}
+
+          <NewConversationModal
+            visible={showNewConversationModal}
+            onClose={() => setShowNewConversationModal(false)}
+            onConversationCreated={async (conversationId) => {
+              setShowNewConversationModal(false);
+              await fetchConversations();
+              setTimeout(() => {
+                navigation.navigate("Chat", { conversationId });
+              }, 100);
+            }}
+          />
+
+          <InboxPanel
+            visible={inboxPanelOpen}
+            onClose={() => setInboxPanelOpen(false)}
+          />
+
+          <SafariPWABanner />
+        </LinearGradient>
       )}
-
-      <NewConversationModal
-        visible={showNewConversationModal}
-        onClose={() => setShowNewConversationModal(false)}
-        onConversationCreated={async (conversationId) => {
-          setShowNewConversationModal(false);
-          await fetchConversations();
-          setTimeout(() => {
-            navigation.navigate("Chat", { conversationId });
-          }, 100);
-        }}
-      />
-
-      <InboxPanel
-        visible={inboxPanelOpen}
-        onClose={() => setInboxPanelOpen(false)}
-      />
-
-      <SafariPWABanner />
-    </LinearGradient>
+    </SpotlightTourProvider>
   );
 };
 

--- a/src/screens/Chat/__tests__/ChatScreen.test.tsx
+++ b/src/screens/Chat/__tests__/ChatScreen.test.tsx
@@ -9,6 +9,18 @@ const mockGoBack = jest.fn();
 jest.mock("@react-navigation/native", () => ({
   useNavigation: () => ({ navigate: mockNavigate, goBack: mockGoBack }),
   useRoute: () => ({ params: { conversationId: "conv1" } }),
+  useFocusEffect: jest.fn(),
+}));
+jest.mock("react-native-spotlight-tour", () => ({
+  SpotlightTourProvider: ({ children }: any) =>
+    typeof children === "function" ? children({}) : children,
+  AttachStep: ({ children }: any) => children,
+}));
+jest.mock("../../../components/Tour/TourAutoStart", () => ({
+  TourAutoStart: () => null,
+}));
+jest.mock("../../../context/TourContext", () => ({
+  useTour: () => ({ isTourActive: false, skipTour: jest.fn() }),
 }));
 jest.mock("expo-linear-gradient", () => ({
   LinearGradient: ({ children }: any) => children,

--- a/src/screens/Contacts/ContactsScreen.tsx
+++ b/src/screens/Contacts/ContactsScreen.tsx
@@ -23,6 +23,13 @@ import React, {
   useMemo,
   useRef,
 } from "react";
+import {
+  AttachStep,
+  SpotlightTourProvider,
+  type TourStep,
+} from "react-native-spotlight-tour";
+import { TourTooltip } from "../../components/Tour/TourTooltip";
+import { TourAutoStart } from "../../components/Tour/TourAutoStart";
 import { formatUsername } from "../../utils";
 import {
   View,
@@ -78,6 +85,35 @@ declare module "@expo/vector-icons";
 
 // hauteur d'une row ContactItem (avatar 52 + padding vertical 14*2 + marginBottom 12)
 const CONTACT_ITEM_HEIGHT = 98;
+
+const CONTACTS_STEPS_COUNT = 2;
+
+const CONTACTS_TOUR_STEPS: TourStep[] = [
+  {
+    placement: "bottom",
+    offset: 10,
+    render: (props) => (
+      <TourTooltip
+        {...props}
+        title="Ajouter un contact"
+        description="Invite un nouveau contact via son identifiant Whispr ou son QR code."
+        total={CONTACTS_STEPS_COUNT}
+      />
+    ),
+  },
+  {
+    placement: "bottom",
+    offset: 10,
+    render: (props) => (
+      <TourTooltip
+        {...props}
+        title="Recherche"
+        description="Tape un nom ou un username pour retrouver un contact rapidement."
+        total={CONTACTS_STEPS_COUNT}
+      />
+    ),
+  },
+];
 
 export const ContactsScreen: React.FC = () => {
   const navigation =
@@ -316,420 +352,444 @@ export const ContactsScreen: React.FC = () => {
   );
 
   return (
-    <LinearGradient
-      colors={colors.background.gradient.app}
-      start={{ x: 0, y: 0 }}
-      end={{ x: 1, y: 1 }}
-      style={styles.gradientContainer}
+    <SpotlightTourProvider
+      steps={CONTACTS_TOUR_STEPS}
+      overlayColor="#0B1124"
+      overlayOpacity={0.82}
+      placement="bottom"
+      offset={10}
     >
-      <SafeAreaView style={styles.container} edges={["top"]}>
-        <View style={styles.topSection}>
-          <BlurView intensity={40} tint="dark" style={styles.headerBlur}>
-            <View style={styles.header}>
-              <View style={styles.headerCopy}>
-                <Text
-                  style={[
-                    styles.headerTitle,
-                    { color: themeColors.text.primary },
-                  ]}
-                >
-                  Contacts
-                </Text>
-                <Text style={styles.headerSubtitle}>Vos contact Whispr.</Text>
-              </View>
-              <View style={styles.headerActions}>
-                <BellIcon
-                  unreadCount={inboxUnreadCount}
-                  onPress={() => setInboxPanelOpen(true)}
-                />
-                <TouchableOpacity
-                  style={styles.headerIconButton}
-                  onPress={() => navigation.navigate("MyQRCode")}
-                  accessibilityLabel="Mon QR code"
-                >
-                  <Ionicons
-                    name="qr-code-outline"
-                    size={22}
-                    color={themeColors.text.primary}
-                  />
-                </TouchableOpacity>
-                <TouchableOpacity
-                  style={styles.headerIconButton}
-                  onPress={() => setShowAddModal(true)}
-                  accessibilityLabel="Ajouter un contact"
-                >
-                  <Ionicons
-                    name="add"
-                    size={22}
-                    color={themeColors.text.primary}
-                  />
-                </TouchableOpacity>
-              </View>
-            </View>
-          </BlurView>
-
-          <BlurView intensity={34} tint="dark" style={styles.searchShell}>
-            <View style={styles.searchContainer}>
-              <View style={styles.searchBar}>
-                <Ionicons
-                  name="search-outline"
-                  size={20}
-                  color="rgba(255, 255, 255, 0.7)"
-                  style={styles.searchIcon}
-                />
-                <TextInput
-                  style={[styles.searchInput, { color: colors.text.light }]}
-                  placeholder="Rechercher un contact"
-                  placeholderTextColor="rgba(255, 255, 255, 0.6)"
-                  value={searchQuery}
-                  onChangeText={handleSearchChange}
-                />
-                {searchQuery.length > 0 && (
-                  <TouchableOpacity
-                    onPress={() => handleSearchChange("")}
-                    style={styles.clearButton}
-                  >
-                    <Ionicons
-                      name="close-circle"
-                      size={20}
-                      color="rgba(255, 255, 255, 0.7)"
+      {() => (
+        <LinearGradient
+          colors={colors.background.gradient.app}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 1 }}
+          style={styles.gradientContainer}
+        >
+          <TourAutoStart />
+          <SafeAreaView style={styles.container} edges={["top"]}>
+            <View style={styles.topSection}>
+              <BlurView intensity={40} tint="dark" style={styles.headerBlur}>
+                <View style={styles.header}>
+                  <View style={styles.headerCopy}>
+                    <Text
+                      style={[
+                        styles.headerTitle,
+                        { color: themeColors.text.primary },
+                      ]}
+                    >
+                      Contacts
+                    </Text>
+                    <Text style={styles.headerSubtitle}>
+                      Vos contact Whispr.
+                    </Text>
+                  </View>
+                  <View style={styles.headerActions}>
+                    <BellIcon
+                      unreadCount={inboxUnreadCount}
+                      onPress={() => setInboxPanelOpen(true)}
                     />
-                  </TouchableOpacity>
-                )}
-              </View>
-            </View>
-          </BlurView>
-
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={styles.filtersContainer}
-          >
-            <TouchableOpacity
-              style={[
-                styles.filterButton,
-                sortBy === "name" && styles.filterButtonActivePrimary,
-              ]}
-              onPress={() => setSortBy("name")}
-            >
-              <Ionicons
-                name="text-outline"
-                size={16}
-                color={
-                  sortBy === "name"
-                    ? colors.text.light
-                    : themeColors.text.secondary
-                }
-              />
-              <Text
-                style={[
-                  styles.filterText,
-                  sortBy === "name" && styles.filterTextActive,
-                  sortBy !== "name" && {
-                    color: themeColors.text.secondary,
-                  },
-                ]}
-              >
-                A-Z
-              </Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={[
-                styles.filterButton,
-                sortBy === "added_at" && styles.filterButtonActivePrimary,
-              ]}
-              onPress={() => setSortBy("added_at")}
-            >
-              <Ionicons
-                name="time-outline"
-                size={16}
-                color={
-                  sortBy === "added_at"
-                    ? colors.text.light
-                    : themeColors.text.secondary
-                }
-              />
-              <Text
-                style={[
-                  styles.filterText,
-                  sortBy === "added_at" && styles.filterTextActive,
-                  sortBy !== "added_at" && {
-                    color: themeColors.text.secondary,
-                  },
-                ]}
-              >
-                Récent
-              </Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={[
-                styles.filterButton,
-                sortBy === "last_seen" && styles.filterButtonActivePrimary,
-              ]}
-              onPress={() => setSortBy("last_seen")}
-            >
-              <Ionicons
-                name="pulse-outline"
-                size={16}
-                color={
-                  sortBy === "last_seen"
-                    ? colors.text.light
-                    : themeColors.text.secondary
-                }
-              />
-              <Text
-                style={[
-                  styles.filterText,
-                  sortBy === "last_seen" && styles.filterTextActive,
-                  sortBy !== "last_seen" && {
-                    color: themeColors.text.secondary,
-                  },
-                ]}
-              >
-                Actif
-              </Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={[
-                styles.filterButton,
-                showFavoritesOnly && styles.filterButtonActivePrimary,
-              ]}
-              onPress={() => setShowFavoritesOnly(!showFavoritesOnly)}
-            >
-              <Ionicons
-                name="star"
-                size={16}
-                color={
-                  showFavoritesOnly
-                    ? colors.text.light
-                    : themeColors.text.secondary
-                }
-              />
-            </TouchableOpacity>
-          </ScrollView>
-
-          <View style={styles.actionsRow}>
-            <TouchableOpacity
-              style={styles.filterButton}
-              onPress={() => setShowSyncModal(true)}
-            >
-              <Ionicons
-                name="sync"
-                size={16}
-                color={themeColors.text.secondary}
-              />
-              <Text
-                style={[
-                  styles.filterText,
-                  { color: themeColors.text.secondary },
-                ]}
-              >
-                Synchroniser
-              </Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={styles.filterButton}
-              onPress={() => {
-                navigation.navigate("BlockedUsers");
-              }}
-            >
-              <Ionicons
-                name="ban-outline"
-                size={16}
-                color={themeColors.text.secondary}
-              />
-              <Text
-                style={[
-                  styles.filterText,
-                  { color: themeColors.text.secondary },
-                ]}
-              >
-                Bloqués
-              </Text>
-            </TouchableOpacity>
-          </View>
-        </View>
-
-        {/* Contact Requests */}
-        {loadingRequests &&
-        pendingRequests.length === 0 ? null : pendingRequests.length > 0 ? (
-          <BlurView intensity={34} tint="dark" style={styles.requestsBlur}>
-            <View style={styles.requestsContainer}>
-              <Text
-                style={[
-                  styles.requestsTitle,
-                  { color: themeColors.text.primary },
-                ]}
-              >
-                Demandes de contact
-              </Text>
-              {pendingRequests.map((request) => {
-                const isIncoming = request.recipient_id === userId;
-                const user = isIncoming
-                  ? request.requester_user
-                  : request.recipient_user;
-                const displayName =
-                  user?.first_name || user?.username || "Utilisateur";
-
-                return (
-                  <View key={request.id} style={styles.requestItem}>
-                    <View style={styles.requestInfo}>
-                      <Text
-                        style={[
-                          styles.requestName,
-                          { color: themeColors.text.primary },
-                        ]}
-                        numberOfLines={1}
+                    <TouchableOpacity
+                      style={styles.headerIconButton}
+                      onPress={() => navigation.navigate("MyQRCode")}
+                      accessibilityLabel="Mon QR code"
+                    >
+                      <Ionicons
+                        name="qr-code-outline"
+                        size={22}
+                        color={themeColors.text.primary}
+                      />
+                    </TouchableOpacity>
+                    <AttachStep index={0}>
+                      <TouchableOpacity
+                        style={styles.headerIconButton}
+                        onPress={() => setShowAddModal(true)}
+                        accessibilityLabel="Ajouter un contact"
                       >
-                        {displayName}
-                      </Text>
-                      {user?.username && (
-                        <Text
-                          style={[
-                            styles.requestSubtitle,
-                            { color: themeColors.text.secondary },
-                          ]}
-                          numberOfLines={1}
+                        <Ionicons
+                          name="add"
+                          size={22}
+                          color={themeColors.text.primary}
+                        />
+                      </TouchableOpacity>
+                    </AttachStep>
+                  </View>
+                </View>
+              </BlurView>
+
+              <AttachStep index={1}>
+                <BlurView intensity={34} tint="dark" style={styles.searchShell}>
+                  <View style={styles.searchContainer}>
+                    <View style={styles.searchBar}>
+                      <Ionicons
+                        name="search-outline"
+                        size={20}
+                        color="rgba(255, 255, 255, 0.7)"
+                        style={styles.searchIcon}
+                      />
+                      <TextInput
+                        style={[
+                          styles.searchInput,
+                          { color: colors.text.light },
+                        ]}
+                        placeholder="Rechercher un contact"
+                        placeholderTextColor="rgba(255, 255, 255, 0.6)"
+                        value={searchQuery}
+                        onChangeText={handleSearchChange}
+                      />
+                      {searchQuery.length > 0 && (
+                        <TouchableOpacity
+                          onPress={() => handleSearchChange("")}
+                          style={styles.clearButton}
                         >
-                          {formatUsername(user.username)}
-                        </Text>
+                          <Ionicons
+                            name="close-circle"
+                            size={20}
+                            color="rgba(255, 255, 255, 0.7)"
+                          />
+                        </TouchableOpacity>
                       )}
                     </View>
-                    {isIncoming && (
-                      <View style={styles.requestActions}>
-                        <TouchableOpacity
-                          style={[
-                            styles.requestButton,
-                            styles.requestAcceptButton,
-                          ]}
-                          onPress={() => handleAcceptRequest(request)}
-                        >
-                          <Ionicons
-                            name="checkmark"
-                            size={16}
-                            color={colors.text.light}
-                          />
-                        </TouchableOpacity>
-                        <TouchableOpacity
-                          style={[
-                            styles.requestButton,
-                            styles.requestRefuseButton,
-                          ]}
-                          onPress={() => handleRefuseRequest(request)}
-                        >
-                          <Ionicons
-                            name="close"
-                            size={16}
-                            color={colors.text.light}
-                          />
-                        </TouchableOpacity>
-                      </View>
-                    )}
                   </View>
-                );
-              })}
-            </View>
-          </BlurView>
-        ) : null}
+                </BlurView>
+              </AttachStep>
 
-        {/* Contacts List */}
-        {loading && contacts.length === 0 ? (
-          <View style={styles.skeletonContainer}>
-            {[...Array(6)].map((_, i) => (
-              <ContactItemSkeleton key={i} />
-            ))}
-          </View>
-        ) : filteredContacts.length === 0 ? (
-          <View style={styles.emptyContainer}>
-            <Ionicons
-              name="people-outline"
-              size={64}
-              color={themeColors.text.tertiary}
-            />
-            <Text
-              style={[styles.emptyText, { color: themeColors.text.secondary }]}
-            >
-              {searchQuery ? "Aucun contact trouvé" : "Aucun contact"}
-            </Text>
-            {!searchQuery && (
-              <Text
-                style={[
-                  styles.emptySubtext,
-                  { color: themeColors.text.tertiary },
-                ]}
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={styles.filtersContainer}
               >
-                Appuyez sur + pour ajouter un contact
-              </Text>
-            )}
-          </View>
-        ) : (
-          <FlatList
-            data={filteredContacts}
-            renderItem={renderContact}
-            keyExtractor={keyExtractor}
-            getItemLayout={getItemLayout}
-            style={styles.list}
-            showsVerticalScrollIndicator={Platform.OS === "web"}
-            refreshControl={
-              <RefreshControl
-                refreshing={refreshing}
-                onRefresh={handleRefresh}
-                tintColor={colors.text.light}
+                <TouchableOpacity
+                  style={[
+                    styles.filterButton,
+                    sortBy === "name" && styles.filterButtonActivePrimary,
+                  ]}
+                  onPress={() => setSortBy("name")}
+                >
+                  <Ionicons
+                    name="text-outline"
+                    size={16}
+                    color={
+                      sortBy === "name"
+                        ? colors.text.light
+                        : themeColors.text.secondary
+                    }
+                  />
+                  <Text
+                    style={[
+                      styles.filterText,
+                      sortBy === "name" && styles.filterTextActive,
+                      sortBy !== "name" && {
+                        color: themeColors.text.secondary,
+                      },
+                    ]}
+                  >
+                    A-Z
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[
+                    styles.filterButton,
+                    sortBy === "added_at" && styles.filterButtonActivePrimary,
+                  ]}
+                  onPress={() => setSortBy("added_at")}
+                >
+                  <Ionicons
+                    name="time-outline"
+                    size={16}
+                    color={
+                      sortBy === "added_at"
+                        ? colors.text.light
+                        : themeColors.text.secondary
+                    }
+                  />
+                  <Text
+                    style={[
+                      styles.filterText,
+                      sortBy === "added_at" && styles.filterTextActive,
+                      sortBy !== "added_at" && {
+                        color: themeColors.text.secondary,
+                      },
+                    ]}
+                  >
+                    Récent
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[
+                    styles.filterButton,
+                    sortBy === "last_seen" && styles.filterButtonActivePrimary,
+                  ]}
+                  onPress={() => setSortBy("last_seen")}
+                >
+                  <Ionicons
+                    name="pulse-outline"
+                    size={16}
+                    color={
+                      sortBy === "last_seen"
+                        ? colors.text.light
+                        : themeColors.text.secondary
+                    }
+                  />
+                  <Text
+                    style={[
+                      styles.filterText,
+                      sortBy === "last_seen" && styles.filterTextActive,
+                      sortBy !== "last_seen" && {
+                        color: themeColors.text.secondary,
+                      },
+                    ]}
+                  >
+                    Actif
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[
+                    styles.filterButton,
+                    showFavoritesOnly && styles.filterButtonActivePrimary,
+                  ]}
+                  onPress={() => setShowFavoritesOnly(!showFavoritesOnly)}
+                >
+                  <Ionicons
+                    name="star"
+                    size={16}
+                    color={
+                      showFavoritesOnly
+                        ? colors.text.light
+                        : themeColors.text.secondary
+                    }
+                  />
+                </TouchableOpacity>
+              </ScrollView>
+
+              <View style={styles.actionsRow}>
+                <TouchableOpacity
+                  style={styles.filterButton}
+                  onPress={() => setShowSyncModal(true)}
+                >
+                  <Ionicons
+                    name="sync"
+                    size={16}
+                    color={themeColors.text.secondary}
+                  />
+                  <Text
+                    style={[
+                      styles.filterText,
+                      { color: themeColors.text.secondary },
+                    ]}
+                  >
+                    Synchroniser
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={styles.filterButton}
+                  onPress={() => {
+                    navigation.navigate("BlockedUsers");
+                  }}
+                >
+                  <Ionicons
+                    name="ban-outline"
+                    size={16}
+                    color={themeColors.text.secondary}
+                  />
+                  <Text
+                    style={[
+                      styles.filterText,
+                      { color: themeColors.text.secondary },
+                    ]}
+                  >
+                    Bloqués
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+
+            {/* Contact Requests */}
+            {loadingRequests &&
+            pendingRequests.length === 0 ? null : pendingRequests.length > 0 ? (
+              <BlurView intensity={34} tint="dark" style={styles.requestsBlur}>
+                <View style={styles.requestsContainer}>
+                  <Text
+                    style={[
+                      styles.requestsTitle,
+                      { color: themeColors.text.primary },
+                    ]}
+                  >
+                    Demandes de contact
+                  </Text>
+                  {pendingRequests.map((request) => {
+                    const isIncoming = request.recipient_id === userId;
+                    const user = isIncoming
+                      ? request.requester_user
+                      : request.recipient_user;
+                    const displayName =
+                      user?.first_name || user?.username || "Utilisateur";
+
+                    return (
+                      <View key={request.id} style={styles.requestItem}>
+                        <View style={styles.requestInfo}>
+                          <Text
+                            style={[
+                              styles.requestName,
+                              { color: themeColors.text.primary },
+                            ]}
+                            numberOfLines={1}
+                          >
+                            {displayName}
+                          </Text>
+                          {user?.username && (
+                            <Text
+                              style={[
+                                styles.requestSubtitle,
+                                { color: themeColors.text.secondary },
+                              ]}
+                              numberOfLines={1}
+                            >
+                              {formatUsername(user.username)}
+                            </Text>
+                          )}
+                        </View>
+                        {isIncoming && (
+                          <View style={styles.requestActions}>
+                            <TouchableOpacity
+                              style={[
+                                styles.requestButton,
+                                styles.requestAcceptButton,
+                              ]}
+                              onPress={() => handleAcceptRequest(request)}
+                            >
+                              <Ionicons
+                                name="checkmark"
+                                size={16}
+                                color={colors.text.light}
+                              />
+                            </TouchableOpacity>
+                            <TouchableOpacity
+                              style={[
+                                styles.requestButton,
+                                styles.requestRefuseButton,
+                              ]}
+                              onPress={() => handleRefuseRequest(request)}
+                            >
+                              <Ionicons
+                                name="close"
+                                size={16}
+                                color={colors.text.light}
+                              />
+                            </TouchableOpacity>
+                          </View>
+                        )}
+                      </View>
+                    );
+                  })}
+                </View>
+              </BlurView>
+            ) : null}
+
+            {/* Contacts List */}
+            {loading && contacts.length === 0 ? (
+              <View style={styles.skeletonContainer}>
+                {[...Array(6)].map((_, i) => (
+                  <ContactItemSkeleton key={i} />
+                ))}
+              </View>
+            ) : filteredContacts.length === 0 ? (
+              <View style={styles.emptyContainer}>
+                <Ionicons
+                  name="people-outline"
+                  size={64}
+                  color={themeColors.text.tertiary}
+                />
+                <Text
+                  style={[
+                    styles.emptyText,
+                    { color: themeColors.text.secondary },
+                  ]}
+                >
+                  {searchQuery ? "Aucun contact trouvé" : "Aucun contact"}
+                </Text>
+                {!searchQuery && (
+                  <Text
+                    style={[
+                      styles.emptySubtext,
+                      { color: themeColors.text.tertiary },
+                    ]}
+                  >
+                    Appuyez sur + pour ajouter un contact
+                  </Text>
+                )}
+              </View>
+            ) : (
+              <FlatList
+                data={filteredContacts}
+                renderItem={renderContact}
+                keyExtractor={keyExtractor}
+                getItemLayout={getItemLayout}
+                style={styles.list}
+                showsVerticalScrollIndicator={Platform.OS === "web"}
+                refreshControl={
+                  <RefreshControl
+                    refreshing={refreshing}
+                    onRefresh={handleRefresh}
+                    tintColor={colors.text.light}
+                  />
+                }
+                contentContainerStyle={[
+                  styles.listContent,
+                  {
+                    paddingTop: 8,
+                    paddingBottom:
+                      insets.bottom + FLOATING_TAB_BAR_RESERVED_SPACE,
+                  },
+                ]}
               />
-            }
-            contentContainerStyle={[
-              styles.listContent,
-              {
-                paddingTop: 8,
-                paddingBottom: insets.bottom + FLOATING_TAB_BAR_RESERVED_SPACE,
-              },
-            ]}
+            )}
+
+            {/* Add Contact Modal */}
+            <AddContactModal
+              visible={showAddModal}
+              onClose={() => setShowAddModal(false)}
+              onContactAdded={() => {
+                loadContacts();
+                loadContactRequests();
+              }}
+              onMessageUser={(conversationId) => {
+                setShowAddModal(false);
+                navigation.navigate("Chat", { conversationId });
+              }}
+            />
+
+            {/* Edit Contact Modal */}
+            <EditContactModal
+              visible={!!editingContact}
+              contact={editingContact}
+              onClose={() => setEditingContact(null)}
+              onContactUpdated={loadContacts}
+            />
+
+            {/* Delete Contact Modal */}
+            <DeleteContactModal
+              visible={!!deletingContact}
+              contact={deletingContact}
+              onClose={() => setDeletingContact(null)}
+              onContactDeleted={loadContacts}
+            />
+
+            {/* Sync Contacts Modal */}
+            <SyncContactsModal
+              visible={showSyncModal}
+              onClose={() => setShowSyncModal(false)}
+              onContactsSynced={loadContacts}
+            />
+          </SafeAreaView>
+
+          <InboxPanel
+            visible={inboxPanelOpen}
+            onClose={() => setInboxPanelOpen(false)}
           />
-        )}
-
-        {/* Add Contact Modal */}
-        <AddContactModal
-          visible={showAddModal}
-          onClose={() => setShowAddModal(false)}
-          onContactAdded={() => {
-            loadContacts();
-            loadContactRequests();
-          }}
-          onMessageUser={(conversationId) => {
-            setShowAddModal(false);
-            navigation.navigate("Chat", { conversationId });
-          }}
-        />
-
-        {/* Edit Contact Modal */}
-        <EditContactModal
-          visible={!!editingContact}
-          contact={editingContact}
-          onClose={() => setEditingContact(null)}
-          onContactUpdated={loadContacts}
-        />
-
-        {/* Delete Contact Modal */}
-        <DeleteContactModal
-          visible={!!deletingContact}
-          contact={deletingContact}
-          onClose={() => setDeletingContact(null)}
-          onContactDeleted={loadContacts}
-        />
-
-        {/* Sync Contacts Modal */}
-        <SyncContactsModal
-          visible={showSyncModal}
-          onClose={() => setShowSyncModal(false)}
-          onContactsSynced={loadContacts}
-        />
-      </SafeAreaView>
-
-      <InboxPanel
-        visible={inboxPanelOpen}
-        onClose={() => setInboxPanelOpen(false)}
-      />
-    </LinearGradient>
+        </LinearGradient>
+      )}
+    </SpotlightTourProvider>
   );
 };
 

--- a/src/screens/Profile/MyProfileScreen.tsx
+++ b/src/screens/Profile/MyProfileScreen.tsx
@@ -23,6 +23,13 @@
 
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import {
+  AttachStep,
+  SpotlightTourProvider,
+  type TourStep,
+} from "react-native-spotlight-tour";
+import { TourTooltip } from "../../components/Tour/TourTooltip";
+import { TourAutoStart } from "../../components/Tour/TourAutoStart";
+import {
   View,
   Text,
   StyleSheet,
@@ -120,6 +127,35 @@ const pickImageFromWeb = (
     input.click();
   });
 };
+
+const PROFILE_STEPS_COUNT = 2;
+
+const PROFILE_TOUR_STEPS: TourStep[] = [
+  {
+    placement: "bottom",
+    offset: 10,
+    render: (props) => (
+      <TourTooltip
+        {...props}
+        title="Photo de profil"
+        description="Appuie sur ta photo pour la changer. Elle est visible par tes contacts."
+        total={PROFILE_STEPS_COUNT}
+      />
+    ),
+  },
+  {
+    placement: "bottom",
+    offset: 10,
+    render: (props) => (
+      <TourTooltip
+        {...props}
+        title="Modifier le profil"
+        description="Mets à jour ton nom, ta bio et tes préférences de confidentialité."
+        total={PROFILE_STEPS_COUNT}
+      />
+    ),
+  },
+];
 
 export const MyProfileScreen: React.FC = () => {
   const { userId: currentUserId } = useAuth();
@@ -700,14 +736,16 @@ export const MyProfileScreen: React.FC = () => {
       <TouchableOpacity onPress={handleHomePress} style={styles.iconButton}>
         <Ionicons name="chatbubbles" size={24} color={colors.text.light} />
       </TouchableOpacity>
-      <TouchableOpacity
-        onPress={() => setIsEditing(true)}
-        style={styles.iconButton}
-        accessibilityRole="button"
-        accessibilityLabel="Modifier le profil"
-      >
-        <Ionicons name="pencil" size={22} color={colors.text.light} />
-      </TouchableOpacity>
+      <AttachStep index={1}>
+        <TouchableOpacity
+          onPress={() => setIsEditing(true)}
+          style={styles.iconButton}
+          accessibilityRole="button"
+          accessibilityLabel="Modifier le profil"
+        >
+          <Ionicons name="pencil" size={22} color={colors.text.light} />
+        </TouchableOpacity>
+      </AttachStep>
     </>
   ) : (
     <TouchableOpacity
@@ -722,238 +760,264 @@ export const MyProfileScreen: React.FC = () => {
   );
 
   return (
-    <LinearGradient
-      colors={colors.background.gradient.app}
-      start={{ x: 0, y: 0 }}
-      end={{ x: 1, y: 1 }}
-      style={styles.container}
+    <SpotlightTourProvider
+      steps={PROFILE_TOUR_STEPS}
+      overlayColor="#0B1124"
+      overlayOpacity={0.82}
+      placement="bottom"
+      offset={10}
     >
-      <KeyboardAvoidingView
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
-        style={styles.keyboardView}
-      >
-        <Animated.View
-          style={[
-            styles.content,
-            {
-              opacity: fadeAnim,
-              transform: [{ translateY: slideAnim }],
-            },
-          ]}
+      {() => (
+        <LinearGradient
+          colors={colors.background.gradient.app}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 1 }}
+          style={styles.container}
         >
-          <ProfileHeader
-            title="Profil"
-            onBack={handleBackPress}
-            rightActions={rightActions}
-          />
-
-          <ScrollView
-            style={styles.scrollView}
-            contentContainerStyle={styles.scrollContent}
-            showsVerticalScrollIndicator={Platform.OS === "web"}
+          <TourAutoStart />
+          <KeyboardAvoidingView
+            behavior={Platform.OS === "ios" ? "padding" : "height"}
+            style={styles.keyboardView}
           >
-            <ProfilePictureBlock
-              uri={profile.profilePicture}
-              name={`${profile.firstName} ${profile.lastName}`.trim()}
-              editable={isEditing}
-              onPress={() => setShowImagePicker(true)}
-              label={isEditing ? "Appuyez pour changer" : "Photo de profil"}
-              scaleAnim={scaleAnim}
-            />
+            <Animated.View
+              style={[
+                styles.content,
+                {
+                  opacity: fadeAnim,
+                  transform: [{ translateY: slideAnim }],
+                },
+              ]}
+            >
+              <ProfileHeader
+                title="Profil"
+                onBack={handleBackPress}
+                rightActions={rightActions}
+              />
 
-            <View style={styles.profileInfo}>
-              {!profileLoaded ? (
-                <View style={styles.loadingRow}>
-                  <ActivityIndicator color="rgba(255,255,255,0.8)" />
-                  <Text style={styles.loadingText}>Chargement du profil</Text>
-                </View>
-              ) : profileLoadError ? (
-                <Text style={styles.loadErrorText}>{profileLoadError}</Text>
-              ) : null}
+              <ScrollView
+                style={styles.scrollView}
+                contentContainerStyle={styles.scrollContent}
+                showsVerticalScrollIndicator={Platform.OS === "web"}
+              >
+                <AttachStep index={0}>
+                  <ProfilePictureBlock
+                    uri={profile.profilePicture}
+                    name={`${profile.firstName} ${profile.lastName}`.trim()}
+                    editable={isEditing}
+                    onPress={() => setShowImagePicker(true)}
+                    label={
+                      isEditing ? "Appuyez pour changer" : "Photo de profil"
+                    }
+                    scaleAnim={scaleAnim}
+                  />
+                </AttachStep>
 
-              {isEditing ? (
-                <View style={styles.section}>
-                  <Text style={styles.sectionLabel}>Nom complet</Text>
-                  <View style={styles.nameInputsContainer}>
-                    <TextInput
-                      style={[styles.input, styles.nameInput]}
-                      value={profile.firstName}
-                      onChangeText={(text) =>
-                        handleFieldChange("firstName", text)
+                <View style={styles.profileInfo}>
+                  {!profileLoaded ? (
+                    <View style={styles.loadingRow}>
+                      <ActivityIndicator color="rgba(255,255,255,0.8)" />
+                      <Text style={styles.loadingText}>
+                        Chargement du profil
+                      </Text>
+                    </View>
+                  ) : profileLoadError ? (
+                    <Text style={styles.loadErrorText}>{profileLoadError}</Text>
+                  ) : null}
+
+                  {isEditing ? (
+                    <View style={styles.section}>
+                      <Text style={styles.sectionLabel}>Nom complet</Text>
+                      <View style={styles.nameInputsContainer}>
+                        <TextInput
+                          style={[styles.input, styles.nameInput]}
+                          value={profile.firstName}
+                          onChangeText={(text) =>
+                            handleFieldChange("firstName", text)
+                          }
+                          placeholder="Prénom"
+                          placeholderTextColor="rgba(255,255,255,0.5)"
+                        />
+                        <TextInput
+                          style={[styles.input, styles.nameInput]}
+                          value={profile.lastName}
+                          onChangeText={(text) =>
+                            handleFieldChange("lastName", text)
+                          }
+                          placeholder="Nom"
+                          placeholderTextColor="rgba(255,255,255,0.5)"
+                        />
+                      </View>
+                    </View>
+                  ) : (
+                    <ProfileFieldRow
+                      label="Nom complet"
+                      value={
+                        profile.firstName || profile.lastName
+                          ? `${profile.firstName} ${profile.lastName}`.trim()
+                          : undefined
                       }
-                      placeholder="Prénom"
-                      placeholderTextColor="rgba(255,255,255,0.5)"
                     />
-                    <TextInput
-                      style={[styles.input, styles.nameInput]}
-                      value={profile.lastName}
-                      onChangeText={(text) =>
-                        handleFieldChange("lastName", text)
+                  )}
+
+                  {isEditing ? (
+                    <View style={styles.section}>
+                      <Text style={styles.sectionLabel}>Nom d'utilisateur</Text>
+                      <TextInput
+                        style={styles.input}
+                        value={profile.username}
+                        onChangeText={(text) =>
+                          handleFieldChange("username", text)
+                        }
+                        placeholder="@nomdutilisateur"
+                        placeholderTextColor={colors.text.placeholder}
+                        autoCapitalize="none"
+                      />
+                      {!!fieldErrors.username && (
+                        <Text style={styles.fieldErrorText}>
+                          {fieldErrors.username}
+                        </Text>
+                      )}
+                      {!fieldErrors.username && (
+                        <Text style={styles.fieldHelperText}>
+                          Lettres Unicode, chiffres et _ autorisés. Normalisé à
+                          l'enregistrement.
+                        </Text>
+                      )}
+                    </View>
+                  ) : (
+                    <ProfileFieldRow
+                      label="Nom d'utilisateur"
+                      value={
+                        profile.username
+                          ? formatUsername(profile.username)
+                          : undefined
                       }
-                      placeholder="Nom"
-                      placeholderTextColor="rgba(255,255,255,0.5)"
+                    />
+                  )}
+
+                  <ProfileFieldRow
+                    label="Numéro de téléphone"
+                    value={profile.phoneNumber}
+                  />
+
+                  {isEditing ? (
+                    <View style={styles.section}>
+                      <Text style={styles.sectionLabel}>Biographie</Text>
+                      <TextInput
+                        style={[styles.input, styles.biographyInput]}
+                        value={profile.biography}
+                        onChangeText={(text) =>
+                          handleFieldChange("biography", text)
+                        }
+                        placeholder="Parlez-nous de vous..."
+                        placeholderTextColor={colors.text.placeholder}
+                        multiline
+                        numberOfLines={4}
+                        textAlignVertical="top"
+                        maxLength={500}
+                      />
+                      <Text style={styles.characterCount}>
+                        {(profile.biography || "").length}/500 caractères
+                      </Text>
+                    </View>
+                  ) : (
+                    <ProfileFieldRow
+                      label="Biographie"
+                      value={profile.biography}
+                    />
+                  )}
+
+                  <StatusChip
+                    isOnline={profile.isOnline}
+                    lastSeen={profile.lastSeen}
+                  />
+
+                  {profile.createdAt && (
+                    <ProfileFieldRow
+                      label="Membre depuis"
+                      value={new Date(profile.createdAt).toLocaleDateString(
+                        "fr-FR",
+                        {
+                          day: "2-digit",
+                          month: "long",
+                          year: "numeric",
+                        },
+                      )}
+                    />
+                  )}
+                </View>
+
+                {isEditing && (
+                  <View style={styles.actionButtons}>
+                    <Button
+                      title={loading ? "Sauvegarde" : "Sauvegarder"}
+                      variant="primary"
+                      size="large"
+                      onPress={handleSaveProfile}
+                      loading={loading}
+                      fullWidth
                     />
                   </View>
-                </View>
-              ) : (
-                <ProfileFieldRow
-                  label="Nom complet"
-                  value={
-                    profile.firstName || profile.lastName
-                      ? `${profile.firstName} ${profile.lastName}`.trim()
-                      : undefined
-                  }
-                />
-              )}
+                )}
+              </ScrollView>
+            </Animated.View>
+          </KeyboardAvoidingView>
 
-              {isEditing ? (
-                <View style={styles.section}>
-                  <Text style={styles.sectionLabel}>Nom d'utilisateur</Text>
-                  <TextInput
-                    style={styles.input}
-                    value={profile.username}
-                    onChangeText={(text) => handleFieldChange("username", text)}
-                    placeholder="@nomdutilisateur"
-                    placeholderTextColor={colors.text.placeholder}
-                    autoCapitalize="none"
+          <Modal
+            visible={showImagePicker}
+            transparent
+            animationType="fade"
+            onRequestClose={() => setShowImagePicker(false)}
+          >
+            <View style={styles.alertOverlay}>
+              <View style={styles.alertCard}>
+                <Text style={styles.alertTitle}>
+                  Changer la photo de profil
+                </Text>
+                <Text style={styles.alertSubtitle}>
+                  Sélectionnez une option
+                </Text>
+
+                <TouchableOpacity
+                  style={styles.alertAction}
+                  onPress={handleCameraCapture}
+                >
+                  <Ionicons
+                    name="camera"
+                    size={18}
+                    color="#0A84FF"
+                    style={styles.alertIcon}
                   />
-                  {!!fieldErrors.username && (
-                    <Text style={styles.fieldErrorText}>
-                      {fieldErrors.username}
-                    </Text>
-                  )}
-                  {!fieldErrors.username && (
-                    <Text style={styles.fieldHelperText}>
-                      Lettres Unicode, chiffres et _ autorisés. Normalisé à
-                      l'enregistrement.
-                    </Text>
-                  )}
-                </View>
-              ) : (
-                <ProfileFieldRow
-                  label="Nom d'utilisateur"
-                  value={
-                    profile.username
-                      ? formatUsername(profile.username)
-                      : undefined
-                  }
-                />
-              )}
+                  <Text style={styles.alertActionText}>Prendre une photo</Text>
+                </TouchableOpacity>
 
-              <ProfileFieldRow
-                label="Numéro de téléphone"
-                value={profile.phoneNumber}
-              />
-
-              {isEditing ? (
-                <View style={styles.section}>
-                  <Text style={styles.sectionLabel}>Biographie</Text>
-                  <TextInput
-                    style={[styles.input, styles.biographyInput]}
-                    value={profile.biography}
-                    onChangeText={(text) =>
-                      handleFieldChange("biography", text)
-                    }
-                    placeholder="Parlez-nous de vous..."
-                    placeholderTextColor={colors.text.placeholder}
-                    multiline
-                    numberOfLines={4}
-                    textAlignVertical="top"
-                    maxLength={500}
+                <TouchableOpacity
+                  style={styles.alertAction}
+                  onPress={handleImagePicker}
+                >
+                  <Ionicons
+                    name="image"
+                    size={18}
+                    color="#0A84FF"
+                    style={styles.alertIcon}
                   />
-                  <Text style={styles.characterCount}>
-                    {(profile.biography || "").length}/500 caractères
+                  <Text style={styles.alertActionText}>
+                    Choisir depuis la galerie
                   </Text>
-                </View>
-              ) : (
-                <ProfileFieldRow label="Biographie" value={profile.biography} />
-              )}
+                </TouchableOpacity>
 
-              <StatusChip
-                isOnline={profile.isOnline}
-                lastSeen={profile.lastSeen}
-              />
-
-              {profile.createdAt && (
-                <ProfileFieldRow
-                  label="Membre depuis"
-                  value={new Date(profile.createdAt).toLocaleDateString(
-                    "fr-FR",
-                    {
-                      day: "2-digit",
-                      month: "long",
-                      year: "numeric",
-                    },
-                  )}
-                />
-              )}
-            </View>
-
-            {isEditing && (
-              <View style={styles.actionButtons}>
-                <Button
-                  title={loading ? "Sauvegarde" : "Sauvegarder"}
-                  variant="primary"
-                  size="large"
-                  onPress={handleSaveProfile}
-                  loading={loading}
-                  fullWidth
-                />
+                <TouchableOpacity
+                  style={styles.alertCancel}
+                  onPress={() => setShowImagePicker(false)}
+                >
+                  <Text style={styles.alertCancelText}>Continuer</Text>
+                </TouchableOpacity>
               </View>
-            )}
-          </ScrollView>
-        </Animated.View>
-      </KeyboardAvoidingView>
-
-      <Modal
-        visible={showImagePicker}
-        transparent
-        animationType="fade"
-        onRequestClose={() => setShowImagePicker(false)}
-      >
-        <View style={styles.alertOverlay}>
-          <View style={styles.alertCard}>
-            <Text style={styles.alertTitle}>Changer la photo de profil</Text>
-            <Text style={styles.alertSubtitle}>Sélectionnez une option</Text>
-
-            <TouchableOpacity
-              style={styles.alertAction}
-              onPress={handleCameraCapture}
-            >
-              <Ionicons
-                name="camera"
-                size={18}
-                color="#0A84FF"
-                style={styles.alertIcon}
-              />
-              <Text style={styles.alertActionText}>Prendre une photo</Text>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              style={styles.alertAction}
-              onPress={handleImagePicker}
-            >
-              <Ionicons
-                name="image"
-                size={18}
-                color="#0A84FF"
-                style={styles.alertIcon}
-              />
-              <Text style={styles.alertActionText}>
-                Choisir depuis la galerie
-              </Text>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              style={styles.alertCancel}
-              onPress={() => setShowImagePicker(false)}
-            >
-              <Text style={styles.alertCancelText}>Continuer</Text>
-            </TouchableOpacity>
-          </View>
-        </View>
-      </Modal>
-    </LinearGradient>
+            </View>
+          </Modal>
+        </LinearGradient>
+      )}
+    </SpotlightTourProvider>
   );
 };
 

--- a/src/screens/__tests__/PartialScreens.smoke.test.tsx
+++ b/src/screens/__tests__/PartialScreens.smoke.test.tsx
@@ -337,6 +337,18 @@ jest.mock("@react-navigation/native", () => {
   };
 });
 
+jest.mock("react-native-spotlight-tour", () => ({
+  SpotlightTourProvider: ({ children }: any) =>
+    typeof children === "function" ? children({}) : children,
+  AttachStep: ({ children }: any) => children,
+}));
+jest.mock("../../components/Tour/TourAutoStart", () => ({
+  TourAutoStart: () => null,
+}));
+jest.mock("../../context/TourContext", () => ({
+  useTour: () => ({ isTourActive: false, skipTour: jest.fn() }),
+}));
+
 import React from "react";
 import { render } from "@testing-library/react-native";
 

--- a/src/services/__tests__/apiBase.test.ts
+++ b/src/services/__tests__/apiBase.test.ts
@@ -15,7 +15,7 @@ jest.mock("expo-constants", () => ({
   default: mockConstants,
 }));
 
-const FALLBACK_DEV = "https://whispr.devzeyu.com";
+const FALLBACK_DEV = "https://whispr-preprod.roadmvn.com";
 
 describe("getApiBaseUrl", () => {
   const originalDev = (global as { __DEV__?: boolean }).__DEV__;

--- a/src/services/apiBase.ts
+++ b/src/services/apiBase.ts
@@ -8,7 +8,7 @@ import Constants from "expo-constants";
  * attaquant qui rachèterait ce domaine intercepterait toutes les
  * requêtes auth/messages des builds qui n'auraient pas reçu d'env.
  */
-const APP_CONFIG_DEFAULT_API = "https://whispr.devzeyu.com";
+const APP_CONFIG_DEFAULT_API = "https://whispr-preprod.roadmvn.com";
 
 function pickBaseUrl(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;


### PR DESCRIPTION
## Summary
- Contextual product tour using `react-native-spotlight-tour` — 12 steps across 5 screens (Discussions, Chat, Contacts, Appels, Profil)
- Tour triggers automatically 700ms after first screen focus, once per install (AsyncStorage flag `whispr_tour_done`)
- Each screen is self-contained with its own `SpotlightTourProvider` + `AttachStep` highlights
- "Passer" ends the tour globally, "Terminer" completes the current screen and continues on the next
- Dev mode auto-resets the flag on each launch for easy testing (`__DEV__` guard)
- Fixed default API base URL to `whispr-preprod.roadmvn.com`

## Test plan
- [ ] Tour starts automatically after login on ConversationsList
- [ ] Steps advance correctly with "Suivant" (1/3 → 2/3 → 3/3)
- [ ] Navigating to Chat/Contacts/Appels/Profil triggers their own tour
- [ ] "Passer" stops the tour globally and never restarts on any screen
- [ ] After app restart in prod build, tour does not reappear
- [ ] Unit tests green (149/149)
- [ ] TypeScript clean