### PR TITLE
feat(chat): enable E2EE by default on direct conversations

### DIFF
--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -852,7 +852,6 @@ export const ChatScreen: React.FC = () => {
             let signature: string | undefined;
             let sender_public_key: string | undefined;
             if (
-              e2eeEnabledRef.current &&
               queued.message_type === "text" &&
               conversation?.type === "direct"
             ) {

--- a/src/screens/Profile/MyProfileScreen.tsx
+++ b/src/screens/Profile/MyProfileScreen.tsx
@@ -134,7 +134,7 @@ const PROFILE_TOUR_STEPS: TourStep[] = [
   {
     placement: "bottom",
     offset: 10,
-    render: (props) => (
+    render: (props: Record<string, unknown>) => (
       <TourTooltip
         {...props}
         title="Photo de profil"
@@ -146,7 +146,7 @@ const PROFILE_TOUR_STEPS: TourStep[] = [
   {
     placement: "bottom",
     offset: 10,
-    render: (props) => (
+    render: (props: Record<string, unknown>) => (
       <TourTooltip
         {...props}
         title="Modifier le profil"

--- a/src/screens/Profile/MyProfileScreen.tsx
+++ b/src/screens/Profile/MyProfileScreen.tsx
@@ -134,7 +134,7 @@ const PROFILE_TOUR_STEPS: TourStep[] = [
   {
     placement: "bottom",
     offset: 10,
-    render: (props: Record<string, unknown>) => (
+    render: (props: import("react-native-spotlight-tour").RenderProps) => (
       <TourTooltip
         {...props}
         title="Photo de profil"
@@ -146,7 +146,7 @@ const PROFILE_TOUR_STEPS: TourStep[] = [
   {
     placement: "bottom",
     offset: 10,
-    render: (props: Record<string, unknown>) => (
+    render: (props: import("react-native-spotlight-tour").RenderProps) => (
       <TourTooltip
         {...props}
         title="Modifier le profil"


### PR DESCRIPTION
## Summary

E2EE texte actif par defaut sur toutes les conversations directes, sans toggle manuel.

- Aligne le comportement texte avec les medias (deja chiffres par defaut sur les convs directes)
- Le fallback opportuniste de DALM1 reste intact : si les cles du destinataire manquent, message passe en clair
- Fix TS7006/TS2740 sur MyProfileScreen (RenderProps tour)

## Test plan
- [ ] Conv directe : message envoye chiffre automatiquement
- [ ] Destinataire sans cles : fallback clair sans crash
- [ ] Conv de groupe : aucun changement (direct uniquement)