### PR TITLE
fix(tour): use useIsFocused for reliable tour start on all screens

### DIFF
--- a/src/components/Tour/TourAutoStart.tsx
+++ b/src/components/Tour/TourAutoStart.tsx
@@ -1,19 +1,18 @@
-import React, { useCallback } from "react";
-import { useFocusEffect } from "@react-navigation/native";
+import React, { useEffect } from "react";
+import { useIsFocused } from "@react-navigation/native";
 import { useSpotlightTour } from "react-native-spotlight-tour";
 import { useTour } from "../../context/TourContext";
 
 export const TourAutoStart: React.FC = () => {
   const { start } = useSpotlightTour();
   const { isTourActive } = useTour();
+  const isFocused = useIsFocused();
 
-  useFocusEffect(
-    useCallback(() => {
-      if (!isTourActive) return;
-      const timer = setTimeout(start, 700);
-      return () => clearTimeout(timer);
-    }, [isTourActive, start]),
-  );
+  useEffect(() => {
+    if (!isFocused || !isTourActive) return;
+    const timer = setTimeout(start, 700);
+    return () => clearTimeout(timer);
+  }, [isFocused, isTourActive, start]);
 
   return null;
 };

--- a/src/screens/Chat/__tests__/ConversationsListScreen.test.tsx
+++ b/src/screens/Chat/__tests__/ConversationsListScreen.test.tsx
@@ -8,6 +8,7 @@ jest.mock("@react-navigation/native", () => ({
   useNavigation: () => ({ navigate: mockNavigate, goBack: jest.fn() }),
   useRoute: () => ({ params: {} }),
   useFocusEffect: jest.fn(),
+  useIsFocused: jest.fn(() => true),
 }));
 jest.mock("expo-linear-gradient", () => ({
   LinearGradient: ({ children }: any) => children,

--- a/src/screens/Contacts/__tests__/ContactsScreen.test.tsx
+++ b/src/screens/Contacts/__tests__/ContactsScreen.test.tsx
@@ -14,6 +14,7 @@ jest.mock("@react-navigation/native", () => ({
     const React = require("react");
     React.useEffect(() => cb(), []);
   },
+  useIsFocused: jest.fn(() => true),
 }));
 jest.mock("expo-linear-gradient", () => ({
   LinearGradient: ({ children }: any) => children,

--- a/src/screens/Profile/__tests__/MyProfileScreen.test.tsx
+++ b/src/screens/Profile/__tests__/MyProfileScreen.test.tsx
@@ -16,6 +16,7 @@ jest.mock("@react-navigation/native", () => ({
     const React = require("react");
     React.useEffect(() => cb(), []);
   },
+  useIsFocused: jest.fn(() => true),
 }));
 jest.mock("react-native-safe-area-context", () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),

--- a/src/screens/__tests__/PartialScreens.smoke.test.tsx
+++ b/src/screens/__tests__/PartialScreens.smoke.test.tsx
@@ -334,6 +334,7 @@ jest.mock("@react-navigation/native", () => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
       }, []);
     },
+    useIsFocused: jest.fn(() => true),
   };
 });
 


### PR DESCRIPTION
## Summary
- Replace `useFocusEffect` + `useCallback` with `useIsFocused` + `useEffect` in `TourAutoStart`
- `useFocusEffect` was not firing reliably when `TourAutoStart` is nested inside `SpotlightTourProvider`'s render prop on non-initial tab screens (Contacts, Calls, Profile, Chat)
- `useIsFocused` returns a boolean that re-triggers `useEffect` on every focus change, regardless of component tree depth

## Test plan
- [x] 149/149 test suites pass (1397 tests)
- [x] Added `useIsFocused: jest.fn(() => true)` to navigation mocks in affected test files
- [ ] Tour starts correctly on all 5 screens: Conversations, Contacts, Calls, Profile, Chat