### PR TITLE
feat(tour): product tour across 5 screens with Settings toggle

### DIFF
--- a/src/components/Tour/TourTooltip.tsx
+++ b/src/components/Tour/TourTooltip.tsx
@@ -10,7 +10,6 @@ import { BlurView } from "expo-blur";
 import { Ionicons } from "@expo/vector-icons";
 import { useSpotlightTour } from "react-native-spotlight-tour";
 import type { RenderProps } from "react-native-spotlight-tour";
-import { useTour } from "../../context/TourContext";
 import { colors } from "../../theme/colors";
 
 const CORAL = colors.primary.main;
@@ -31,11 +30,9 @@ export const TourTooltip: React.FC<TourTooltipProps> = ({
   total,
 }) => {
   const { stop } = useSpotlightTour();
-  const { skipTour } = useTour();
 
   const handleSkip = () => {
     stop();
-    skipTour();
   };
 
   const handleNext = () => {

--- a/src/context/TourContext.tsx
+++ b/src/context/TourContext.tsx
@@ -1,13 +1,4 @@
-import React, {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useState,
-} from "react";
-import AsyncStorage from "@react-native-async-storage/async-storage";
-
-const TOUR_DONE_KEY = "whispr_tour_done";
+import React, { createContext, useCallback, useContext, useState } from "react";
 
 type TourContextType = {
   isTourActive: boolean;
@@ -16,7 +7,7 @@ type TourContextType = {
 };
 
 const TourContext = createContext<TourContextType>({
-  isTourActive: false,
+  isTourActive: true,
   skipTour: () => {},
   replayTour: () => {},
 });
@@ -26,23 +17,8 @@ export const TourProvider: React.FC<{ children: React.ReactNode }> = ({
 }) => {
   const [isTourActive, setIsTourActive] = useState(true);
 
-  useEffect(() => {
-    const load = async () => {
-      const v = await AsyncStorage.getItem(TOUR_DONE_KEY);
-      setIsTourActive(v !== "1");
-    };
-    load();
-  }, []);
-
-  const skipTour = useCallback(() => {
-    setIsTourActive(false);
-    AsyncStorage.setItem(TOUR_DONE_KEY, "1");
-  }, []);
-
-  const replayTour = useCallback(() => {
-    AsyncStorage.removeItem(TOUR_DONE_KEY);
-    setIsTourActive(true);
-  }, []);
+  const skipTour = useCallback(() => setIsTourActive(false), []);
+  const replayTour = useCallback(() => setIsTourActive(true), []);
 
   return (
     <TourContext.Provider value={{ isTourActive, replayTour, skipTour }}>

--- a/src/context/TourContext.tsx
+++ b/src/context/TourContext.tsx
@@ -24,7 +24,7 @@ const TourContext = createContext<TourContextType>({
 export const TourProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const [isTourActive, setIsTourActive] = useState(false);
+  const [isTourActive, setIsTourActive] = useState(true);
 
   useEffect(() => {
     const load = async () => {

--- a/src/context/TourContext.tsx
+++ b/src/context/TourContext.tsx
@@ -28,7 +28,6 @@ export const TourProvider: React.FC<{ children: React.ReactNode }> = ({
 
   useEffect(() => {
     const load = async () => {
-      if (__DEV__) await AsyncStorage.removeItem(TOUR_DONE_KEY);
       const v = await AsyncStorage.getItem(TOUR_DONE_KEY);
       setIsTourActive(v !== "1");
     };

--- a/src/context/TourContext.tsx
+++ b/src/context/TourContext.tsx
@@ -12,11 +12,13 @@ const TOUR_DONE_KEY = "whispr_tour_done";
 type TourContextType = {
   isTourActive: boolean;
   skipTour: () => void;
+  replayTour: () => void;
 };
 
 const TourContext = createContext<TourContextType>({
   isTourActive: false,
   skipTour: () => {},
+  replayTour: () => {},
 });
 
 export const TourProvider: React.FC<{ children: React.ReactNode }> = ({
@@ -38,8 +40,13 @@ export const TourProvider: React.FC<{ children: React.ReactNode }> = ({
     AsyncStorage.setItem(TOUR_DONE_KEY, "1");
   }, []);
 
+  const replayTour = useCallback(() => {
+    AsyncStorage.removeItem(TOUR_DONE_KEY);
+    setIsTourActive(true);
+  }, []);
+
   return (
-    <TourContext.Provider value={{ isTourActive, skipTour }}>
+    <TourContext.Provider value={{ isTourActive, replayTour, skipTour }}>
       {children}
     </TourContext.Provider>
   );

--- a/src/screens/Calls/CallHistoryScreen.tsx
+++ b/src/screens/Calls/CallHistoryScreen.tsx
@@ -125,7 +125,7 @@ export const CallHistoryScreen: React.FC = () => {
             ItemSeparatorComponent={() => <View style={{ height: 12 }} />}
             ListHeaderComponent={
               <View style={styles.headerBlock}>
-                <AttachStep index={0}>
+                <AttachStep index={0} fill>
                   <BlurView
                     intensity={45}
                     tint="dark"
@@ -149,7 +149,7 @@ export const CallHistoryScreen: React.FC = () => {
                     </View>
                   </BlurView>
                 </AttachStep>
-                <AttachStep index={1}>
+                <AttachStep index={1} fill>
                   <BlurView intensity={45} tint="dark" style={styles.heroBlur}>
                     <View style={styles.heroCard}>
                       <View style={styles.heroBadge}>

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -3057,7 +3057,7 @@ export const ChatScreen: React.FC = () => {
             edges={["top"]}
           >
             <OfflineBanner connectionState={connectionState} />
-            <AttachStep index={0}>
+            <AttachStep index={0} fill>
               <ChatHeader
                 conversationName={
                   conversation
@@ -3238,7 +3238,7 @@ export const ChatScreen: React.FC = () => {
                       />
                     </View>
                   )}
-                  <AttachStep index={1}>
+                  <AttachStep index={1} fill>
                     <MessageInput
                       onSend={handleSendMessage}
                       onSendMedia={handleSendMedia}

--- a/src/screens/Chat/ConversationsListScreen.tsx
+++ b/src/screens/Chat/ConversationsListScreen.tsx
@@ -740,7 +740,7 @@ export const ConversationsListScreen: React.FC = () => {
             </View>
 
             {/* Search Bar */}
-            <AttachStep index={2}>
+            <AttachStep index={2} fill>
               <View style={styles.searchContainer}>
                 <View
                   style={[

--- a/src/screens/Contacts/ContactsScreen.tsx
+++ b/src/screens/Contacts/ContactsScreen.tsx
@@ -417,7 +417,7 @@ export const ContactsScreen: React.FC = () => {
                 </View>
               </BlurView>
 
-              <AttachStep index={1}>
+              <AttachStep index={1} fill>
                 <BlurView intensity={34} tint="dark" style={styles.searchShell}>
                   <View style={styles.searchContainer}>
                     <View style={styles.searchBar}>

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -37,6 +37,7 @@ import {
 } from "../../services/NotificationService";
 import { setReadReceiptsEnabled } from "../../services/messaging/readReceiptsPref";
 import { SettingsChoiceAlert } from "./SettingsChoiceAlert";
+import { useTour } from "../../context/TourContext";
 import { DangerConfirmModal } from "../../components/Common/DangerConfirmModal";
 import { FLOATING_TAB_BAR_RESERVED_SPACE } from "../../components/Navigation/floatingTabBarLayout";
 import {
@@ -81,6 +82,7 @@ export const SettingsScreen: React.FC = () => {
   const { fetchMyRole } = useModerationStore();
   const isStaff = useIsStaff();
   const insets = useSafeAreaInsets();
+  const { replayTour } = useTour();
 
   const [showThemeModal, setShowThemeModal] = useState(false);
   const [showBackgroundModal, setShowBackgroundModal] = useState(false);
@@ -1204,6 +1206,12 @@ export const SettingsScreen: React.FC = () => {
                   : getLocalizedText("settings.fontSize.large")
             }
             onPress={() => setShowFontSizeModal(true)}
+          />
+          <SettingItem
+            label="Tour guidé"
+            subtitle="Rejouer le tour de présentation"
+            icon="compass-outline"
+            onPress={replayTour}
           />
         </SettingSection>
 

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -82,7 +82,7 @@ export const SettingsScreen: React.FC = () => {
   const { fetchMyRole } = useModerationStore();
   const isStaff = useIsStaff();
   const insets = useSafeAreaInsets();
-  const { replayTour } = useTour();
+  const { isTourActive, replayTour, skipTour: disableTour } = useTour();
 
   const [showThemeModal, setShowThemeModal] = useState(false);
   const [showBackgroundModal, setShowBackgroundModal] = useState(false);
@@ -1209,9 +1209,22 @@ export const SettingsScreen: React.FC = () => {
           />
           <SettingItem
             label="Tour guidé"
-            subtitle="Rejouer le tour de présentation"
+            subtitle="Afficher le tour de présentation"
             icon="compass-outline"
-            onPress={replayTour}
+            onPress={() => (isTourActive ? disableTour() : replayTour())}
+            rightComponent={
+              <Switch
+                value={isTourActive}
+                onValueChange={(value) =>
+                  value ? replayTour() : disableTour()
+                }
+                trackColor={{
+                  false: themeColors.text.tertiary,
+                  true: themeColors.primary,
+                }}
+                thumbColor="#FFFFFF"
+              />
+            }
           />
         </SettingSection>
 


### PR DESCRIPTION
## Summary
- Add contextual product tour on ConversationsList, Chat, Contacts, Calls, and Profile screens
- Fix \`AttachStep\` collapsing full-width components (added \`fill\` prop)
- Fix tour not starting on non-initial tab screens (switch from \`useFocusEffect\` to \`useIsFocused\`)
- Add Settings Switch to enable/disable the tour at any time
- Tour is always active on fresh app launch; \`Passer\` only closes the current overlay without disabling it
- Disabling the tour permanently is reserved for the Settings Switch

## Test plan
- [ ] Unit tests green
- [ ] Lint clean
- [ ] Tour starts on each app launch on all 5 screens
- [ ] \`Passer\` closes the overlay but Switch in Settings stays ON
- [ ] Settings Switch OFF disables the tour; Switch ON re-enables it
- [ ] ChatScreen header layout intact (name, avatar, call button visible)

Closes WHISPR-product-tour