### PR TITLE
fix(chat): restore search, info and scheduled buttons in chat header

### DIFF
--- a/src/screens/Chat/ChatHeader.tsx
+++ b/src/screens/Chat/ChatHeader.tsx
@@ -32,6 +32,9 @@ interface ChatHeaderProps {
   onAudioCallPress?: () => void;
   onVideoCallPress?: () => void;
   callsAvailable?: boolean;
+  onSearchPress?: () => void;
+  onInfoPress?: () => void;
+  onScheduledPress?: () => void;
 }
 
 const formatTypingLabel = (names: string[]): string => {
@@ -55,6 +58,9 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
   onAudioCallPress,
   onVideoCallPress,
   callsAvailable = true,
+  onSearchPress,
+  onInfoPress,
+  onScheduledPress,
 }) => {
   const navigation = useNavigation();
   const { getThemeColors } = useTheme();
@@ -191,6 +197,51 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
         </View>
       </TouchableOpacity>
       <View style={styles.actions}>
+        {onScheduledPress && (
+          <TouchableOpacity
+            onPress={onScheduledPress}
+            style={styles.actionButton}
+            hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
+            accessibilityRole="button"
+            accessibilityLabel="Messages programmés"
+          >
+            <Ionicons
+              name="timer-outline"
+              size={22}
+              color={themeColors.text.primary}
+            />
+          </TouchableOpacity>
+        )}
+        {onSearchPress && (
+          <TouchableOpacity
+            onPress={onSearchPress}
+            style={styles.actionButton}
+            hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
+            accessibilityRole="button"
+            accessibilityLabel="Rechercher"
+          >
+            <Ionicons
+              name="search"
+              size={22}
+              color={themeColors.text.primary}
+            />
+          </TouchableOpacity>
+        )}
+        {onInfoPress && (
+          <TouchableOpacity
+            onPress={onInfoPress}
+            style={styles.actionButton}
+            hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
+            accessibilityRole="button"
+            accessibilityLabel="Informations"
+          >
+            <Ionicons
+              name="information-circle-outline"
+              size={22}
+              color={themeColors.text.primary}
+            />
+          </TouchableOpacity>
+        )}
         {hasCallActions && (
           <TouchableOpacity
             onPress={handleCallButtonPress}
@@ -198,7 +249,6 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
               styles.actionButton,
               !callsAvailable && styles.actionButtonDisabled,
             ]}
-            // hitSlop pour respecter iOS HIG 44pt
             hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
             accessibilityRole="button"
             accessibilityLabel="Lancer un appel"

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -3084,6 +3084,9 @@ export const ChatScreen: React.FC = () => {
                   .map((id) => typingUsersNames[id])
                   .filter(Boolean)}
                 onTitlePress={handleInfoPress}
+                onSearchPress={() => setShowSearch(true)}
+                onInfoPress={handleInfoPress}
+                onScheduledPress={handleScheduledPress}
                 onAudioCallPress={() => handleInitiateCall("audio")}
                 onVideoCallPress={() => handleInitiateCall("video")}
                 callsAvailable={callsAvailability.available}


### PR DESCRIPTION
## Summary
- Restore the search (`search`), info (`information-circle-outline`) and scheduled (`timer-outline`) action buttons that were removed in the 75a2723 glassmorphism redesign
- Adds `onSearchPress`, `onInfoPress`, `onScheduledPress` props to `ChatHeaderProps`
- Wires them to the existing `ChatScreen` handlers (`setShowSearch`, `handleInfoPress`, `handleScheduledPress`)
- Unified call button (audio + video modal) is preserved

## Test plan
- [ ] Unit tests green
- [ ] Search button opens message search overlay
- [ ] Info button opens conversation info modal
- [ ] Scheduled button opens scheduled messages
- [ ] Call button still opens audio/video menu