### PR TITLE
revert(chat): disable E2EE by default on direct convs

### DIFF
--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -891,6 +891,7 @@ export const ChatScreen: React.FC = () => {
             let signature: string | undefined;
             let sender_public_key: string | undefined;
             if (
+              e2eeEnabledRef.current &&
               queued.message_type === "text" &&
               conversation?.type === "direct"
             ) {


### PR DESCRIPTION
Revert E2EE auto sur convs directes - bugs critiques cle identite + key_packets manquants destinataire. Toggle manuel reste dispo.