### PR TITLE
fix(chat): web regressions batch - E2EE leak + layout + onboarding

### DIFF
--- a/src/components/Chat/MessageBubble.tsx
+++ b/src/components/Chat/MessageBubble.tsx
@@ -44,6 +44,7 @@ import { useMessageSwipe } from "../../context/MessageSwipeContext";
 import { FormattedText } from "../../utils/textFormatter";
 import { isReachableUrl, formatHourMinute } from "../../utils";
 import { getApiBaseUrl } from "../../services/apiBase";
+import { E2EEService } from "../../services/E2EEService";
 import {
   extractFirstUrl,
   getLinkPreview,
@@ -292,11 +293,20 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
     message.content &&
     ["Photo", "Vidéo", "Fichier", "Message vocal"].includes(message.content);
 
+  // Belt-and-suspenders: si jamais une enveloppe E2EE brute remonte jusqu'ici
+  // (decryption ratee, message texte chiffre route via media, etc.), on
+  // remplace par un fallback lisible plutot que de leak la JSON dans la UI.
+  const rawContent = message.content || "";
+  const safeContent =
+    typeof rawContent === "string" && E2EEService.isEncryptedPayload(rawContent)
+      ? "[Message chiffré]"
+      : rawContent;
+
   const displayContent = isTombstoned
     ? "[Message supprimé]"
     : hasMedia && isDefaultMediaText
       ? "" // Don't show default text for media without caption
-      : message.content || "";
+      : safeContent;
 
   const firstLinkInMessage = useMemo(
     () => extractFirstUrl(message.content),

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -79,12 +79,23 @@ import { PinnedMessagesBar } from "../../components/Chat/PinnedMessagesBar";
 import { EmptyChatState } from "../../components/Chat/EmptyChatState";
 import { ChatHeader } from "./ChatHeader";
 import {
-  AttachStep,
-  SpotlightTourProvider,
+  AttachStep as RNAttachStep,
+  SpotlightTourProvider as RNSpotlightTourProvider,
   type TourStep,
 } from "react-native-spotlight-tour";
 import { TourTooltip } from "../../components/Tour/TourTooltip";
 import { TourAutoStart } from "../../components/Tour/TourAutoStart";
+
+// Le SpotlightTour casse le layout web (overlay SVG qui squeeze le flex root).
+// On garde le tour produit uniquement en natif iOS/Android.
+const IS_WEB = Platform.OS === "web";
+const SpotlightTourProvider: any = IS_WEB
+  ? ({ children }: { children: any }) =>
+      typeof children === "function" ? children() : children
+  : RNSpotlightTourProvider;
+const AttachStep: any = IS_WEB
+  ? ({ children }: { children: React.ReactNode }) => <>{children}</>
+  : RNAttachStep;
 
 const CHAT_STEPS_COUNT = 2;
 

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -533,8 +533,10 @@ export const ChatScreen: React.FC = () => {
       // casts below. Missing fields stay undefined and the `||` fallbacks
       // still kick in, so behaviour is unchanged.
       const message = incoming as MessageWithRelations;
+      // Ne pas filtrer sur message_type: si un payload chiffré arrive sur un
+      // type inattendu (media sans caption, futur type), on doit toujours le
+      // masquer pour eviter de leak la JSON envelope dans la UI.
       const isEncryptedIncoming =
-        message.message_type === "text" &&
         typeof message.content === "string" &&
         E2EEService.isEncryptedPayload(message.content);
       const displayMessage: MessageWithRelations = isEncryptedIncoming
@@ -554,7 +556,6 @@ export const ChatScreen: React.FC = () => {
                 ? {
                     ...displayMessage,
                     content:
-                      message.message_type === "text" &&
                       typeof message.content === "string" &&
                       E2EEService.isEncryptedPayload(message.content)
                         ? m.content
@@ -606,7 +607,6 @@ export const ChatScreen: React.FC = () => {
             newMessages[optimisticMessageIndex] = {
               ...displayMessage,
               content:
-                message.message_type === "text" &&
                 typeof message.content === "string" &&
                 E2EEService.isEncryptedPayload(message.content)
                   ? existing.content
@@ -712,7 +712,6 @@ export const ChatScreen: React.FC = () => {
     },
     onMessageUpdated: (message: Message) => {
       const isEncryptedUpdate =
-        message.message_type === "text" &&
         typeof message.content === "string" &&
         E2EEService.isEncryptedPayload(message.content);
       if (message.conversation_id === conversationId) {
@@ -1350,7 +1349,6 @@ export const ChatScreen: React.FC = () => {
             .map(async (msg) => {
               let displayContent = msg.content;
               if (
-                msg.message_type === "text" &&
                 typeof msg.content === "string" &&
                 E2EEService.isEncryptedPayload(msg.content)
               ) {


### PR DESCRIPTION
## Summary
- Disable SpotlightTour overlay on web to fix chat layout squeeze (kept native iOS/Android behaviour intact)
- Drop the `message_type === \"text\"` filter on the encrypted-payload guards so a JSON envelope can never reach the UI even when routed via an unexpected type
- Belt-and-suspenders: MessageBubble now replaces a raw E2EE envelope by `[Message chiffré]` before rendering, regardless of upstream filtering

## Severity
- P0 info disclosure fix: the raw E2EE envelope (identity_key, ciphertext boxes per-device, device_ids) is no longer rendered as message text in the chat UI.
- P1 layout: web chat layout no longer squeezed by the SpotlightTour SVG overlay.

## Test plan
- [x] npm test --watchAll=false --testPathPattern=\"ChatScreen|MessageBubble|OnboardingScreen\" -> 18/18 green
- [x] tsc --noEmit clean
- [ ] Smoke test on https://whispr-preprod.roadmvn.com after merge (chat layout web + send/receive E2EE)
- [ ] Verify tour still triggers on native iOS/Android

## Notes
- Onboarding \"Suivant\" button fix is already on `deploy/preprod` via PR #243 (commit a768e0bd), nothing to do here.
- ContactsScreen, ConversationsListScreen, MyProfileScreen, CallHistoryScreen also wrap with `SpotlightTourProvider`. They are left untouched in this PR to keep the scope tight; they should be audited next if web layout regressions appear there too.