### PR TITLE
fix(ui): extend SpotlightTour web guard to ConversationsList/Contacts/MyProfile/CallHistory

### DIFF
--- a/src/screens/Calls/CallHistoryScreen.tsx
+++ b/src/screens/Calls/CallHistoryScreen.tsx
@@ -1,11 +1,23 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Platform } from "react-native";
 import {
-  AttachStep,
-  SpotlightTourProvider,
+  AttachStep as RNAttachStep,
+  SpotlightTourProvider as RNSpotlightTourProvider,
   type TourStep,
 } from "react-native-spotlight-tour";
 import { TourTooltip } from "../../components/Tour/TourTooltip";
 import { TourAutoStart } from "../../components/Tour/TourAutoStart";
+
+// Le SpotlightTour casse le layout web (overlay SVG qui squeeze le flex root).
+// On garde le tour produit uniquement en natif iOS/Android.
+const IS_WEB = Platform.OS === "web";
+const SpotlightTourProvider: any = IS_WEB
+  ? ({ children }: { children: any }) =>
+      typeof children === "function" ? children() : children
+  : RNSpotlightTourProvider;
+const AttachStep: any = IS_WEB
+  ? ({ children }: { children: React.ReactNode }) => <>{children}</>
+  : RNAttachStep;
 
 const CALLS_STEPS_COUNT = 2;
 

--- a/src/screens/Chat/ConversationsListScreen.tsx
+++ b/src/screens/Chat/ConversationsListScreen.tsx
@@ -23,8 +23,8 @@
 
 import React, { useState, useEffect, useCallback, useMemo } from "react";
 import {
-  AttachStep,
-  SpotlightTourProvider,
+  AttachStep as RNAttachStep,
+  SpotlightTourProvider as RNSpotlightTourProvider,
   type TourStep,
 } from "react-native-spotlight-tour";
 import { TourTooltip } from "../../components/Tour/TourTooltip";
@@ -40,6 +40,17 @@ import {
   Platform,
   AppState,
 } from "react-native";
+
+// Le SpotlightTour casse le layout web (overlay SVG qui squeeze le flex root).
+// On garde le tour produit uniquement en natif iOS/Android.
+const IS_WEB = Platform.OS === "web";
+const SpotlightTourProvider: any = IS_WEB
+  ? ({ children }: { children: any }) =>
+      typeof children === "function" ? children() : children
+  : RNSpotlightTourProvider;
+const AttachStep: any = IS_WEB
+  ? ({ children }: { children: React.ReactNode }) => <>{children}</>
+  : RNAttachStep;
 import {
   SafeAreaView,
   useSafeAreaInsets,

--- a/src/screens/Contacts/ContactsScreen.tsx
+++ b/src/screens/Contacts/ContactsScreen.tsx
@@ -24,8 +24,8 @@ import React, {
   useRef,
 } from "react";
 import {
-  AttachStep,
-  SpotlightTourProvider,
+  AttachStep as RNAttachStep,
+  SpotlightTourProvider as RNSpotlightTourProvider,
   type TourStep,
 } from "react-native-spotlight-tour";
 import { TourTooltip } from "../../components/Tour/TourTooltip";
@@ -43,6 +43,17 @@ import {
   ScrollView,
   Platform,
 } from "react-native";
+
+// Le SpotlightTour casse le layout web (overlay SVG qui squeeze le flex root).
+// On garde le tour produit uniquement en natif iOS/Android.
+const IS_WEB = Platform.OS === "web";
+const SpotlightTourProvider: any = IS_WEB
+  ? ({ children }: { children: any }) =>
+      typeof children === "function" ? children() : children
+  : RNSpotlightTourProvider;
+const AttachStep: any = IS_WEB
+  ? ({ children }: { children: React.ReactNode }) => <>{children}</>
+  : RNAttachStep;
 import {
   SafeAreaView,
   useSafeAreaInsets,

--- a/src/screens/Profile/MyProfileScreen.tsx
+++ b/src/screens/Profile/MyProfileScreen.tsx
@@ -23,8 +23,8 @@
 
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import {
-  AttachStep,
-  SpotlightTourProvider,
+  AttachStep as RNAttachStep,
+  SpotlightTourProvider as RNSpotlightTourProvider,
   type TourStep,
 } from "react-native-spotlight-tour";
 import { TourTooltip } from "../../components/Tour/TourTooltip";
@@ -43,6 +43,17 @@ import {
   Platform,
   ActivityIndicator,
 } from "react-native";
+
+// Le SpotlightTour casse le layout web (overlay SVG qui squeeze le flex root).
+// On garde le tour produit uniquement en natif iOS/Android.
+const IS_WEB = Platform.OS === "web";
+const SpotlightTourProvider: any = IS_WEB
+  ? ({ children }: { children: any }) =>
+      typeof children === "function" ? children() : children
+  : RNSpotlightTourProvider;
+const AttachStep: any = IS_WEB
+  ? ({ children }: { children: React.ReactNode }) => <>{children}</>
+  : RNAttachStep;
 import { LinearGradient } from "expo-linear-gradient";
 import { useNavigation, useFocusEffect } from "@react-navigation/native";
 import type { StackNavigationProp } from "@react-navigation/stack";


### PR DESCRIPTION
## Summary
- Apply same Platform.OS !== 'web' guard for SpotlightTourProvider + AttachStep used by PR #245 to the 4 remaining screens
- Tour produit reste fonctionnel en native iOS/Android
- Fix layout squeeze + tour overlay visible on web

## Test plan
- npm test green (121/121 tests pass on touched screens)
- Tested on whispr-preprod.roadmvn.com after merge (manual)