### PR TITLE
fix(tour): restore SpotlightTour on web and bound overlay to child

### DIFF
--- a/src/screens/Calls/CallHistoryScreen.tsx
+++ b/src/screens/Calls/CallHistoryScreen.tsx
@@ -126,7 +126,7 @@ export const CallHistoryScreen: React.FC = () => {
             ItemSeparatorComponent={() => <View style={{ height: 12 }} />}
             ListHeaderComponent={
               <View style={styles.headerBlock}>
-                <AttachStep index={0} fill>
+                <AttachStep index={0} fill={Platform.OS !== "web"}>
                   <BlurView
                     intensity={45}
                     tint="dark"
@@ -150,7 +150,7 @@ export const CallHistoryScreen: React.FC = () => {
                     </View>
                   </BlurView>
                 </AttachStep>
-                <AttachStep index={1} fill>
+                <AttachStep index={1} fill={Platform.OS !== "web"}>
                   <BlurView intensity={45} tint="dark" style={styles.heroBlur}>
                     <View style={styles.heroCard}>
                       <View style={styles.heroBadge}>

--- a/src/screens/Calls/CallHistoryScreen.tsx
+++ b/src/screens/Calls/CallHistoryScreen.tsx
@@ -1,23 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Platform } from "react-native";
 import {
-  AttachStep as RNAttachStep,
-  SpotlightTourProvider as RNSpotlightTourProvider,
+  AttachStep,
+  SpotlightTourProvider,
   type TourStep,
 } from "react-native-spotlight-tour";
 import { TourTooltip } from "../../components/Tour/TourTooltip";
 import { TourAutoStart } from "../../components/Tour/TourAutoStart";
-
-// Le SpotlightTour casse le layout web (overlay SVG qui squeeze le flex root).
-// On garde le tour produit uniquement en natif iOS/Android.
-const IS_WEB = Platform.OS === "web";
-const SpotlightTourProvider: any = IS_WEB
-  ? ({ children }: { children: any }) =>
-      typeof children === "function" ? children() : children
-  : RNSpotlightTourProvider;
-const AttachStep: any = IS_WEB
-  ? ({ children }: { children: React.ReactNode }) => <>{children}</>
-  : RNAttachStep;
 
 const CALLS_STEPS_COUNT = 2;
 

--- a/src/screens/Calls/__tests__/CallHistoryScreen.test.tsx
+++ b/src/screens/Calls/__tests__/CallHistoryScreen.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from "react";
+import { Platform } from "react-native";
 import { render, waitFor } from "@testing-library/react-native";
 
 jest.mock("@expo/vector-icons", () => ({ Ionicons: () => null }));
@@ -101,5 +102,19 @@ describe("CallHistoryScreen", () => {
     mockListCalls.mockRejectedValue(new Error("boom"));
     const { findByText } = render(<CallHistoryScreen />);
     expect(await findByText("Aucun appel pour le moment")).toBeTruthy();
+  });
+});
+
+describe("CallHistoryScreen sur web", () => {
+  const originalOS = Platform.OS;
+  beforeAll(() => {
+    (Platform as { OS: string }).OS = "web";
+  });
+  afterAll(() => {
+    (Platform as { OS: string }).OS = originalOS;
+  });
+
+  it("rend sans planter (fill du tour borné au child)", () => {
+    expect(() => render(<CallHistoryScreen />)).not.toThrow();
   });
 });

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -79,23 +79,12 @@ import { PinnedMessagesBar } from "../../components/Chat/PinnedMessagesBar";
 import { EmptyChatState } from "../../components/Chat/EmptyChatState";
 import { ChatHeader } from "./ChatHeader";
 import {
-  AttachStep as RNAttachStep,
-  SpotlightTourProvider as RNSpotlightTourProvider,
+  AttachStep,
+  SpotlightTourProvider,
   type TourStep,
 } from "react-native-spotlight-tour";
 import { TourTooltip } from "../../components/Tour/TourTooltip";
 import { TourAutoStart } from "../../components/Tour/TourAutoStart";
-
-// Le SpotlightTour casse le layout web (overlay SVG qui squeeze le flex root).
-// On garde le tour produit uniquement en natif iOS/Android.
-const IS_WEB = Platform.OS === "web";
-const SpotlightTourProvider: any = IS_WEB
-  ? ({ children }: { children: any }) =>
-      typeof children === "function" ? children() : children
-  : RNSpotlightTourProvider;
-const AttachStep: any = IS_WEB
-  ? ({ children }: { children: React.ReactNode }) => <>{children}</>
-  : RNAttachStep;
 
 const CHAT_STEPS_COUNT = 2;
 

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -3093,7 +3093,7 @@ export const ChatScreen: React.FC = () => {
             edges={["top"]}
           >
             <OfflineBanner connectionState={connectionState} />
-            <AttachStep index={0} fill>
+            <AttachStep index={0} fill={Platform.OS !== "web"}>
               <ChatHeader
                 conversationName={
                   conversation
@@ -3318,7 +3318,7 @@ export const ChatScreen: React.FC = () => {
                       />
                     </View>
                   )}
-                  <AttachStep index={1} fill>
+                  <AttachStep index={1} fill={Platform.OS !== "web"}>
                     <MessageInput
                       onSend={handleSendMessage}
                       onSendMedia={handleSendMedia}

--- a/src/screens/Chat/ConversationsListScreen.tsx
+++ b/src/screens/Chat/ConversationsListScreen.tsx
@@ -740,7 +740,7 @@ export const ConversationsListScreen: React.FC = () => {
             </View>
 
             {/* Search Bar */}
-            <AttachStep index={2} fill>
+            <AttachStep index={2} fill={Platform.OS !== "web"}>
               <View style={styles.searchContainer}>
                 <View
                   style={[

--- a/src/screens/Chat/ConversationsListScreen.tsx
+++ b/src/screens/Chat/ConversationsListScreen.tsx
@@ -23,8 +23,8 @@
 
 import React, { useState, useEffect, useCallback, useMemo } from "react";
 import {
-  AttachStep as RNAttachStep,
-  SpotlightTourProvider as RNSpotlightTourProvider,
+  AttachStep,
+  SpotlightTourProvider,
   type TourStep,
 } from "react-native-spotlight-tour";
 import { TourTooltip } from "../../components/Tour/TourTooltip";
@@ -40,17 +40,6 @@ import {
   Platform,
   AppState,
 } from "react-native";
-
-// Le SpotlightTour casse le layout web (overlay SVG qui squeeze le flex root).
-// On garde le tour produit uniquement en natif iOS/Android.
-const IS_WEB = Platform.OS === "web";
-const SpotlightTourProvider: any = IS_WEB
-  ? ({ children }: { children: any }) =>
-      typeof children === "function" ? children() : children
-  : RNSpotlightTourProvider;
-const AttachStep: any = IS_WEB
-  ? ({ children }: { children: React.ReactNode }) => <>{children}</>
-  : RNAttachStep;
 import {
   SafeAreaView,
   useSafeAreaInsets,

--- a/src/screens/Chat/__tests__/ChatScreen.test.tsx
+++ b/src/screens/Chat/__tests__/ChatScreen.test.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Platform } from "react-native";
 import { render, waitFor } from "@testing-library/react-native";
 import { ChatScreen } from "../ChatScreen";
 import { messagingAPI } from "../../../services/messaging/api";
@@ -281,5 +282,19 @@ describe("ChatScreen", () => {
       expect(firstCall[0]).toBe("conv1");
       expect(typeof firstCall[1]).toBe("object");
     });
+  });
+});
+
+describe("ChatScreen sur web", () => {
+  const originalOS = Platform.OS;
+  beforeAll(() => {
+    (Platform as { OS: string }).OS = "web";
+  });
+  afterAll(() => {
+    (Platform as { OS: string }).OS = originalOS;
+  });
+
+  it("rend sans planter (fill du tour borné au child)", () => {
+    expect(() => render(<ChatScreen />)).not.toThrow();
   });
 });

--- a/src/screens/Chat/__tests__/ConversationsListScreen.test.tsx
+++ b/src/screens/Chat/__tests__/ConversationsListScreen.test.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Platform } from "react-native";
 import { render, fireEvent, waitFor } from "@testing-library/react-native";
 import { ConversationsListScreen } from "../ConversationsListScreen";
 
@@ -193,5 +194,19 @@ describe("ConversationsListScreen", () => {
     const { getByText } = render(<ConversationsListScreen />);
     fireEvent.press(getByText("Modifier"));
     expect(getByText("Annuler")).toBeTruthy();
+  });
+});
+
+describe("ConversationsListScreen sur web", () => {
+  const originalOS = Platform.OS;
+  beforeAll(() => {
+    (Platform as { OS: string }).OS = "web";
+  });
+  afterAll(() => {
+    (Platform as { OS: string }).OS = originalOS;
+  });
+
+  it("rend sans planter (fill du tour borné au child)", () => {
+    expect(() => render(<ConversationsListScreen />)).not.toThrow();
   });
 });

--- a/src/screens/Contacts/ContactsScreen.tsx
+++ b/src/screens/Contacts/ContactsScreen.tsx
@@ -417,7 +417,7 @@ export const ContactsScreen: React.FC = () => {
                 </View>
               </BlurView>
 
-              <AttachStep index={1} fill>
+              <AttachStep index={1} fill={Platform.OS !== "web"}>
                 <BlurView intensity={34} tint="dark" style={styles.searchShell}>
                   <View style={styles.searchContainer}>
                     <View style={styles.searchBar}>

--- a/src/screens/Contacts/ContactsScreen.tsx
+++ b/src/screens/Contacts/ContactsScreen.tsx
@@ -24,8 +24,8 @@ import React, {
   useRef,
 } from "react";
 import {
-  AttachStep as RNAttachStep,
-  SpotlightTourProvider as RNSpotlightTourProvider,
+  AttachStep,
+  SpotlightTourProvider,
   type TourStep,
 } from "react-native-spotlight-tour";
 import { TourTooltip } from "../../components/Tour/TourTooltip";
@@ -43,17 +43,6 @@ import {
   ScrollView,
   Platform,
 } from "react-native";
-
-// Le SpotlightTour casse le layout web (overlay SVG qui squeeze le flex root).
-// On garde le tour produit uniquement en natif iOS/Android.
-const IS_WEB = Platform.OS === "web";
-const SpotlightTourProvider: any = IS_WEB
-  ? ({ children }: { children: any }) =>
-      typeof children === "function" ? children() : children
-  : RNSpotlightTourProvider;
-const AttachStep: any = IS_WEB
-  ? ({ children }: { children: React.ReactNode }) => <>{children}</>
-  : RNAttachStep;
 import {
   SafeAreaView,
   useSafeAreaInsets,

--- a/src/screens/Contacts/__tests__/ContactsScreen.test.tsx
+++ b/src/screens/Contacts/__tests__/ContactsScreen.test.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Platform } from "react-native";
 import { render, fireEvent, waitFor } from "@testing-library/react-native";
 import { ContactsScreen } from "../ContactsScreen";
 import { contactsAPI } from "../../../services/contacts/api";
@@ -204,5 +205,19 @@ describe("ContactsScreen", () => {
         conversationId: "conv1",
       });
     });
+  });
+});
+
+describe("ContactsScreen sur web", () => {
+  const originalOS = Platform.OS;
+  beforeAll(() => {
+    (Platform as { OS: string }).OS = "web";
+  });
+  afterAll(() => {
+    (Platform as { OS: string }).OS = originalOS;
+  });
+
+  it("rend sans planter (fill du tour borné au child)", () => {
+    expect(() => render(<ContactsScreen />)).not.toThrow();
   });
 });

--- a/src/screens/Profile/MyProfileScreen.tsx
+++ b/src/screens/Profile/MyProfileScreen.tsx
@@ -23,8 +23,8 @@
 
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import {
-  AttachStep as RNAttachStep,
-  SpotlightTourProvider as RNSpotlightTourProvider,
+  AttachStep,
+  SpotlightTourProvider,
   type TourStep,
 } from "react-native-spotlight-tour";
 import { TourTooltip } from "../../components/Tour/TourTooltip";
@@ -43,17 +43,6 @@ import {
   Platform,
   ActivityIndicator,
 } from "react-native";
-
-// Le SpotlightTour casse le layout web (overlay SVG qui squeeze le flex root).
-// On garde le tour produit uniquement en natif iOS/Android.
-const IS_WEB = Platform.OS === "web";
-const SpotlightTourProvider: any = IS_WEB
-  ? ({ children }: { children: any }) =>
-      typeof children === "function" ? children() : children
-  : RNSpotlightTourProvider;
-const AttachStep: any = IS_WEB
-  ? ({ children }: { children: React.ReactNode }) => <>{children}</>
-  : RNAttachStep;
 import { LinearGradient } from "expo-linear-gradient";
 import { useNavigation, useFocusEffect } from "@react-navigation/native";
 import type { StackNavigationProp } from "@react-navigation/stack";


### PR DESCRIPTION
## Summary

PR #247 disabled SpotlightTour on web to work around an overlay-induced layout squeeze and an oversized highlight that hid the tooltip Next/Close buttons (most visible on the conversations search step).

This restores the tour on every platform and fixes the actual root cause: the `fill` prop on AttachStep expanded the spotlight overlay to the AttachStep parent, which on react-native-web resolves to the full-screen flex container.

## Changes

- **Commit 1 (revert)** — drop the Platform.OS guards that aliased SpotlightTourProvider / AttachStep to no-op pass-through on web in 5 screens (chat, conversations, contacts, profile, calls).
- **Commit 2 (fix)** — replace `fill` with `fill={Platform.OS !== "web"}` on the 6 AttachStep occurrences. Native iOS / Android behaviour is unchanged; web overlay now matches the wrapped child bounds.

## Test plan

- [x] tsc --noEmit clean
- [x] Targeted Jest suites (ConversationsListScreen, ChatScreen, ContactsScreen, CallHistoryScreen, MyProfileScreen, Tour) — 30/30 pass
- [ ] Manual verification on https://whispr-preprod.roadmvn.com after deploy
  - tour démarre à la connexion sur Conversations
  - step Recherche n'englobe plus tout l'écran et Next / Close restent cliquables
  - tours chat / contacts / calls : overlay bien bornée
- [ ] Smoke check iOS / Android native — tours doivent être strictement identiques à avant