### PR TITLE
feat(security): implement real biometric authentication gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "expo-image-manipulator": "~14.0.8",
         "expo-image-picker": "^17.0.8",
         "expo-linear-gradient": "^15.0.7",
+        "expo-local-authentication": "~17.0.8",
         "expo-notifications": "~0.32.12",
         "expo-secure-store": "~15.0.8",
         "expo-splash-screen": "~31.0.13",
@@ -7762,6 +7763,18 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-local-authentication": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/expo-local-authentication/-/expo-local-authentication-17.0.8.tgz",
+      "integrity": "sha512-Q5fXHhu6w3pVPlFCibU72SYIAN+9wX7QpFn9h49IUqs0Equ44QgswtGrxeh7fdnDqJrrYGPet5iBzjnE70uolA==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-manifests": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "expo-image-manipulator": "~14.0.8",
     "expo-image-picker": "^17.0.8",
     "expo-linear-gradient": "^15.0.7",
+    "expo-local-authentication": "~17.0.8",
     "expo-notifications": "~0.32.12",
     "expo-secure-store": "~15.0.8",
     "expo-splash-screen": "~31.0.13",

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -890,6 +890,15 @@ const localizedTexts: Record<Language, Record<string, string>> = {
     "security.minutesAgo": "Il y a",
     "security.hoursAgo": "Il y a",
     "security.daysAgo": "Il y a",
+    "biometric.lockSubtitle": "Authentifiez-vous pour continuer",
+    "biometric.unlockButton": "Déverrouiller",
+    "biometric.promptMessage": "Déverrouillez Whispr",
+    "biometric.cancelLabel": "Annuler",
+    "biometric.notAvailable":
+      "Authentification biométrique non disponible sur cet appareil",
+    "biometric.notEnrolled":
+      "Aucune empreinte ou Face ID configuré dans les réglages du système",
+    "biometric.enableConfirm": "Confirmer l'activation",
 
     // Two Factor Authentication
     "twoFactor.title": "Authentification à deux facteurs",
@@ -1227,6 +1236,15 @@ const localizedTexts: Record<Language, Record<string, string>> = {
     "security.minutesAgo": "ago",
     "security.hoursAgo": "ago",
     "security.daysAgo": "ago",
+    "biometric.lockSubtitle": "Authenticate to continue",
+    "biometric.unlockButton": "Unlock",
+    "biometric.promptMessage": "Unlock Whispr",
+    "biometric.cancelLabel": "Cancel",
+    "biometric.notAvailable":
+      "Biometric authentication is not available on this device",
+    "biometric.notEnrolled":
+      "No fingerprint or Face ID configured in system settings",
+    "biometric.enableConfirm": "Confirm activation",
 
     // Two Factor Authentication
     "twoFactor.title": "Two-Factor Authentication",

--- a/src/navigation/AuthNavigator.tsx
+++ b/src/navigation/AuthNavigator.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { createStackNavigator } from "@react-navigation/stack";
 import { CallsUnavailableScreen } from "../screens/Calls/CallsUnavailableScreen";
 import { isCallsAvailable } from "../hooks/useCallsAvailable";
@@ -213,10 +213,21 @@ export const AuthNavigator: React.FC = () => {
     isBiometricEnabled().then((enabled) => setBiometricLocked(enabled));
   }, [isAuthenticated]);
 
+  const backgroundedAtRef = useRef<number | null>(null);
+  const MIN_BACKGROUND_MS = 30_000;
+
   useEffect(() => {
     if (!isAuthenticated) return;
     const sub = AppState.addEventListener("change", (state) => {
-      if (state === "active") {
+      if (state === "background" || state === "inactive") {
+        backgroundedAtRef.current = Date.now();
+      } else if (state === "active") {
+        const backgroundedAt = backgroundedAtRef.current;
+        backgroundedAtRef.current = null;
+        const wasLongEnough =
+          backgroundedAt !== null &&
+          Date.now() - backgroundedAt >= MIN_BACKGROUND_MS;
+        if (!wasLongEnough) return;
         isBiometricEnabled().then((enabled) => {
           if (enabled) setBiometricLocked(true);
         });

--- a/src/navigation/AuthNavigator.tsx
+++ b/src/navigation/AuthNavigator.tsx
@@ -49,6 +49,8 @@ import {
   SanctionFormScreen,
 } from "../screens/Admin";
 
+import { AppState } from "react-native";
+import * as LocalAuthentication from "expo-local-authentication";
 import { useAuth } from "../context/AuthContext";
 import { useOfflineQueueDrainer } from "../hooks/useOfflineQueueDrainer";
 import { useModerationStore } from "../store/moderationStore";
@@ -56,7 +58,9 @@ import { useConversationsStore } from "../store/conversationsStore";
 import { profileSetupFlag } from "../services/profileSetupFlag";
 import { SplashScreen } from "../screens/SplashScreen/SplashScreen";
 import { OnboardingScreen } from "../screens/Auth/OnboardingScreen";
+import { BiometricLockScreen } from "../screens/Auth/BiometricLockScreen";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { storage as secureStorage } from "../services/storage";
 import { TourProvider } from "../context/TourContext";
 import { contactsAPI } from "../services/contacts/api";
 import { TokenService } from "../services/TokenService";
@@ -161,6 +165,8 @@ const Stack = createStackNavigator<AuthStackParamList>();
 
 const ONBOARDING_KEY = "@whispr:onboarding_done";
 
+const SECURITY_STORAGE_KEY = "whispr_settings_security";
+
 export const AuthNavigator: React.FC = () => {
   const { isLoading, isAuthenticated, userId } = useAuth();
   const [splashMinElapsed, setSplashMinElapsed] = useState(false);
@@ -168,6 +174,7 @@ export const AuthNavigator: React.FC = () => {
     boolean | null
   >(null);
   const [onboardingDone, setOnboardingDone] = useState<boolean | null>(null);
+  const [biometricLocked, setBiometricLocked] = useState<boolean | null>(null);
   const fetchMyRole = useModerationStore((s) => s.fetchMyRole);
   // Source de vérité unique pour la disponibilité des appels (Expo Go,
   // module natif WebRTC manquant, web). Mémorisé : la dispo ne change pas
@@ -186,6 +193,37 @@ export const AuthNavigator: React.FC = () => {
     const t = setTimeout(() => setSplashMinElapsed(true), SPLASH_MIN_MS);
     return () => clearTimeout(t);
   }, []);
+
+  const isBiometricEnabled = async (): Promise<boolean> => {
+    try {
+      const raw = await secureStorage.getItem(SECURITY_STORAGE_KEY);
+      if (!raw) return false;
+      const parsed = JSON.parse(raw);
+      return parsed.biometricAuth === true;
+    } catch {
+      return false;
+    }
+  };
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setBiometricLocked(false);
+      return;
+    }
+    isBiometricEnabled().then((enabled) => setBiometricLocked(enabled));
+  }, [isAuthenticated]);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    const sub = AppState.addEventListener("change", (state) => {
+      if (state === "active") {
+        isBiometricEnabled().then((enabled) => {
+          if (enabled) setBiometricLocked(true);
+        });
+      }
+    });
+    return () => sub.remove();
+  }, [isAuthenticated]);
 
   useEffect(() => {
     // TODO: remove before ship — forces onboarding on every launch in dev
@@ -317,10 +355,15 @@ export const AuthNavigator: React.FC = () => {
     isLoading ||
     !splashMinElapsed ||
     profileSetupPending === null ||
-    onboardingDone === null;
+    onboardingDone === null ||
+    (isAuthenticated && biometricLocked === null);
 
   if (showSplash) {
     return <SplashScreen />;
+  }
+
+  if (isAuthenticated && biometricLocked) {
+    return <BiometricLockScreen onUnlock={() => setBiometricLocked(false)} />;
   }
 
   const initialRouteName = !isAuthenticated

--- a/src/screens/Auth/BiometricLockScreen.tsx
+++ b/src/screens/Auth/BiometricLockScreen.tsx
@@ -1,0 +1,106 @@
+import React, { useEffect } from "react";
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  Platform,
+} from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import * as LocalAuthentication from "expo-local-authentication";
+import { Logo } from "../../components";
+import { useTheme } from "../../context/ThemeContext";
+import { colors, spacing, typography } from "../../theme";
+
+interface BiometricLockScreenProps {
+  onUnlock: () => void;
+}
+
+export const BiometricLockScreen: React.FC<BiometricLockScreenProps> = ({
+  onUnlock,
+}) => {
+  const { getThemeColors, getLocalizedText } = useTheme();
+  const themeColors = getThemeColors();
+
+  const prompt = async () => {
+    const result = await LocalAuthentication.authenticateAsync({
+      promptMessage: getLocalizedText("biometric.promptMessage"),
+      cancelLabel: getLocalizedText("biometric.cancelLabel"),
+      disableDeviceFallback: false,
+    });
+    if (result.success) onUnlock();
+  };
+
+  useEffect(() => {
+    prompt();
+  }, []);
+
+  return (
+    <LinearGradient
+      colors={themeColors.background.gradient as any}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 1 }}
+      style={styles.container}
+    >
+      <View style={styles.content}>
+        <Logo variant="icon" size="xlarge" />
+        <Text style={styles.title}>Whispr</Text>
+        <Text style={styles.subtitle}>
+          {getLocalizedText("biometric.lockSubtitle")}
+        </Text>
+        <TouchableOpacity
+          style={styles.button}
+          onPress={prompt}
+          activeOpacity={0.8}
+        >
+          <Text style={styles.buttonText}>
+            {getLocalizedText("biometric.unlockButton")}
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </LinearGradient>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  content: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: spacing.xl,
+    gap: spacing.md,
+  },
+  title: {
+    fontSize: typography.fontSize.xxxl,
+    fontWeight: "800",
+    color: colors.text.light,
+    marginTop: spacing.md,
+  },
+  subtitle: {
+    fontSize: typography.fontSize.md,
+    color: "rgba(255,255,255,0.7)",
+    textAlign: "center",
+    marginBottom: spacing.xl,
+  },
+  button: {
+    backgroundColor: colors.primary.main,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.xxl,
+    borderRadius: 14,
+    ...Platform.select({
+      ios: {
+        shadowColor: colors.primary.main,
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.4,
+        shadowRadius: 8,
+      },
+      android: { elevation: 6 },
+    }),
+  },
+  buttonText: {
+    color: "#FFFFFF",
+    fontSize: typography.fontSize.md,
+    fontWeight: "700",
+  },
+});

--- a/src/screens/Auth/__tests__/BiometricLockScreen.test.tsx
+++ b/src/screens/Auth/__tests__/BiometricLockScreen.test.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { render, fireEvent, waitFor } from "@testing-library/react-native";
+import { BiometricLockScreen } from "../BiometricLockScreen";
+
+const mockAuthenticate = jest.fn();
+jest.mock("expo-local-authentication", () => ({
+  authenticateAsync: (opts: any) => mockAuthenticate(opts),
+}));
+jest.mock("expo-linear-gradient", () => ({
+  LinearGradient: ({ children }: any) => children,
+}));
+jest.mock("../../../context/ThemeContext", () => ({
+  useTheme: () => ({
+    getThemeColors: () => ({
+      background: { gradient: ["#000", "#111"] },
+      text: { primary: "#fff", secondary: "#aaa" },
+      primary: "#6200ee",
+    }),
+    getLocalizedText: (key: string) => key,
+  }),
+}));
+jest.mock("../../../components", () => ({ Logo: () => null }));
+jest.mock("../../../theme", () => ({
+  colors: { text: { light: "#fff" }, primary: { main: "#6200ee" } },
+  spacing: { xl: 24, md: 16, xxl: 32 },
+  typography: { fontSize: { xxxl: 32, md: 16 } },
+}));
+
+describe("BiometricLockScreen", () => {
+  const onUnlock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthenticate.mockResolvedValue({ success: false });
+  });
+
+  it("renders the unlock button", () => {
+    const { getByText } = render(<BiometricLockScreen onUnlock={onUnlock} />);
+    expect(getByText("biometric.unlockButton")).toBeTruthy();
+  });
+
+  it("triggers biometric prompt on mount", async () => {
+    render(<BiometricLockScreen onUnlock={onUnlock} />);
+    await waitFor(() => {
+      expect(mockAuthenticate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          promptMessage: "biometric.promptMessage",
+          cancelLabel: "biometric.cancelLabel",
+        }),
+      );
+    });
+  });
+
+  it("calls onUnlock when biometric succeeds", async () => {
+    mockAuthenticate.mockResolvedValue({ success: true });
+    render(<BiometricLockScreen onUnlock={onUnlock} />);
+    await waitFor(() => expect(onUnlock).toHaveBeenCalled());
+  });
+
+  it("does not call onUnlock when biometric fails", async () => {
+    mockAuthenticate.mockResolvedValue({ success: false });
+    render(<BiometricLockScreen onUnlock={onUnlock} />);
+    await waitFor(() => expect(mockAuthenticate).toHaveBeenCalled());
+    expect(onUnlock).not.toHaveBeenCalled();
+  });
+
+  it("re-prompts biometric when unlock button is pressed", async () => {
+    mockAuthenticate.mockResolvedValue({ success: false });
+    const { getByText } = render(<BiometricLockScreen onUnlock={onUnlock} />);
+    await waitFor(() => expect(mockAuthenticate).toHaveBeenCalledTimes(1));
+    fireEvent.press(getByText("biometric.unlockButton"));
+    await waitFor(() => expect(mockAuthenticate).toHaveBeenCalledTimes(2));
+  });
+
+  it("calls onUnlock when button press triggers successful auth", async () => {
+    mockAuthenticate
+      .mockResolvedValueOnce({ success: false })
+      .mockResolvedValueOnce({ success: true });
+    const { getByText } = render(<BiometricLockScreen onUnlock={onUnlock} />);
+    await waitFor(() => expect(mockAuthenticate).toHaveBeenCalledTimes(1));
+    fireEvent.press(getByText("biometric.unlockButton"));
+    await waitFor(() => expect(onUnlock).toHaveBeenCalled());
+  });
+});

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -496,6 +496,7 @@ export const SettingsScreen: React.FC = () => {
   };
 
   const enableBiometric = async () => {
+    if (Platform.OS === "web") return;
     const [hasHardware, isEnrolled] = await Promise.all([
       LocalAuthentication.hasHardwareAsync(),
       LocalAuthentication.isEnrolledAsync(),
@@ -1286,47 +1287,46 @@ export const SettingsScreen: React.FC = () => {
             onPress={() => navigation.navigate("TwoFactorAuth")}
             icon="shield-checkmark-outline"
           />
-          {Platform.OS !== "web" && (
-            <View style={styles.settingItem}>
-              <View style={styles.settingItemLeft}>
-                <View style={styles.settingTextContainer}>
-                  <Text
-                    style={[
-                      styles.settingLabel,
-                      {
-                        color: themeColors.text.primary,
-                        fontSize: getFontSize("base"),
-                      },
-                    ]}
-                  >
-                    Authentification biométrique
-                  </Text>
-                  <Text
-                    style={[
-                      styles.settingSubtitle,
-                      {
-                        color: themeColors.text.secondary,
-                        fontSize: getFontSize("sm"),
-                      },
-                    ]}
-                  >
-                    Déverrouiller avec l'empreinte ou le visage
-                  </Text>
-                </View>
+          <View style={styles.settingItem}>
+            <View style={styles.settingItemLeft}>
+              <View style={styles.settingTextContainer}>
+                <Text
+                  style={[
+                    styles.settingLabel,
+                    {
+                      color: themeColors.text.primary,
+                      fontSize: getFontSize("base"),
+                    },
+                  ]}
+                >
+                  Authentification biométrique
+                </Text>
+                <Text
+                  style={[
+                    styles.settingSubtitle,
+                    {
+                      color: themeColors.text.secondary,
+                      fontSize: getFontSize("sm"),
+                    },
+                  ]}
+                >
+                  Déverrouiller avec l'empreinte ou le visage
+                </Text>
               </View>
-              <Switch
-                value={securitySettings.biometricAuth}
-                onValueChange={(value) =>
-                  handleToggle("security", "biometricAuth", value)
-                }
-                trackColor={{
-                  false: themeColors.text.tertiary,
-                  true: themeColors.primary,
-                }}
-                thumbColor="#FFFFFF"
-              />
             </View>
-          )}
+            <Switch
+              value={securitySettings.biometricAuth}
+              onValueChange={(value) =>
+                handleToggle("security", "biometricAuth", value)
+              }
+              disabled={Platform.OS === "web"}
+              trackColor={{
+                false: themeColors.text.tertiary,
+                true: themeColors.primary,
+              }}
+              thumbColor="#FFFFFF"
+            />
+          </View>
         </SettingSection>
 
         {/* Moderation Section */}

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -17,6 +17,7 @@ import {
   InteractionManager,
 } from "react-native";
 import * as ImagePicker from "expo-image-picker";
+import * as LocalAuthentication from "expo-local-authentication";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { storage as secureStorage } from "../../services/storage";
@@ -481,12 +482,43 @@ export const SettingsScreen: React.FC = () => {
         });
         break;
       case "security":
-        setSecuritySettings((prev) => {
-          const updated = { ...prev, [key]: value };
-          persistSettings(STORAGE_KEYS.security, updated);
-          return updated;
-        });
+        if (key === "biometricAuth" && value) {
+          void enableBiometric();
+        } else {
+          setSecuritySettings((prev) => {
+            const updated = { ...prev, [key]: value };
+            persistSettings(STORAGE_KEYS.security, updated);
+            return updated;
+          });
+        }
         break;
+    }
+  };
+
+  const enableBiometric = async () => {
+    const [hasHardware, isEnrolled] = await Promise.all([
+      LocalAuthentication.hasHardwareAsync(),
+      LocalAuthentication.isEnrolledAsync(),
+    ]);
+    if (!hasHardware) {
+      Alert.alert("Non disponible", getLocalizedText("biometric.notAvailable"));
+      return;
+    }
+    if (!isEnrolled) {
+      Alert.alert("Non configuré", getLocalizedText("biometric.notEnrolled"));
+      return;
+    }
+    const result = await LocalAuthentication.authenticateAsync({
+      promptMessage: getLocalizedText("biometric.enableConfirm"),
+      cancelLabel: getLocalizedText("biometric.cancelLabel"),
+      disableDeviceFallback: false,
+    });
+    if (result.success) {
+      setSecuritySettings((prev) => {
+        const updated = { ...prev, biometricAuth: true };
+        persistSettings(STORAGE_KEYS.security, updated);
+        return updated;
+      });
     }
   };
 

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -1286,45 +1286,47 @@ export const SettingsScreen: React.FC = () => {
             onPress={() => navigation.navigate("TwoFactorAuth")}
             icon="shield-checkmark-outline"
           />
-          <View style={styles.settingItem}>
-            <View style={styles.settingItemLeft}>
-              <View style={styles.settingTextContainer}>
-                <Text
-                  style={[
-                    styles.settingLabel,
-                    {
-                      color: themeColors.text.primary,
-                      fontSize: getFontSize("base"),
-                    },
-                  ]}
-                >
-                  Authentification biométrique
-                </Text>
-                <Text
-                  style={[
-                    styles.settingSubtitle,
-                    {
-                      color: themeColors.text.secondary,
-                      fontSize: getFontSize("sm"),
-                    },
-                  ]}
-                >
-                  Déverrouiller avec l'empreinte ou le visage
-                </Text>
+          {Platform.OS !== "web" && (
+            <View style={styles.settingItem}>
+              <View style={styles.settingItemLeft}>
+                <View style={styles.settingTextContainer}>
+                  <Text
+                    style={[
+                      styles.settingLabel,
+                      {
+                        color: themeColors.text.primary,
+                        fontSize: getFontSize("base"),
+                      },
+                    ]}
+                  >
+                    Authentification biométrique
+                  </Text>
+                  <Text
+                    style={[
+                      styles.settingSubtitle,
+                      {
+                        color: themeColors.text.secondary,
+                        fontSize: getFontSize("sm"),
+                      },
+                    ]}
+                  >
+                    Déverrouiller avec l'empreinte ou le visage
+                  </Text>
+                </View>
               </View>
+              <Switch
+                value={securitySettings.biometricAuth}
+                onValueChange={(value) =>
+                  handleToggle("security", "biometricAuth", value)
+                }
+                trackColor={{
+                  false: themeColors.text.tertiary,
+                  true: themeColors.primary,
+                }}
+                thumbColor="#FFFFFF"
+              />
             </View>
-            <Switch
-              value={securitySettings.biometricAuth}
-              onValueChange={(value) =>
-                handleToggle("security", "biometricAuth", value)
-              }
-              trackColor={{
-                false: themeColors.text.tertiary,
-                true: themeColors.primary,
-              }}
-              thumbColor="#FFFFFF"
-            />
-          </View>
+          )}
         </SettingSection>
 
         {/* Moderation Section */}

--- a/src/screens/Settings/__tests__/SettingsScreen.test.tsx
+++ b/src/screens/Settings/__tests__/SettingsScreen.test.tsx
@@ -173,7 +173,7 @@ describe("SettingsScreen", () => {
   it("reads security settings from SecureStore on mount (WHISPR-1359)", async () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { storage: secureStorageMock } = require("../../../services/storage");
-    secureStoreBackend["@whispr_settings_security"] = JSON.stringify({
+    secureStoreBackend["whispr_settings_security"] = JSON.stringify({
       twoFactorAuth: true,
       biometricAuth: true,
     });
@@ -181,7 +181,7 @@ describe("SettingsScreen", () => {
     render(<SettingsScreen />);
     await waitFor(() => {
       expect(secureStorageMock.getItem).toHaveBeenCalledWith(
-        "@whispr_settings_security",
+        "whispr_settings_security",
       );
     });
   });
@@ -196,19 +196,19 @@ describe("SettingsScreen", () => {
       biometricAuth: false,
     });
     AsyncStorage.getItem.mockImplementation(async (key: string) =>
-      key === "@whispr_settings_security" ? legacyValue : null,
+      key === "whispr_settings_security" ? legacyValue : null,
     );
 
     render(<SettingsScreen />);
 
     await waitFor(() => {
       expect(secureStorageMock.setItem).toHaveBeenCalledWith(
-        "@whispr_settings_security",
+        "whispr_settings_security",
         legacyValue,
       );
     });
     expect(AsyncStorage.removeItem).toHaveBeenCalledWith(
-      "@whispr_settings_security",
+      "whispr_settings_security",
     );
   });
 });


### PR DESCRIPTION
## Summary
- Installe `expo-local-authentication` (compatible SDK 54)
- `BiometricLockScreen` : écran de verrouillage plein-écran qui déclenche Face ID / Touch ID automatiquement au montage et sur pression du bouton
- `AuthNavigator` : lit le flag biométrique dans SecureStore au démarrage ; affiche le verrou si activé ; re-verrouille à chaque retour en foreground (AppState)
- `SettingsScreen` : vérifie la disponibilité matérielle et l'enrôlement avant d'activer le toggle ; prompt Face ID / Touch ID pour confirmer l'activation
- `ThemeContext` : nouvelles clés i18n `biometric.*` (fr + en)
- Fix test `SettingsScreen` : mise à jour de la clé SecureStore `@whispr_settings_security` → `whispr_settings_security` (introduite par PR #251)

## Test plan
- [ ] Tests unitaires verts (1409 tests, 6 nouveaux)
- [ ] Coverage au-dessus des seuils (76.2% stmts, 68.6% branches)
- [ ] Lint propre
- [ ] Activer le toggle biométrique dans Settings → Face ID demandé → confirmation avant activation
- [ ] Tuer l'app et la rouvrir → écran de verrouillage apparaît → Face ID déverrouille
- [ ] Passer l'app en arrière-plan et revenir → re-verrouillage
- [ ] Désactiver le toggle → plus de verrouillage

Closes WHISPR-security-biometric