### PR TITLE
fix(web): repare layout chat et bouton Suivant onboarding

### DIFF
--- a/src/screens/Auth/OnboardingScreen.tsx
+++ b/src/screens/Auth/OnboardingScreen.tsx
@@ -357,8 +357,13 @@ export const OnboardingScreen: React.FC = () => {
 
   const goNext = useCallback(() => {
     if (current < SLIDES.length - 1) {
+      // Sur web onViewableItemsChanged ne fire pas fiablement avec
+      // pagingEnabled, donc le current restait bloque a 0 et le clic
+      // suivant recalculait le meme offset. On met a jour current direct.
+      const next = current + 1;
+      setCurrent(next);
       flatRef.current?.scrollToOffset({
-        offset: (current + 1) * W,
+        offset: next * W,
         animated: true,
       });
     } else {

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -79,12 +79,25 @@ import { PinnedMessagesBar } from "../../components/Chat/PinnedMessagesBar";
 import { EmptyChatState } from "../../components/Chat/EmptyChatState";
 import { ChatHeader } from "./ChatHeader";
 import {
-  AttachStep,
-  SpotlightTourProvider,
+  AttachStep as RNAttachStep,
+  SpotlightTourProvider as RNSpotlightTourProvider,
   type TourStep,
 } from "react-native-spotlight-tour";
 import { TourTooltip } from "../../components/Tour/TourTooltip";
 import { TourAutoStart } from "../../components/Tour/TourAutoStart";
+
+// Sur web, le SpotlightTour casse le layout du ChatScreen (le flex root
+// est squeeze a la largeur mobile). On garde le tour seulement en natif.
+const IS_WEB = Platform.OS === "web";
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const SpotlightTourProvider: any = IS_WEB
+  ? ({ children }: { children: unknown }) =>
+      typeof children === "function" ? children() : children
+  : RNSpotlightTourProvider;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const AttachStep: any = IS_WEB
+  ? ({ children }: { children: React.ReactNode }) => <>{children}</>
+  : RNAttachStep;
 
 const CHAT_STEPS_COUNT = 2;
 

--- a/src/screens/Settings/__tests__/SettingsScreen.test.tsx
+++ b/src/screens/Settings/__tests__/SettingsScreen.test.tsx
@@ -173,7 +173,7 @@ describe("SettingsScreen", () => {
   it("reads security settings from SecureStore on mount (WHISPR-1359)", async () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { storage: secureStorageMock } = require("../../../services/storage");
-    secureStoreBackend["@whispr_settings_security"] = JSON.stringify({
+    secureStoreBackend["whispr_settings_security"] = JSON.stringify({
       twoFactorAuth: true,
       biometricAuth: true,
     });
@@ -181,7 +181,7 @@ describe("SettingsScreen", () => {
     render(<SettingsScreen />);
     await waitFor(() => {
       expect(secureStorageMock.getItem).toHaveBeenCalledWith(
-        "@whispr_settings_security",
+        "whispr_settings_security",
       );
     });
   });
@@ -196,19 +196,19 @@ describe("SettingsScreen", () => {
       biometricAuth: false,
     });
     AsyncStorage.getItem.mockImplementation(async (key: string) =>
-      key === "@whispr_settings_security" ? legacyValue : null,
+      key === "whispr_settings_security" ? legacyValue : null,
     );
 
     render(<SettingsScreen />);
 
     await waitFor(() => {
       expect(secureStorageMock.setItem).toHaveBeenCalledWith(
-        "@whispr_settings_security",
+        "whispr_settings_security",
         legacyValue,
       );
     });
     expect(AsyncStorage.removeItem).toHaveBeenCalledWith(
-      "@whispr_settings_security",
+      "whispr_settings_security",
     );
   });
 });


### PR DESCRIPTION
Deux fix web rapides apres PR #250 :

- **chat** : le SpotlightTourProvider squeeze le flex root sur web et la conv s'affichait en colonne mobile. On le repasse en no-op web pour ChatScreen uniquement (tour reste actif sur les autres ecrans + iOS/Android intact).
- **onboarding** : le bouton Suivant restait bloque a partir du 2e step car onViewableItemsChanged ne fire pas fiablement sur react-native-web avec pagingEnabled. On met a jour le current direct dans goNext.

Verifie sur whispr-preprod.roadmvn.com apres deploy.