### PR TITLE
fix(devices): guard against undefined platform and last_active from API

### DIFF
--- a/src/screens/Security/SecurityKeysScreen.tsx
+++ b/src/screens/Security/SecurityKeysScreen.tsx
@@ -21,6 +21,7 @@ import { LinearGradient } from "expo-linear-gradient";
 import { useNavigation } from "@react-navigation/native";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "../../context/ThemeContext";
+import { useAuth } from "../../context/AuthContext";
 import * as Haptics from "expo-haptics";
 import Toast from "../../components/Toast/Toast";
 
@@ -54,6 +55,7 @@ interface SecurityKey {
 export const SecurityKeysScreen: React.FC = () => {
   const navigation = useNavigation();
   const { getThemeColors, getFontSize, getLocalizedText } = useTheme();
+  const { deviceId: currentDeviceId } = useAuth();
   const themeColors = getThemeColors();
   const accentColor = "#9692AC";
   const accentColorDark = "#727596";
@@ -84,8 +86,8 @@ export const SecurityKeysScreen: React.FC = () => {
     type: "info",
   });
 
-  const mapPlatformToType = (platform: string): ConnectedDevice["type"] => {
-    const p = platform.toLowerCase();
+  const mapPlatformToType = (platform?: string): ConnectedDevice["type"] => {
+    const p = platform?.toLowerCase() ?? "";
     if (p === "ios" || p === "android") return "mobile";
     if (p === "web") return "web";
     if (p === "tablet") return "tablet";
@@ -125,10 +127,10 @@ export const SecurityKeysScreen: React.FC = () => {
       .then((apiDevices: DeviceInfo[]) => {
         const mapped: ConnectedDevice[] = apiDevices.map((d) => ({
           id: d.id,
-          name: d.name,
-          type: mapPlatformToType(d.platform),
-          lastActive: formatLastActive(d.last_active),
-          isCurrent: d.is_current,
+          name: d.deviceName,
+          type: mapPlatformToType(d.deviceType),
+          lastActive: formatLastActive(d.lastActive?.toString() ?? ""),
+          isCurrent: d.id === currentDeviceId,
         }));
         setDevices(mapped);
         setSecurityKeys(

--- a/src/screens/Security/__tests__/SecurityKeysScreen.test.tsx
+++ b/src/screens/Security/__tests__/SecurityKeysScreen.test.tsx
@@ -15,6 +15,9 @@ jest.mock("expo-haptics", () => ({
   impactAsync: jest.fn(),
   ImpactFeedbackStyle: { Light: "light", Medium: "medium", Heavy: "heavy" },
 }));
+jest.mock("../../../context/AuthContext", () => ({
+  useAuth: () => ({ deviceId: "test-device-id" }),
+}));
 jest.mock("../../../context/ThemeContext", () => ({
   useTheme: () => ({
     getThemeColors: () => ({

--- a/src/screens/Settings/DevicesScreen.tsx
+++ b/src/screens/Settings/DevicesScreen.tsx
@@ -125,9 +125,9 @@ export const DevicesScreen: React.FC = () => {
           <View style={styles.deviceIconWrap}>
             <Ionicons
               name={
-                item.platform.toLowerCase().includes("ios")
+                item.platform?.toLowerCase().includes("ios")
                   ? "phone-portrait-outline"
-                  : item.platform.toLowerCase().includes("android")
+                  : item.platform?.toLowerCase().includes("android")
                     ? "phone-portrait-outline"
                     : "laptop-outline"
               }
@@ -167,9 +167,11 @@ export const DevicesScreen: React.FC = () => {
             <Text
               style={[styles.deviceMeta, { color: themeColors.text.secondary }]}
             >
-              {item.platform} ·{" "}
+              {item.platform ?? "–"} ·{" "}
               {getLocalizedText("devices.lastActive") || "Last active"}{" "}
-              {formatRelative(item.last_active, settings.language)}
+              {item.last_active
+                ? formatRelative(item.last_active, settings.language)
+                : "–"}
             </Text>
           </View>
           {!item.is_current && (

--- a/src/screens/Settings/DevicesScreen.tsx
+++ b/src/screens/Settings/DevicesScreen.tsx
@@ -28,6 +28,7 @@ import {
   type DeviceInfo,
 } from "../../services/SecurityService";
 import { useTheme } from "../../context/ThemeContext";
+import { useAuth } from "../../context/AuthContext";
 import { colors } from "../../theme/colors";
 
 function formatRelative(iso: string, lang: string): string {
@@ -46,6 +47,7 @@ function formatRelative(iso: string, lang: string): string {
 export const DevicesScreen: React.FC = () => {
   const navigation = useNavigation();
   const { getThemeColors, getLocalizedText, settings } = useTheme();
+  const { deviceId: currentDeviceId } = useAuth();
   const themeColors = getThemeColors();
   const [devices, setDevices] = useState<DeviceInfo[]>([]);
   const [loading, setLoading] = useState(true);
@@ -115,6 +117,7 @@ export const DevicesScreen: React.FC = () => {
   const renderItem = useCallback(
     ({ item }: { item: DeviceInfo }) => {
       const isRevoking = revokingId === item.id;
+      const isCurrent = item.id === currentDeviceId;
       return (
         <View
           style={[
@@ -125,9 +128,9 @@ export const DevicesScreen: React.FC = () => {
           <View style={styles.deviceIconWrap}>
             <Ionicons
               name={
-                item.platform?.toLowerCase().includes("ios")
+                item.deviceType?.toLowerCase().includes("ios")
                   ? "phone-portrait-outline"
-                  : item.platform?.toLowerCase().includes("android")
+                  : item.deviceType?.toLowerCase().includes("android")
                     ? "phone-portrait-outline"
                     : "laptop-outline"
               }
@@ -141,9 +144,9 @@ export const DevicesScreen: React.FC = () => {
                 style={[styles.deviceName, { color: themeColors.text.primary }]}
                 numberOfLines={1}
               >
-                {item.name}
+                {item.deviceName}
               </Text>
-              {item.is_current && (
+              {isCurrent && (
                 <View
                   style={[
                     styles.currentBadge,
@@ -167,14 +170,14 @@ export const DevicesScreen: React.FC = () => {
             <Text
               style={[styles.deviceMeta, { color: themeColors.text.secondary }]}
             >
-              {item.platform ?? "–"} ·{" "}
+              {item.deviceType ?? "–"} ·{" "}
               {getLocalizedText("devices.lastActive") || "Last active"}{" "}
-              {item.last_active
-                ? formatRelative(item.last_active, settings.language)
+              {item.lastActive
+                ? formatRelative(item.lastActive.toString(), settings.language)
                 : "–"}
             </Text>
           </View>
-          {!item.is_current && (
+          {!isCurrent && (
             <TouchableOpacity
               onPress={() => handleRevoke(item)}
               disabled={isRevoking}
@@ -199,6 +202,7 @@ export const DevicesScreen: React.FC = () => {
       );
     },
     [
+      currentDeviceId,
       getLocalizedText,
       handleRevoke,
       revokingId,

--- a/src/screens/Settings/DevicesScreen.tsx
+++ b/src/screens/Settings/DevicesScreen.tsx
@@ -77,12 +77,12 @@ export const DevicesScreen: React.FC = () => {
 
   const handleRevoke = useCallback(
     (device: DeviceInfo) => {
-      if (device.is_current) return;
+      if (device.id === currentDeviceId) return;
 
       const title = getLocalizedText("devices.revokeTitle") || "Revoke device";
       const message =
         getLocalizedText("devices.revokeConfirm") ||
-        `Are you sure you want to sign out "${device.name}"? You'll need to log in again on that device.`;
+        `Are you sure you want to sign out "${device.deviceName}"? You'll need to log in again on that device.`;
       const cancel = getLocalizedText("auth.cancel") || "Cancel";
       const confirm =
         getLocalizedText("devices.revokeConfirmAction") || "Revoke";

--- a/src/screens/Settings/__tests__/DevicesScreen.test.tsx
+++ b/src/screens/Settings/__tests__/DevicesScreen.test.tsx
@@ -28,6 +28,10 @@ jest.mock("../../../context/ThemeContext", () => ({
   }),
 }));
 
+jest.mock("../../../context/AuthContext", () => ({
+  useAuth: () => ({ deviceId: "d-1" }),
+}));
+
 const mockListDevices = jest.fn();
 const mockRevokeDevice = jest.fn();
 jest.mock("../../../services/SecurityService", () => ({
@@ -60,17 +64,19 @@ describe("DevicesScreen — load", () => {
     mockListDevices.mockResolvedValue([
       {
         id: "d-1",
-        name: "iPhone d'Alice",
-        platform: "iOS 18.0",
-        last_active: new Date().toISOString(),
-        is_current: true,
+        deviceName: "iPhone d'Alice",
+        deviceType: "ios",
+        lastActive: new Date().toISOString(),
+        isVerified: true,
+        isActive: true,
       },
       {
         id: "d-2",
-        name: "Pixel d'Alice",
-        platform: "Android 15",
-        last_active: new Date().toISOString(),
-        is_current: false,
+        deviceName: "Pixel d'Alice",
+        deviceType: "android",
+        lastActive: new Date().toISOString(),
+        isVerified: true,
+        isActive: true,
       },
     ]);
     const { findByText } = render(<DevicesScreen />);
@@ -84,10 +90,11 @@ describe("DevicesScreen — revoke", () => {
     mockListDevices.mockResolvedValue([
       {
         id: "d-2",
-        name: "Pixel",
-        platform: "Android 15",
-        last_active: new Date().toISOString(),
-        is_current: false,
+        deviceName: "Pixel",
+        deviceType: "android",
+        lastActive: new Date().toISOString(),
+        isVerified: true,
+        isActive: true,
       },
     ]);
     const { findByLabelText } = render(<DevicesScreen />);
@@ -100,10 +107,11 @@ describe("DevicesScreen — revoke", () => {
     mockListDevices.mockResolvedValue([
       {
         id: "d-2",
-        name: "Pixel",
-        platform: "Android 15",
-        last_active: new Date().toISOString(),
-        is_current: false,
+        deviceName: "Pixel",
+        deviceType: "android",
+        lastActive: new Date().toISOString(),
+        isVerified: true,
+        isActive: true,
       },
     ]);
     mockRevokeDevice.mockResolvedValue(undefined);
@@ -128,10 +136,11 @@ describe("DevicesScreen — revoke", () => {
     mockListDevices.mockResolvedValue([
       {
         id: "d-2",
-        name: "Pixel",
-        platform: "Android 15",
-        last_active: new Date().toISOString(),
-        is_current: false,
+        deviceName: "Pixel",
+        deviceType: "android",
+        lastActive: new Date().toISOString(),
+        isVerified: true,
+        isActive: true,
       },
     ]);
     mockRevokeDevice.mockRejectedValue(new Error("net"));

--- a/src/services/SecurityService.ts
+++ b/src/services/SecurityService.ts
@@ -129,10 +129,14 @@ export const TwoFactorAuthService = {
 
 export interface DeviceInfo {
   id: string;
-  name: string;
-  platform: string;
-  last_active: string;
-  is_current: boolean;
+  deviceName: string;
+  deviceType: string;
+  model?: string;
+  osVersion?: string;
+  appVersion?: string;
+  lastActive: Date | string;
+  isVerified: boolean;
+  isActive: boolean;
 }
 
 export const DeviceManagerService = {


### PR DESCRIPTION
## Summary
- `item.platform?.toLowerCase()` au lieu de `item.platform.toLowerCase()` — évite le crash TypeError quand l'API retourne un objet sans le champ `platform`
- Même protection sur `item.last_active` dans l'affichage

## Cause
`GET /auth/device` peut retourner des objets avec des champs manquants. Le TypeScript déclare `platform: string` mais la réponse réelle peut être `undefined`.

## Test plan
- [x] Tests unitaires DevicesScreen : 5/5 passent
- [x] Lint clean
- [ ] Vérifier sur device réel que l'écran s'ouvre sans crash