### PR TITLE
fix(settings): privacy 404 et toggles notif non persistes

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,8 @@
     ],
     "moduleNameMapper": {
       "@react-native-async-storage/async-storage": "<rootDir>/node_modules/@react-native-async-storage/async-storage/jest/async-storage-mock",
-      "\\.bin$": "<rootDir>/src/__test-utils__/binaryAssetMock.js"
+      "\\.bin$": "<rootDir>/src/__test-utils__/binaryAssetMock.js",
+      "^expo-local-authentication$": "<rootDir>/src/__test-utils__/expoLocalAuthMock.js"
     },
     "transformIgnorePatterns": [
       "node_modules/(?!((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|@sentry/.*))"

--- a/src/__test-utils__/expoLocalAuthMock.js
+++ b/src/__test-utils__/expoLocalAuthMock.js
@@ -1,0 +1,10 @@
+// Mock minimal expo-local-authentication pour les tests Jest
+// Le package n'est pas installe dans l'env de test (natif uniquement)
+module.exports = {
+  authenticateAsync: jest.fn().mockResolvedValue({ success: false }),
+  hasHardwareAsync: jest.fn().mockResolvedValue(false),
+  isEnrolledAsync: jest.fn().mockResolvedValue(false),
+  supportedAuthenticationTypesAsync: jest.fn().mockResolvedValue([]),
+  AuthenticationType: { FINGERPRINT: 1, FACIAL_RECOGNITION: 2, IRIS: 3 },
+  SecurityLevel: { NONE: 0, SECRET: 1, BIOMETRIC_WEAK: 2, BIOMETRIC_STRONG: 3 },
+};

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -250,16 +250,28 @@ export const SettingsScreen: React.FC = () => {
    * Uses a PATCH-style merge: reads current backend settings first, then
    * updates only the fields we manage locally, preserving backend-only
    * fields (message_previews, show_sender_name, quiet_hours_*).
+   * Si le backend refuse, rollback vers previous et alerte l'utilisateur.
    */
   const syncNotificationsToBackend = useCallback(
-    async (local: typeof notificationSettings) => {
+    async (
+      local: typeof notificationSettings,
+      previous: typeof notificationSettings,
+    ) => {
       if (!userId) return;
+      const doRollback = () => {
+        setNotificationSettings(previous);
+        persistSettings(STORAGE_KEYS.notifications, previous);
+        Alert.alert(
+          "Erreur",
+          "Impossible de synchroniser ce parametre. Veuillez reessayer.",
+        );
+      };
       try {
         let existing: Partial<NotificationSettings> = {};
         try {
           existing = await NotificationService.getSettings(userId);
         } catch {
-          // If fetching fails, proceed with only local fields
+          // si fetch echoue, on continue avec les champs locaux uniquement
         }
         const merged: Partial<NotificationSettings> = {
           ...existing,
@@ -268,28 +280,43 @@ export const SettingsScreen: React.FC = () => {
         await NotificationService.updateSettings(userId, merged);
       } catch (error) {
         console.error("Error syncing notification settings to backend:", error);
+        doRollback();
       }
     },
-    [userId, notificationToApi],
+    [userId, notificationToApi, persistSettings, STORAGE_KEYS.notifications],
   );
 
   /**
-   * Sync privacy settings to the backend API
+   * Sync privacy settings to the backend API.
+   * Si le backend refuse, rollback vers previous et alerte l'utilisateur.
    */
   const syncPrivacyToBackend = useCallback(
-    async (localPrivacy: typeof privacySettings) => {
+    async (
+      localPrivacy: typeof privacySettings,
+      previous: typeof privacySettings,
+    ) => {
+      const doRollback = () => {
+        setPrivacySettings(previous);
+        persistSettings(STORAGE_KEYS.privacy, previous);
+        Alert.alert(
+          "Erreur",
+          "Impossible de synchroniser ce parametre. Veuillez reessayer.",
+        );
+      };
       try {
         const userService = UserService.getInstance();
         const apiSettings = privacyToApi(localPrivacy);
         const result = await userService.updatePrivacySettings(apiSettings);
         if (!result.success) {
           console.error("Failed to sync privacy settings:", result.message);
+          doRollback();
         }
       } catch (error) {
         console.error("Error syncing privacy to backend:", error);
+        doRollback();
       }
     },
-    [privacyToApi],
+    [privacyToApi, persistSettings, STORAGE_KEYS.privacy],
   );
 
   /**
@@ -414,7 +441,7 @@ export const SettingsScreen: React.FC = () => {
         setNotificationSettings((prev) => {
           const updated = { ...prev, [key]: value };
           persistSettings(STORAGE_KEYS.notifications, updated);
-          syncNotificationsToBackend(updated);
+          syncNotificationsToBackend(updated, prev);
           return updated;
         });
         break;
@@ -609,7 +636,7 @@ export const SettingsScreen: React.FC = () => {
         setPrivacySettings((prev) => {
           const updated = { ...prev, [selectedPrivacyItem]: value };
           persistSettings(STORAGE_KEYS.privacy, updated);
-          syncPrivacyToBackend(updated);
+          syncPrivacyToBackend(updated, prev);
           return updated;
         });
         setShowPrivacyModal(false);

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -570,7 +570,7 @@ export class UserService {
     message?: string;
   }> {
     try {
-      const response = await this.authFetch("/privacy/{userId}");
+      const response = await this.authFetch("/privacy");
 
       if (!response.ok) {
         return { success: false, message: `Erreur ${response.status}` };
@@ -651,7 +651,7 @@ export class UserService {
       if (settings.readReceipts !== undefined) {
         body.readReceipts = settings.readReceipts;
       }
-      const response = await this.authFetch("/privacy/{userId}", {
+      const response = await this.authFetch("/privacy", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),

--- a/src/types/expo-local-authentication.d.ts
+++ b/src/types/expo-local-authentication.d.ts
@@ -1,0 +1,33 @@
+// Stub de types pour expo-local-authentication (package natif non installe en env local/CI)
+declare module "expo-local-authentication" {
+  export enum AuthenticationType {
+    FINGERPRINT = 1,
+    FACIAL_RECOGNITION = 2,
+    IRIS = 3,
+  }
+
+  export enum SecurityLevel {
+    NONE = 0,
+    SECRET = 1,
+    BIOMETRIC_WEAK = 2,
+    BIOMETRIC_STRONG = 3,
+  }
+
+  export interface LocalAuthenticationResult {
+    success: boolean;
+    error?: string;
+    warning?: string;
+  }
+
+  export function hasHardwareAsync(): Promise<boolean>;
+  export function isEnrolledAsync(): Promise<boolean>;
+  export function supportedAuthenticationTypesAsync(): Promise<
+    AuthenticationType[]
+  >;
+  export function authenticateAsync(options?: {
+    promptMessage?: string;
+    cancelLabel?: string;
+    disableDeviceFallback?: boolean;
+    fallbackLabel?: string;
+  }): Promise<LocalAuthenticationResult>;
+}


### PR DESCRIPTION
## Summary
- Bug A : front PATCH /user/v1/privacy/{userId} alors que BE expose PATCH /user/v1/privacy. Realigne le path (GET aussi). UserId extrait du JWT cote BE.
- Bug B : syncNotificationsToBackend et syncPrivacyToBackend n'avaient pas de rollback. Aligne sur le pattern readReceipts : revert state + AsyncStorage + Alert si echec BE.
- Fix annexe : mock expo-local-authentication manquant (package liste dans package.json mais non installe) - debloque les tests Jest et le hook pre-push TSC.

## Test plan
- [x] Tests Jest 41/41 verts (SettingsScreen + UserService)
- [x] TSC clean (0 erreur)
- [x] Lint + Prettier pass
- [x] groupAddPermission conserve dans le body PATCH privacy
- [x] Comportement readReceipts inchange