### PR TITLE
fix(ux): re-fetch archive et toast erreurs block

### DIFF
--- a/src/components/Profile/MiniProfileCard.tsx
+++ b/src/components/Profile/MiniProfileCard.tsx
@@ -8,6 +8,7 @@
  */
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
+  Alert,
   View,
   Text,
   StyleSheet,
@@ -220,7 +221,9 @@ export const MiniProfileCard: React.FC<MiniProfileCardProps> = ({
       setCachedRelation(userId, "blocked");
       setRelation("blocked");
     } catch {
-      // si l'appel rate, on garde le relation precedent
+      if (mounted.current) {
+        Alert.alert("Erreur", "Impossible de bloquer cet utilisateur");
+      }
     } finally {
       if (mounted.current) setBusyAction(null);
     }
@@ -236,7 +239,9 @@ export const MiniProfileCard: React.FC<MiniProfileCardProps> = ({
       setCachedRelation(userId, "contact");
       setRelation("contact");
     } catch {
-      // idem
+      if (mounted.current) {
+        Alert.alert("Erreur", "Impossible de debloquer cet utilisateur");
+      }
     } finally {
       if (mounted.current) setBusyAction(null);
     }

--- a/src/screens/Chat/ArchivedConversationsScreen.tsx
+++ b/src/screens/Chat/ArchivedConversationsScreen.tsx
@@ -129,6 +129,7 @@ export const ArchivedConversationsScreen: React.FC = () => {
   const unarchiveConversation = useConversationsStore(
     (s) => s.unarchiveConversation,
   );
+  const fetchConversations = useConversationsStore((s) => s.fetchConversations);
 
   const [refreshing, setRefreshing] = useState(false);
   const [screenRefreshKey, setScreenRefreshKey] = useState(0);
@@ -160,6 +161,8 @@ export const ArchivedConversationsScreen: React.FC = () => {
     async (conversationId: string) => {
       try {
         await unarchiveConversation(conversationId);
+        // re-fetch pour garantir la sync multi-device
+        fetchConversations();
         setToast({
           visible: true,
           message: "Conversation désarchivée",
@@ -173,7 +176,7 @@ export const ArchivedConversationsScreen: React.FC = () => {
         });
       }
     },
-    [unarchiveConversation],
+    [unarchiveConversation, fetchConversations],
   );
 
   const onRefresh = useCallback(async () => {

--- a/src/screens/Chat/ConversationsListScreen.tsx
+++ b/src/screens/Chat/ConversationsListScreen.tsx
@@ -516,6 +516,9 @@ export const ConversationsListScreen: React.FC = () => {
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
       try {
         await archiveConversation(conversationId);
+        // re-fetch pour garantir la sync multi-device (un autre device peut
+        // avoir modifie la liste entre temps)
+        fetchConversations();
       } catch {
         setToast({
           visible: true,
@@ -524,7 +527,7 @@ export const ConversationsListScreen: React.FC = () => {
         });
       }
     },
-    [archiveConversation],
+    [archiveConversation, fetchConversations],
   );
 
   const handlePin = useCallback(


### PR DESCRIPTION
## Summary
- Bug 1 : pas de re-fetch apres archive/unarchive donc multi-device sync fragile, ajout fetchConversations apres succes dans handleArchive (ConversationsListScreen) et handleUnarchive (ArchivedConversationsScreen)
- Bug 2 : catch vide sur block/unblock dans MiniProfileCard, ajout Alert.alert erreur coherent avec le pattern du projet

## Test plan
- [ ] Tests Jest 102/102 verts
- [ ] Lint clean
- [ ] TypeScript noEmit exit 0