### PR TITLE
feat(admin): ecran AdminDemos pour demo modeles IA

### DIFF
--- a/src/navigation/AuthNavigator.tsx
+++ b/src/navigation/AuthNavigator.tsx
@@ -40,6 +40,7 @@ import {
   AppealStatusScreen,
 } from "../screens/Moderation";
 import {
+  AdminDemosScreen,
   ModerationDashboardScreen,
   ReportQueueScreen,
   ReportReviewScreen,
@@ -148,6 +149,7 @@ export type AuthStackParamList = {
   AppealForm: { sanction: UserSanction };
   AppealStatus: { sanctionId?: string; appealId?: string };
   // Admin screens
+  AdminDemos: undefined;
   ModerationDashboard: undefined;
   ReportQueue: undefined;
   ReportReview: { report: Report };
@@ -558,6 +560,7 @@ export const AuthNavigator: React.FC = () => {
         <Stack.Screen name="AppealForm" component={AppealFormScreen} />
         <Stack.Screen name="AppealStatus" component={AppealStatusScreen} />
         {/* Moderation — admin */}
+        <Stack.Screen name="AdminDemos" component={AdminDemosScreen} />
         <Stack.Screen
           name="ModerationDashboard"
           component={ModerationDashboardScreen}

--- a/src/screens/Admin/AdminDemosScreen.tsx
+++ b/src/screens/Admin/AdminDemosScreen.tsx
@@ -1,0 +1,244 @@
+/**
+ * AdminDemosScreen - Ecran de demonstration des modeles IA pour les prospects.
+ * Accessible uniquement aux administrateurs via AdminGate.
+ *
+ * Les deux modeles (Zeyou / Maya) ne sont pas encore implementes dans
+ * moderation-service (seul NudeNet est en prod). Les boutons sont donc
+ * des placeholders avec TODO explicite.
+ */
+
+import React from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { LinearGradient } from "expo-linear-gradient";
+import { useNavigation } from "@react-navigation/native";
+import { Ionicons } from "@expo/vector-icons";
+import { colors } from "../../theme/colors";
+import { AdminGate } from "../../components/Moderation";
+
+interface DemoModel {
+  id: string;
+  title: string;
+  description: string;
+}
+
+const DEMO_MODELS: DemoModel[] = [
+  {
+    id: "zeyou",
+    title: "Modele V1 (Zeyou)",
+    description:
+      "Premier modele de classification IA. Detecte les contenus inappropries sur image et texte.",
+  },
+  {
+    id: "maya",
+    title: "Modele V2 (Maya)",
+    description:
+      "Deuxieme modele, architecture amelioree. Meilleure precision sur les cas limites.",
+  },
+];
+
+export const AdminDemosScreen: React.FC = () => {
+  const navigation = useNavigation<any>();
+
+  // TODO(WHISPR-admin-demos): brancher sur les vrais endpoints moderation-service
+  // quand Zeyou et Maya seront deployes. Pour l'instant ces boutons sont des stubs.
+  const handleTestImage = (modelId: string) => {
+    console.log(`[AdminDemos] Test image - modele: ${modelId}`);
+    // TODO: ouvrir un picker image + appeler POST /moderation/demo/image?model=<modelId>
+  };
+
+  const handleTestText = (modelId: string) => {
+    console.log(`[AdminDemos] Test texte - modele: ${modelId}`);
+    // TODO: ouvrir une saisie texte + appeler POST /moderation/demo/text?model=<modelId>
+  };
+
+  return (
+    <LinearGradient
+      colors={colors.background.gradient.app}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 1 }}
+      style={styles.gradient}
+    >
+      <SafeAreaView style={styles.container} edges={["top"]}>
+        <AdminGate>
+          <View style={styles.header}>
+            <TouchableOpacity
+              onPress={() => navigation.goBack()}
+              style={styles.backButton}
+              accessibilityRole="button"
+              accessibilityLabel="Retour"
+            >
+              <Ionicons name="arrow-back" size={24} color="#FFFFFF" />
+            </TouchableOpacity>
+            <Text style={styles.headerTitle}>Demos IA</Text>
+            <View style={styles.headerPlaceholder} />
+          </View>
+
+          <ScrollView
+            contentContainerStyle={styles.scrollContent}
+            showsVerticalScrollIndicator={false}
+          >
+            <Text style={styles.intro}>
+              Demonstration des modeles de moderation IA pour les prospects. Les
+              boutons sont des placeholders en attente de l'integration backend.
+            </Text>
+
+            {DEMO_MODELS.map((model) => (
+              <View
+                key={model.id}
+                style={styles.card}
+                testID={`demo-card-${model.id}`}
+              >
+                <View style={styles.cardHeader}>
+                  <Ionicons
+                    name="cube-outline"
+                    size={22}
+                    color={colors.primary.main}
+                  />
+                  <Text style={styles.cardTitle}>{model.title}</Text>
+                </View>
+
+                <Text style={styles.cardDescription}>{model.description}</Text>
+
+                <View style={styles.buttonRow}>
+                  <TouchableOpacity
+                    style={styles.demoButton}
+                    onPress={() => handleTestImage(model.id)}
+                    activeOpacity={0.7}
+                    testID={`btn-image-${model.id}`}
+                  >
+                    <Ionicons name="image-outline" size={16} color="#FFFFFF" />
+                    <Text style={styles.demoButtonText}>Tester sur image</Text>
+                  </TouchableOpacity>
+
+                  <TouchableOpacity
+                    style={[styles.demoButton, styles.demoButtonSecondary]}
+                    onPress={() => handleTestText(model.id)}
+                    activeOpacity={0.7}
+                    testID={`btn-text-${model.id}`}
+                  >
+                    <Ionicons
+                      name="text-outline"
+                      size={16}
+                      color="rgba(255,255,255,0.8)"
+                    />
+                    <Text
+                      style={[
+                        styles.demoButtonText,
+                        styles.demoButtonTextSecondary,
+                      ]}
+                    >
+                      Tester sur texte
+                    </Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+            ))}
+
+            <View style={styles.bottomSpacer} />
+          </ScrollView>
+        </AdminGate>
+      </SafeAreaView>
+    </LinearGradient>
+  );
+};
+
+const styles = StyleSheet.create({
+  gradient: {
+    flex: 1,
+  },
+  container: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: "rgba(255, 255, 255, 0.1)",
+  },
+  backButton: {
+    marginRight: 12,
+  },
+  headerTitle: {
+    flex: 1,
+    fontSize: 20,
+    fontWeight: "600",
+    color: "#FFFFFF",
+  },
+  headerPlaceholder: {
+    width: 36,
+  },
+  scrollContent: {
+    paddingHorizontal: 16,
+    paddingTop: 20,
+  },
+  intro: {
+    fontSize: 14,
+    color: "rgba(255, 255, 255, 0.6)",
+    marginBottom: 24,
+    lineHeight: 20,
+  },
+  card: {
+    backgroundColor: "rgba(255, 255, 255, 0.08)",
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 16,
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.12)",
+  },
+  cardHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 8,
+    gap: 8,
+  },
+  cardTitle: {
+    fontSize: 16,
+    fontWeight: "700",
+    color: "#FFFFFF",
+  },
+  cardDescription: {
+    fontSize: 13,
+    color: "rgba(255, 255, 255, 0.65)",
+    lineHeight: 18,
+    marginBottom: 16,
+  },
+  buttonRow: {
+    flexDirection: "row",
+    gap: 10,
+  },
+  demoButton: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: colors.primary.main,
+    borderRadius: 8,
+    paddingVertical: 10,
+    gap: 6,
+  },
+  demoButtonSecondary: {
+    backgroundColor: "rgba(255, 255, 255, 0.12)",
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.2)",
+  },
+  demoButtonText: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#FFFFFF",
+  },
+  demoButtonTextSecondary: {
+    color: "rgba(255, 255, 255, 0.8)",
+  },
+  bottomSpacer: {
+    height: 40,
+  },
+});

--- a/src/screens/Admin/__tests__/AdminDemosScreen.test.tsx
+++ b/src/screens/Admin/__tests__/AdminDemosScreen.test.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react-native";
+import { AdminDemosScreen } from "../AdminDemosScreen";
+
+const mockGoBack = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({ goBack: mockGoBack }),
+}));
+
+jest.mock("expo-linear-gradient", () => ({
+  LinearGradient: ({ children }: any) => children,
+}));
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  SafeAreaView: ({ children }: any) => children,
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock("../../../theme/colors", () => ({
+  colors: {
+    background: { gradient: { app: ["#000", "#111"] } },
+    primary: { main: "#6200ee" },
+  },
+}));
+
+// Mock moderationStore : isStaff = true pour le cas admin
+jest.mock("../../../store/moderationStore", () => ({
+  useIsStaff: jest.fn(() => true),
+}));
+
+// Mock AdminGate : rend les enfants directement quand isStaff = true
+jest.mock("../../../components/Moderation", () => ({
+  AdminGate: ({ children }: any) => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { useIsStaff } = require("../../../store/moderationStore");
+    const isStaff = useIsStaff();
+    if (!isStaff) {
+      const { Text } = require("react-native");
+      return <Text>Acces refuse</Text>;
+    }
+    return children;
+  },
+}));
+
+describe("AdminDemosScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("affiche les deux cards modeles quand l'utilisateur est admin", async () => {
+    const { getByText } = render(<AdminDemosScreen />);
+    await waitFor(() => {
+      expect(getByText("Modele V1 (Zeyou)")).toBeTruthy();
+      expect(getByText("Modele V2 (Maya)")).toBeTruthy();
+    });
+  });
+
+  it("affiche les boutons placeholder pour chaque modele", async () => {
+    const { getAllByText } = render(<AdminDemosScreen />);
+    await waitFor(() => {
+      expect(getAllByText("Tester sur image")).toHaveLength(2);
+      expect(getAllByText("Tester sur texte")).toHaveLength(2);
+    });
+  });
+
+  it("affiche le titre du header", async () => {
+    const { getByText } = render(<AdminDemosScreen />);
+    await waitFor(() => {
+      expect(getByText("Demos IA")).toBeTruthy();
+    });
+  });
+
+  it("affiche 'Acces refuse' si l'utilisateur n'est pas staff", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { useIsStaff } = require("../../../store/moderationStore");
+    (useIsStaff as jest.Mock).mockReturnValue(false);
+
+    const { getByText, queryByText } = render(<AdminDemosScreen />);
+    await waitFor(() => {
+      expect(getByText("Acces refuse")).toBeTruthy();
+    });
+    expect(queryByText("Modele V1 (Zeyou)")).toBeNull();
+    expect(queryByText("Modele V2 (Maya)")).toBeNull();
+  });
+});

--- a/src/screens/Admin/index.ts
+++ b/src/screens/Admin/index.ts
@@ -1,3 +1,4 @@
+export { AdminDemosScreen } from "./AdminDemosScreen";
 export { ModerationDashboardScreen } from "./ModerationDashboardScreen";
 export { ReportQueueScreen } from "./ReportQueueScreen";
 export { ReportReviewScreen } from "./ReportReviewScreen";

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -1395,6 +1395,18 @@ export const SettingsScreen: React.FC = () => {
           )}
         </SettingSection>
 
+        {/* Administration - visible uniquement pour les admins/modérateurs */}
+        {isStaff && (
+          <SettingSection title="Administration" icon="flask-outline">
+            <SettingItem
+              label="Demos IA (Admin)"
+              subtitle="Demontrer les modeles IA Zeyou et Maya aux prospects"
+              onPress={() => navigation.navigate("AdminDemos")}
+              icon="cube-outline"
+            />
+          </SettingSection>
+        )}
+
         {/* Developer / Debug - visible en dev local + en build preprod (jamais en prod) */}
         {(__DEV__ || process.env.EXPO_PUBLIC_ENV === "preprod") && (
           <SettingSection title="Debug" icon="bug-outline">


### PR DESCRIPTION
Ajoute un ecran cache derriere AdminGate avec 2 cards placeholder Modele V1 (Zeyou) et Modele V2 (Maya). Boutons inactifs avec TODO. Bouton conditionnel dans Settings si l'utilisateur est admin. Suit le pattern admin existant (useModerationStore, AdminGate).