### PR TITLE
fix(groups): modal custom dernier admin + selectTextOnFocus au create groupe

### DIFF
--- a/src/components/Chat/NewConversationModal.tsx
+++ b/src/components/Chat/NewConversationModal.tsx
@@ -318,10 +318,16 @@ export const NewConversationModal: React.FC<NewConversationModalProps> = ({
                     setGroupName(text);
                     setGroupNameTouched(true);
                   }}
+                  onFocus={() => {
+                    // marque le champ comme touche des le focus pour eviter
+                    // que defaultGroupName ecrase ce que l'user va taper
+                    if (!groupNameTouched) setGroupNameTouched(true);
+                  }}
                   placeholder="Nom du groupe"
                   placeholderTextColor="rgba(255, 255, 255, 0.5)"
                   maxLength={100}
                   returnKeyType="done"
+                  selectTextOnFocus
                 />
                 <Ionicons
                   name="pencil"

--- a/src/screens/Groups/GroupDetailsScreen.tsx
+++ b/src/screens/Groups/GroupDetailsScreen.tsx
@@ -136,6 +136,8 @@ export const GroupDetailsScreen: React.FC = () => {
   const [showLeaveModal, setShowLeaveModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showTransferAdminModal, setShowTransferAdminModal] = useState(false);
+  const [showLastAdminWarningModal, setShowLastAdminWarningModal] =
+    useState(false);
   const [leaving, setLeaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [savingSettings, setSavingSettings] = useState(false);
@@ -1587,19 +1589,8 @@ export const GroupDetailsScreen: React.FC = () => {
               // refresh members avant decision pour eviter isLastAdmin stale (concurrent demote)
               await loadGroupData().catch(() => {});
               if (isLastAdmin && otherMembers.length > 0) {
-                // dernier admin + autres membres : auto-promotion BE, on confirme juste
-                Alert.alert(
-                  "Tu es le dernier admin",
-                  "Un autre membre sera promu admin automatiquement. Continuer ?",
-                  [
-                    { text: "Annuler", style: "cancel" },
-                    {
-                      text: "Quitter",
-                      style: "destructive",
-                      onPress: () => setShowLeaveModal(true),
-                    },
-                  ],
-                );
+                // dernier admin + autres membres : Modal custom (Alert.alert muet sur web)
+                setShowLastAdminWarningModal(true);
               } else {
                 setShowLeaveModal(true);
               }
@@ -1710,6 +1701,76 @@ export const GroupDetailsScreen: React.FC = () => {
       onCancel={() => setShowLeaveModal(false)}
       onConfirm={handleLeaveGroup}
     />
+  );
+
+  const renderLastAdminWarningModal = () => (
+    <Modal
+      visible={showLastAdminWarningModal}
+      transparent
+      animationType="fade"
+      onRequestClose={() => setShowLastAdminWarningModal(false)}
+    >
+      <View style={styles.modalOverlay}>
+        <AnimatedView
+          style={styles.modalContainer}
+          entering={FadeInDown.duration(250).springify()}
+        >
+          <LinearGradient
+            colors={colors.background.gradient.app}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 1 }}
+            style={styles.modalGradient}
+          >
+            <View style={styles.modalHeader}>
+              <View
+                style={[
+                  styles.modalIconContainer,
+                  styles.modalIconContainerInfo,
+                ]}
+              >
+                <LinearGradient
+                  colors={[colors.ui.warning, colors.ui.error]}
+                  style={styles.modalIconGradient}
+                >
+                  <Ionicons
+                    name="shield-outline"
+                    size={28}
+                    color={colors.text.light}
+                  />
+                </LinearGradient>
+              </View>
+              <Text style={styles.modalTitle}>Dernier administrateur</Text>
+              <Text style={styles.modalDescription}>
+                Un autre membre sera promu administrateur automatiquement.
+                Continuer ?
+              </Text>
+            </View>
+            <View style={styles.modalActions}>
+              <TouchableOpacity
+                style={styles.modalButtonCancel}
+                onPress={() => setShowLastAdminWarningModal(false)}
+                activeOpacity={0.7}
+              >
+                <Text style={styles.modalButtonCancelText}>Annuler</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[
+                  styles.modalButtonConfirm,
+                  { backgroundColor: colors.ui.error },
+                ]}
+                onPress={() => {
+                  setShowLastAdminWarningModal(false);
+                  setShowLeaveModal(true);
+                }}
+                activeOpacity={0.7}
+              >
+                <Text style={styles.modalButtonConfirmText}>Quitter</Text>
+              </TouchableOpacity>
+            </View>
+          </LinearGradient>
+        </AnimatedView>
+      </View>
+    </Modal>
   );
 
   const renderDeleteModal = () => (
@@ -2214,6 +2275,7 @@ export const GroupDetailsScreen: React.FC = () => {
           <View style={styles.contentContainer}>{renderContent()}</View>
         </ScrollView>
         {renderLeaveModal()}
+        {renderLastAdminWarningModal()}
         {renderDeleteModal()}
         {renderTransferAdminModal()}
         {renderAddMemberModal()}
@@ -2674,6 +2736,19 @@ const styles = StyleSheet.create({
     fontSize: typography.fontSize.base,
     fontWeight: typography.fontWeight.semiBold,
     color: withOpacity(colors.text.light, 0.9),
+    letterSpacing: 0.3,
+  },
+  modalButtonConfirm: {
+    flex: 1,
+    paddingVertical: 16,
+    borderRadius: 16,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  modalButtonConfirmText: {
+    fontSize: typography.fontSize.base,
+    fontWeight: typography.fontWeight.semiBold,
+    color: colors.text.light,
     letterSpacing: 0.3,
   },
   membersList: {

--- a/src/screens/Groups/__tests__/GroupDetailsScreen.test.tsx
+++ b/src/screens/Groups/__tests__/GroupDetailsScreen.test.tsx
@@ -442,7 +442,7 @@ describe("GroupDetailsScreen", () => {
       await waitFor(() => expect(toJSON()).toBeTruthy());
     });
 
-    it("leave seul admin avec autres membres : ouvre Alert confirm auto-promotion", async () => {
+    it("leave seul admin avec autres membres : ouvre le modal custom auto-promotion (pas Alert)", async () => {
       mockedGroupsAPI.getGroupMembers.mockResolvedValue({
         members: [adminMe, memberOther],
         total: 2,
@@ -453,9 +453,9 @@ describe("GroupDetailsScreen", () => {
         total: 2,
       } as any);
 
-      const alertSpy = jest.spyOn(Alert, "alert");
-
-      const { getByText, getAllByText } = render(<GroupDetailsScreen />);
+      const { getByText, getAllByText, queryByText } = render(
+        <GroupDetailsScreen />,
+      );
       await waitFor(() =>
         expect(getAllByText("Test Group").length).toBeGreaterThan(0),
       );
@@ -465,15 +465,13 @@ describe("GroupDetailsScreen", () => {
 
       fireEvent.press(getByText("Quitter le groupe"));
 
+      // le modal custom doit s'afficher (pas Alert.alert)
       await waitFor(() => {
-        expect(alertSpy).toHaveBeenCalledWith(
-          "Tu es le dernier admin",
-          expect.stringContaining("promu admin automatiquement"),
-          expect.any(Array),
-        );
+        expect(getByText("Dernier administrateur")).toBeTruthy();
+        expect(
+          queryByText(/promu administrateur automatiquement/),
+        ).toBeTruthy();
       });
-
-      alertSpy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Bug 1 : remplace Alert.alert (muet sur web) par un Modal custom pour le warning \"dernier admin\" quand owner quitte le groupe - native iOS/Android non impacté
- Bug 2 : ajoute selectTextOnFocus + onFocus guard sur le TextInput du nom de groupe pour eviter la concat defaultGroupName + nom custom quand l'user tape sans effacer

## Test plan
- [x] Tests unitaires verts (1421/1421)
- [x] TSC clean (0 erreurs)
- [x] Lint 0 erreurs
- [x] Test GroupDetailsScreen : modal custom s'affiche a la place de Alert.alert
- [x] Ne touche que GroupDetailsScreen.tsx, GroupDetailsScreen.test.tsx, NewConversationModal.tsx