### PR TITLE
feat(groups): hierarchie owner > admin > member UI

### DIFF
--- a/src/screens/Groups/GroupDetailsScreen.tsx
+++ b/src/screens/Groups/GroupDetailsScreen.tsx
@@ -293,9 +293,12 @@ export const GroupDetailsScreen: React.FC = () => {
   }, [navigation, conversationId, conversationKey]);
 
   const currentUserMember = members.find((m) => m.user_id === CURRENT_USER_ID);
-  const isAdmin = currentUserMember?.role === "admin";
+  const isOwner = currentUserMember?.role === "owner";
+  // owner compte aussi comme admin pour les permissions existantes
+  const isAdmin = isOwner || currentUserMember?.role === "admin";
+  const ownerCount = members.filter((m) => m.role === "owner").length;
   const adminCount = members.filter((m) => m.role === "admin").length;
-  const isLastAdmin = isAdmin && adminCount === 1;
+  const isLastAdmin = isAdmin && (ownerCount + adminCount) === 1;
   const otherMembers = members.filter((m) => m.user_id !== CURRENT_USER_ID);
 
   const handleLeaveGroup = useCallback(async () => {
@@ -1006,8 +1009,14 @@ export const GroupDetailsScreen: React.FC = () => {
               { color: withOpacity(colors.text.light, 0.7) },
             ]}
           >
-            {stats?.adminCount || 0} administrateur
-            {stats && stats.adminCount > 1 ? "s" : ""}
+            {(() => {
+              const owners = members.filter((m) => m.role === "owner").length;
+              const admins = members.filter((m) => m.role === "admin").length;
+              const parts: string[] = [];
+              if (owners > 0) parts.push(`${owners} propriétaire${owners > 1 ? "s" : ""}`);
+              if (admins > 0) parts.push(`${admins} administrateur${admins > 1 ? "s" : ""}`);
+              return parts.length > 0 ? parts.join(", ") : "0 administrateur";
+            })()}
           </Text>
         </View>
         <TouchableOpacity
@@ -1076,6 +1085,28 @@ export const GroupDetailsScreen: React.FC = () => {
                 <Text style={[styles.memberName, { color: colors.text.light }]}>
                   {member.display_name}
                 </Text>
+                {member.role === "owner" && (
+                  <View
+                    style={[
+                      styles.roleBadge,
+                      { backgroundColor: "#B8860B" },
+                    ]}
+                  >
+                    <Ionicons
+                      name="star"
+                      size={12}
+                      color="#FFD700"
+                    />
+                    <Text
+                      style={[
+                        styles.roleBadgeText,
+                        { color: "#FFD700" },
+                      ]}
+                    >
+                      Propriétaire
+                    </Text>
+                  </View>
+                )}
                 {member.role === "admin" && (
                   <View
                     style={[
@@ -1144,10 +1175,13 @@ export const GroupDetailsScreen: React.FC = () => {
                 })}
               </Text>
             </View>
-            {isAdmin && member.user_id !== CURRENT_USER_ID && (
+            {member.user_id !== CURRENT_USER_ID &&
+              // owner peut agir sur tout le monde sauf lui-même
+              // admin peut agir uniquement sur les membres simples
+              (isOwner || (isAdmin && member.role === "member")) && (
               <TouchableOpacity
                 onPress={(e) => {
-                  e.stopPropagation?.();
+                  e?.stopPropagation?.();
                   Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
                   setMemberActionFor(member);
                 }}
@@ -2090,11 +2124,13 @@ export const GroupDetailsScreen: React.FC = () => {
                   {member.display_name}
                 </Text>
                 <Text style={styles.modalDescription}>
-                  {member.role === "admin"
-                    ? "Administrateur"
-                    : member.role === "moderator"
-                      ? "Modérateur"
-                      : "Membre"}
+                  {member.role === "owner"
+                    ? "Propriétaire"
+                    : member.role === "admin"
+                      ? "Administrateur"
+                      : member.role === "moderator"
+                        ? "Modérateur"
+                        : "Membre"}
                 </Text>
               </View>
 
@@ -2106,7 +2142,8 @@ export const GroupDetailsScreen: React.FC = () => {
                 />
               )}
 
-              {member.role !== "admin" && !isSelf && (
+              {/* Promouvoir : owner uniquement, sur les membres simples */}
+              {isOwner && member.role === "member" && !isSelf && (
                 <TouchableOpacity
                   style={styles.memberActionRow}
                   onPress={() => handleChangeRole(member, "admin")}
@@ -2124,7 +2161,8 @@ export const GroupDetailsScreen: React.FC = () => {
                 </TouchableOpacity>
               )}
 
-              {member.role === "admin" && !isSelf && (
+              {/* Rétrograder : owner uniquement, sur les admins */}
+              {isOwner && member.role === "admin" && !isSelf && (
                 <TouchableOpacity
                   style={styles.memberActionRow}
                   onPress={() => handleChangeRole(member, "member")}
@@ -2142,7 +2180,11 @@ export const GroupDetailsScreen: React.FC = () => {
                 </TouchableOpacity>
               )}
 
-              {!isSelf && (
+              {/* Retirer : owner sur admin+membre, admin sur membre uniquement */}
+              {!isSelf &&
+                (isOwner
+                  ? member.role !== "owner"
+                  : isAdmin && member.role === "member") && (
                 <TouchableOpacity
                   style={styles.memberActionRow}
                   onPress={() => handleRemoveMember(member)}

--- a/src/screens/Groups/__tests__/GroupDetailsScreen.test.tsx
+++ b/src/screens/Groups/__tests__/GroupDetailsScreen.test.tsx
@@ -105,6 +105,7 @@ jest.mock("../../../services/groups/api", () => ({
     promoteMember: jest.fn(),
     demoteMember: jest.fn(),
     transferAdmin: jest.fn(),
+    kickMember: jest.fn(),
   },
 }));
 jest.mock("../../../theme/colors", () => ({
@@ -471,6 +472,248 @@ describe("GroupDetailsScreen", () => {
         expect(
           queryByText(/promu administrateur automatiquement/),
         ).toBeTruthy();
+      });
+    });
+  });
+
+  describe("owner role — WHISPR-group-owner-ui", () => {
+    const ownerMe = {
+      id: "user1",
+      user_id: "user1",
+      display_name: "Me",
+      role: "owner" as const,
+      joined_at: "2024-01-01T00:00:00Z",
+      is_active: true,
+    };
+    const adminOther = {
+      id: "user2",
+      user_id: "user2",
+      display_name: "AdminUser",
+      role: "admin" as const,
+      joined_at: "2024-01-01T00:00:00Z",
+      is_active: true,
+    };
+    const memberOther = {
+      id: "user3",
+      user_id: "user3",
+      display_name: "Bob",
+      role: "member" as const,
+      joined_at: "2024-01-01T00:00:00Z",
+      is_active: true,
+    };
+
+    it("badge Propriétaire visible pour le membre owner dans l'onglet Membres", async () => {
+      mockedGroupsAPI.getGroupMembers.mockResolvedValue({
+        members: [ownerMe, memberOther],
+        total: 2,
+      } as any);
+
+      const { getByText, getAllByText } = render(<GroupDetailsScreen />);
+      await waitFor(() =>
+        expect(getAllByText("Test Group").length).toBeGreaterThan(0),
+      );
+
+      fireEvent.press(getByText("Membres"));
+
+      await waitFor(() => {
+        expect(getByText("Propriétaire")).toBeTruthy();
+      });
+    });
+
+    it("badge Admin toujours visible pour les admins quand owner est présent", async () => {
+      mockedGroupsAPI.getGroupMembers.mockResolvedValue({
+        members: [ownerMe, adminOther, memberOther],
+        total: 3,
+      } as any);
+
+      const { getByText, getAllByText } = render(<GroupDetailsScreen />);
+      await waitFor(() =>
+        expect(getAllByText("Test Group").length).toBeGreaterThan(0),
+      );
+
+      fireEvent.press(getByText("Membres"));
+
+      await waitFor(() => {
+        expect(getByText("Propriétaire")).toBeTruthy();
+        expect(getByText("Admin")).toBeTruthy();
+      });
+    });
+
+    it("header compte propriétaire et admins séparément", async () => {
+      mockedGroupsAPI.getGroupMembers.mockResolvedValue({
+        members: [ownerMe, adminOther, memberOther],
+        total: 3,
+      } as any);
+
+      const { getByText, getAllByText } = render(<GroupDetailsScreen />);
+      await waitFor(() =>
+        expect(getAllByText("Test Group").length).toBeGreaterThan(0),
+      );
+
+      fireEvent.press(getByText("Membres"));
+
+      await waitFor(() => {
+        // le header doit mentionner proprietaire et admin séparément
+        expect(getByText(/propriétaire/)).toBeTruthy();
+        expect(getByText(/administrateur/)).toBeTruthy();
+      });
+    });
+
+    it("owner voit le bouton ellipsis sur un admin", async () => {
+      mockedGroupsAPI.getGroupMembers.mockResolvedValue({
+        members: [ownerMe, adminOther],
+        total: 2,
+      } as any);
+
+      const { getByText, getAllByText, getAllByLabelText } = render(
+        <GroupDetailsScreen />,
+      );
+      await waitFor(() =>
+        expect(getAllByText("Test Group").length).toBeGreaterThan(0),
+      );
+
+      fireEvent.press(getByText("Membres"));
+      await waitFor(() => expect(getByText("AdminUser")).toBeTruthy());
+
+      const actionBtns = getAllByLabelText(/Actions pour/);
+      expect(actionBtns.length).toBeGreaterThan(0);
+    });
+
+    it("admin ne voit pas le bouton ellipsis sur un autre admin", async () => {
+      const adminMe = {
+        id: "user1",
+        user_id: "user1",
+        display_name: "Me",
+        role: "admin" as const,
+        joined_at: "2024-01-01T00:00:00Z",
+        is_active: true,
+      };
+      mockedGroupsAPI.getGroupMembers.mockResolvedValue({
+        members: [adminMe, adminOther],
+        total: 2,
+      } as any);
+
+      const { getByText, getAllByText, queryAllByLabelText } = render(
+        <GroupDetailsScreen />,
+      );
+      await waitFor(() =>
+        expect(getAllByText("Test Group").length).toBeGreaterThan(0),
+      );
+
+      fireEvent.press(getByText("Membres"));
+      await waitFor(() => expect(getByText("AdminUser")).toBeTruthy());
+
+      // aucun bouton ellipsis visible car admin ne peut pas agir sur un autre admin
+      const actionBtns = queryAllByLabelText(/Actions pour/);
+      expect(actionBtns.length).toBe(0);
+    });
+
+    it("modal actions owner sur membre : Promouvoir en admin visible", async () => {
+      mockedGroupsAPI.getGroupMembers.mockResolvedValue({
+        members: [ownerMe, memberOther],
+        total: 2,
+      } as any);
+
+      const { getByText, getAllByText, getAllByLabelText } = render(
+        <GroupDetailsScreen />,
+      );
+      await waitFor(() =>
+        expect(getAllByText("Test Group").length).toBeGreaterThan(0),
+      );
+
+      fireEvent.press(getByText("Membres"));
+      await waitFor(() => expect(getByText("Bob")).toBeTruthy());
+
+      const actionBtns = getAllByLabelText(/Actions pour Bob/);
+      fireEvent.press(actionBtns[0]);
+
+      await waitFor(() => {
+        expect(getByText("Promouvoir en admin")).toBeTruthy();
+      });
+    });
+
+    it("modal actions owner sur admin : Rétrograder en membre visible", async () => {
+      mockedGroupsAPI.getGroupMembers.mockResolvedValue({
+        members: [ownerMe, adminOther],
+        total: 2,
+      } as any);
+
+      const { getByText, getAllByText, getAllByLabelText } = render(
+        <GroupDetailsScreen />,
+      );
+      await waitFor(() =>
+        expect(getAllByText("Test Group").length).toBeGreaterThan(0),
+      );
+
+      fireEvent.press(getByText("Membres"));
+      await waitFor(() => expect(getByText("AdminUser")).toBeTruthy());
+
+      const actionBtns = getAllByLabelText(/Actions pour AdminUser/);
+      fireEvent.press(actionBtns[0]);
+
+      await waitFor(() => {
+        expect(getByText("Rétrograder en membre")).toBeTruthy();
+      });
+    });
+
+    it("modal actions admin sur membre : pas de Promouvoir ni Rétrograder", async () => {
+      const adminMe = {
+        id: "user1",
+        user_id: "user1",
+        display_name: "Me",
+        role: "admin" as const,
+        joined_at: "2024-01-01T00:00:00Z",
+        is_active: true,
+      };
+      mockedGroupsAPI.getGroupMembers.mockResolvedValue({
+        members: [adminMe, memberOther],
+        total: 2,
+      } as any);
+
+      const { getByText, getAllByText, getAllByLabelText, queryByText } = render(
+        <GroupDetailsScreen />,
+      );
+      await waitFor(() =>
+        expect(getAllByText("Test Group").length).toBeGreaterThan(0),
+      );
+
+      fireEvent.press(getByText("Membres"));
+      await waitFor(() => expect(getByText("Bob")).toBeTruthy());
+
+      const actionBtns = getAllByLabelText(/Actions pour Bob/);
+      fireEvent.press(actionBtns[0]);
+
+      await waitFor(() => {
+        // admin ne peut pas promouvoir ni rétrograder
+        expect(queryByText("Promouvoir en admin")).toBeNull();
+        expect(queryByText("Rétrograder en membre")).toBeNull();
+        // mais peut retirer
+        expect(getByText("Retirer du groupe")).toBeTruthy();
+      });
+    });
+
+    it("sous-texte role 'Propriétaire' dans le modal détails", async () => {
+      mockedGroupsAPI.getGroupMembers.mockResolvedValue({
+        members: [ownerMe, memberOther],
+        total: 2,
+      } as any);
+
+      const { getByText, getAllByText, getAllByLabelText } = render(
+        <GroupDetailsScreen />,
+      );
+      await waitFor(() =>
+        expect(getAllByText("Test Group").length).toBeGreaterThan(0),
+      );
+
+      fireEvent.press(getByText("Membres"));
+      await waitFor(() => expect(getByText("Bob")).toBeTruthy());
+
+      const actionBtns = getAllByLabelText(/Actions pour Bob/);
+      fireEvent.press(actionBtns[0]);
+
+      // le sous-texte du rôle dans le modal est "Membre"
+      await waitFor(() => {
+        expect(getByText("Membre")).toBeTruthy();
       });
     });
   });

--- a/src/services/groups/api.ts
+++ b/src/services/groups/api.ts
@@ -25,7 +25,7 @@ export interface GroupMember {
   display_name: string;
   username?: string;
   avatar_url?: string;
-  role: "admin" | "moderator" | "member";
+  role: "owner" | "admin" | "moderator" | "member";
   joined_at: string;
   is_active: boolean;
 }
@@ -87,7 +87,7 @@ interface RawConversationMember {
 }
 
 interface ResolvedMemberMeta {
-  role: "admin" | "moderator" | "member";
+  role: "owner" | "admin" | "moderator" | "member";
   joinedAt?: string;
   isActive?: boolean;
 }
@@ -483,8 +483,10 @@ async function fetchConversationMembers(
     const uid = m.userId ?? m.user_id;
     if (!uid) continue;
     const rawRole = (m.role ?? "member").toLowerCase();
-    let role: "admin" | "moderator" | "member" = "member";
-    if (rawRole === "admin" || rawRole === "owner") {
+    let role: "owner" | "admin" | "moderator" | "member" = "member";
+    if (rawRole === "owner") {
+      role = "owner";
+    } else if (rawRole === "admin") {
       role = "admin";
     } else if (rawRole === "moderator") {
       role = "moderator";
@@ -704,7 +706,7 @@ export const groupsAPI = {
         const displayName = fullName || profile?.username || "Utilisateur";
 
         const memberMeta = roleByUserId.get(userId);
-        const role: "admin" | "moderator" | "member" =
+        const role: "owner" | "admin" | "moderator" | "member" =
           memberMeta?.role ?? (userId === ownerId ? "admin" : "member");
 
         return {
@@ -1196,6 +1198,31 @@ export const groupsAPI = {
       `${API_BASE_URL}/groups/${encodeURIComponent(groupId)}/members/${encodeURIComponent(userId)}/demote`,
       {
         method: "PATCH",
+        headers,
+      },
+    );
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      const msg =
+        (body as { error?: string; message?: string })?.error ??
+        (body as { message?: string })?.message ??
+        `HTTP ${res.status}`;
+      const err = new Error(msg) as Error & { status: number };
+      err.status = res.status;
+      throw err;
+    }
+  },
+
+  /**
+   * DELETE /user/v1/groups/:groupId/members/:userId/kick — owner ou admin
+   * Retirer un membre par force (équivalent de remove, mais via user-service).
+   */
+  async kickMember(groupId: string, userId: string): Promise<void> {
+    const headers = await getAuthHeaders();
+    const res = await fetch(
+      `${API_BASE_URL}/groups/${encodeURIComponent(groupId)}/members/${encodeURIComponent(userId)}/kick`,
+      {
+        method: "DELETE",
         headers,
       },
     );


### PR DESCRIPTION
## Summary
- Badge couronne \"Propriétaire\" (#FFD700) distinct du badge Admin bleu
- Action sheet adaptée au rôle : owner peut promouvoir/rétrograder/retirer ; admin peut retirer un membre uniquement ; member : aucun bouton
- Header onglet Membres affiche \"1 propriétaire, X administrateurs\" séparément
- Sous-texte rôle dans modal détails membre : Propriétaire / Administrateur / Membre
- Type GroupMemberRole étendu : 'owner' | 'admin' | 'moderator' | 'member'
- kickMember endpoint ajouté dans groupsAPI (DELETE /groups/:id/members/:userId/kick)
- Dégradation gracieuse : backend old qui retourne 'admin' pour owner continue de fonctionner

## Test plan
- [x] 26/26 tests GroupDetailsScreen verts
- [x] 46/46 tests groupsAPI verts
- [x] tsc --noEmit clean
- [x] lint : 0 erreur
- [ ] Tester visuellement badge sur iOS/Web preprod