### PR TITLE
fix(security): QR code device pairing login

### DIFF
--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -879,6 +879,11 @@ const localizedTexts: Record<Language, Record<string, string>> = {
     "security.scanQRCode": "Scanner le code QR",
     "security.qrScannerComingSoon":
       "Le scanner QR sera disponible prochainement",
+    "security.qrInstructions": "Scannez ce code avec l'appareil à connecter",
+    "security.qrExpiresIn": "Expire dans",
+    "security.qrRefresh": "Actualiser",
+    "security.qrExpired": "QR code expiré",
+    "security.qrGenerateError": "Impossible de générer le QR code",
     "security.createdOn": "Créé le",
     "security.infoMessage":
       "Ces clés permettent de vérifier l'identité de vos appareils et de sécuriser vos conversations.",
@@ -1226,6 +1231,12 @@ const localizedTexts: Record<Language, Record<string, string>> = {
     "security.codeCopied": "Code copied to clipboard",
     "security.scanQRCode": "Scan QR Code",
     "security.qrScannerComingSoon": "QR scanner will be available soon",
+    "security.qrInstructions":
+      "Scan this code with the device you want to connect",
+    "security.qrExpiresIn": "Expires in",
+    "security.qrRefresh": "Refresh",
+    "security.qrExpired": "QR code expired",
+    "security.qrGenerateError": "Unable to generate QR code",
     "security.createdOn": "Created on",
     "security.infoMessage":
       "These keys allow you to verify your devices' identity and secure your conversations.",

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -761,6 +761,7 @@ const localizedTexts: Record<Language, Record<string, string>> = {
     "auth.cancel": "Annuler",
     "auth.skip": "Passer",
     "auth.linkedAccount": "Compte associé :",
+    "auth.loginViaQR": "Se connecter via QR code",
 
     // Profile
     "profile.title": "Profil",
@@ -1110,6 +1111,7 @@ const localizedTexts: Record<Language, Record<string, string>> = {
     "auth.cancel": "Cancel",
     "auth.skip": "Skip",
     "auth.linkedAccount": "Linked account:",
+    "auth.loginViaQR": "Sign in with QR code",
 
     // Profile
     "profile.title": "Profile",

--- a/src/navigation/AuthNavigator.tsx
+++ b/src/navigation/AuthNavigator.tsx
@@ -112,6 +112,7 @@ export type AuthStackParamList = {
   Contacts: undefined;
   MyQRCode: undefined;
   QRCodeScanner: undefined;
+  DevicePairingScanner: undefined;
   BlockedUsers: undefined;
   GroupDetails: {
     groupId: string;
@@ -484,6 +485,13 @@ export const AuthNavigator: React.FC = () => {
           getComponent={() =>
             require("../screens/Contacts/QRCodeScannerScreen")
               .QRCodeScannerScreen
+          }
+        />
+        <Stack.Screen
+          name="DevicePairingScanner"
+          getComponent={() =>
+            require("../screens/Auth/DevicePairingScannerScreen")
+              .DevicePairingScannerScreen
           }
         />
         <Stack.Screen name="BlockedUsers" component={BlockedUsersScreen} />

--- a/src/screens/Auth/DevicePairingScannerScreen.tsx
+++ b/src/screens/Auth/DevicePairingScannerScreen.tsx
@@ -1,0 +1,515 @@
+import React, { useState, useEffect, useRef } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Alert,
+  Animated,
+  Dimensions,
+  ActivityIndicator,
+  Platform,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { LinearGradient } from "expo-linear-gradient";
+import { CameraView, useCameraPermissions } from "expo-camera";
+import { useNavigation } from "@react-navigation/native";
+import type { StackNavigationProp } from "@react-navigation/stack";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "../../context/ThemeContext";
+import { useAuth } from "../../context/AuthContext";
+import { colors } from "../../theme/colors";
+import { TokenService } from "../../services/TokenService";
+import { DeviceManagerService } from "../../services/SecurityService";
+import { SignalKeyService } from "../../services/SignalKeyService";
+import { SignalKeysService } from "../../services/SecurityService";
+import type { AuthStackParamList } from "../../navigation/AuthNavigator";
+
+// Lazy-load the web QR scanner so native bundles don't pull in browser-only deps.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let WebScanner: any = null;
+if (Platform.OS === "web") {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  WebScanner = require("@yudiel/react-qr-scanner").Scanner;
+}
+
+const { width: SCREEN_WIDTH } = Dimensions.get("window");
+const SCAN_AREA_SIZE = Math.min(SCREEN_WIDTH - 64, 280);
+
+const generateAndUploadSignalKeys = async (): Promise<void> => {
+  try {
+    const bundle = await SignalKeyService.generateKeyBundle();
+    await SignalKeysService.uploadSignedPrekey({
+      key_id: bundle.signedPreKey.keyId,
+      public_key: bundle.signedPreKey.publicKey,
+      signature: bundle.signedPreKey.signature,
+    });
+    await SignalKeysService.uploadPrekeys(
+      bundle.preKeys.map((pk) => ({
+        key_id: pk.keyId,
+        public_key: pk.publicKey,
+      })),
+    );
+  } catch (err) {
+    console.warn("[DevicePairingScannerScreen] Signal key upload failed:", err);
+  }
+};
+
+export const DevicePairingScannerScreen: React.FC = () => {
+  const navigation = useNavigation<StackNavigationProp<AuthStackParamList>>();
+  const { getThemeColors } = useTheme();
+  const themeColors = getThemeColors();
+  const { signIn } = useAuth();
+
+  const [permission, requestPermission] = useCameraPermissions();
+  const [scanned, setScanned] = useState(false);
+  const [processing, setProcessing] = useState(false);
+
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+  const scanLineAnim = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    if (Platform.OS === "web") return;
+    if (permission?.granted) {
+      Animated.timing(fadeAnim, {
+        toValue: 1,
+        duration: 300,
+        useNativeDriver: true,
+      }).start();
+
+      Animated.loop(
+        Animated.sequence([
+          Animated.timing(scanLineAnim, {
+            toValue: 1,
+            duration: 2000,
+            useNativeDriver: true,
+          }),
+          Animated.timing(scanLineAnim, {
+            toValue: 0,
+            duration: 0,
+            useNativeDriver: true,
+          }),
+        ]),
+      ).start();
+    }
+  }, [permission?.granted]);
+
+  const handleBarCodeScanned = async ({
+    data,
+  }: {
+    data: string;
+    type?: string;
+  }) => {
+    if (scanned || processing) return;
+
+    setScanned(true);
+    setProcessing(true);
+
+    try {
+      const tokens = await DeviceManagerService.scanQRChallenge(data);
+      await TokenService.saveTokens(tokens);
+
+      const payload = TokenService.decodeAccessToken(tokens.accessToken);
+      if (!payload) throw new Error("Invalid token");
+
+      signIn(payload.sub, payload.deviceId);
+      generateAndUploadSignalKeys();
+
+      navigation.reset({ index: 0, routes: [{ name: "ConversationsList" }] });
+    } catch (err: unknown) {
+      const status =
+        typeof err === "object" && err !== null && "status" in err
+          ? Number((err as { status?: number }).status)
+          : undefined;
+
+      let message = "Impossible de se connecter avec ce QR code.";
+      if (status === 401 || status === 403) {
+        message = "Ce QR code est expiré ou invalide. Demandez-en un nouveau.";
+      } else if (status === 400) {
+        message = "QR code invalide. Assurez-vous de scanner le code Whispr.";
+      }
+
+      Alert.alert("Connexion échouée", message, [
+        {
+          text: "Réessayer",
+          onPress: () => {
+            setScanned(false);
+            setProcessing(false);
+          },
+        },
+      ]);
+    }
+  };
+
+  if (Platform.OS === "web" && WebScanner) {
+    return (
+      <LinearGradient
+        colors={colors.background.gradient.app}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={styles.gradientContainer}
+      >
+        <SafeAreaView style={styles.container} edges={["top"]}>
+          <View style={styles.header}>
+            <TouchableOpacity
+              onPress={() => navigation.goBack()}
+              style={styles.backButton}
+            >
+              <Ionicons
+                name="arrow-back"
+                size={24}
+                color={themeColors.text.primary || colors.text.light}
+              />
+            </TouchableOpacity>
+            <Text
+              style={[
+                styles.headerTitle,
+                { color: themeColors.text.primary || colors.text.light },
+              ]}
+            >
+              Se connecter via QR
+            </Text>
+            <View style={styles.placeholder} />
+          </View>
+          <View style={styles.cameraContainer}>
+            <WebScanner
+              onScan={(results: { rawValue: string }[]) => {
+                if (results && results[0]) {
+                  void handleBarCodeScanned({ data: results[0].rawValue });
+                }
+              }}
+              onError={(err: Error) => {
+                console.warn("QR scan error", err);
+              }}
+              constraints={{ facingMode: "environment" }}
+              styles={{
+                container: { width: "100%", height: "100%" },
+                video: { width: "100%", height: "100%" },
+              }}
+            />
+            <View style={styles.overlayBottom}>
+              <Text style={styles.instructionText}>
+                Scannez le QR code affiché sur l'autre appareil
+              </Text>
+              {processing ? (
+                <View style={styles.processingContainer}>
+                  <ActivityIndicator size="small" color={colors.primary.main} />
+                  <Text style={styles.processingText}>Connexion...</Text>
+                </View>
+              ) : null}
+            </View>
+          </View>
+        </SafeAreaView>
+      </LinearGradient>
+    );
+  }
+
+  if (!permission) {
+    return (
+      <LinearGradient
+        colors={colors.background.gradient.app}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={styles.gradientContainer}
+      >
+        <SafeAreaView style={styles.container} edges={["top"]}>
+          <View style={styles.permissionContainer}>
+            <ActivityIndicator size="large" color={colors.primary.main} />
+            <Text style={[styles.permissionText, { color: colors.text.light }]}>
+              Vérification des permissions...
+            </Text>
+          </View>
+        </SafeAreaView>
+      </LinearGradient>
+    );
+  }
+
+  if (!permission.granted) {
+    return (
+      <LinearGradient
+        colors={colors.background.gradient.app}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={styles.gradientContainer}
+      >
+        <SafeAreaView style={styles.container} edges={["top"]}>
+          <View style={styles.header}>
+            <TouchableOpacity
+              onPress={() => navigation.goBack()}
+              style={styles.backButton}
+            >
+              <Ionicons
+                name="arrow-back"
+                size={24}
+                color={themeColors.text.primary || colors.text.light}
+              />
+            </TouchableOpacity>
+            <Text
+              style={[
+                styles.headerTitle,
+                { color: themeColors.text.primary || colors.text.light },
+              ]}
+            >
+              Se connecter via QR
+            </Text>
+            <View style={styles.placeholder} />
+          </View>
+
+          <View style={styles.permissionContainer}>
+            <Ionicons
+              name="camera-outline"
+              size={64}
+              color={colors.text.light}
+              style={{ opacity: 0.7 }}
+            />
+            <Text
+              style={[styles.permissionTitle, { color: colors.text.light }]}
+            >
+              Accès à la caméra requis
+            </Text>
+            <Text
+              style={[
+                styles.permissionText,
+                { color: colors.text.light, opacity: 0.8 },
+              ]}
+            >
+              Pour scanner le QR code, Whispr a besoin d&apos;accéder à votre
+              caméra.
+            </Text>
+            <TouchableOpacity
+              style={styles.permissionButton}
+              onPress={() => void requestPermission()}
+              activeOpacity={0.8}
+            >
+              <Text style={styles.permissionButtonText}>
+                Autoriser l&apos;accès
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </SafeAreaView>
+      </LinearGradient>
+    );
+  }
+
+  return (
+    <LinearGradient
+      colors={colors.background.gradient.app}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 1 }}
+      style={styles.gradientContainer}
+    >
+      <SafeAreaView style={styles.container} edges={["top"]}>
+        <View style={styles.header}>
+          <TouchableOpacity
+            onPress={() => navigation.goBack()}
+            style={styles.backButton}
+          >
+            <Ionicons
+              name="arrow-back"
+              size={24}
+              color={themeColors.text.primary || colors.text.light}
+            />
+          </TouchableOpacity>
+          <Text
+            style={[
+              styles.headerTitle,
+              { color: themeColors.text.primary || colors.text.light },
+            ]}
+          >
+            Se connecter via QR
+          </Text>
+          <View style={styles.placeholder} />
+        </View>
+
+        <Animated.View style={[styles.cameraContainer, { opacity: fadeAnim }]}>
+          <CameraView
+            style={styles.camera}
+            facing="back"
+            onBarcodeScanned={scanned ? undefined : handleBarCodeScanned}
+            barcodeScannerSettings={{
+              barcodeTypes: ["qr"],
+            }}
+          >
+            <View style={styles.overlay}>
+              <View style={styles.overlayTop} />
+              <View style={styles.overlayMiddle}>
+                <View style={styles.overlaySide} />
+                <View style={styles.scanArea}>
+                  <View style={[styles.corner, styles.cornerTopLeft]} />
+                  <View style={[styles.corner, styles.cornerTopRight]} />
+                  <View style={[styles.corner, styles.cornerBottomLeft]} />
+                  <View style={[styles.corner, styles.cornerBottomRight]} />
+                  {!scanned ? (
+                    <Animated.View
+                      style={[
+                        styles.scanLine,
+                        {
+                          transform: [
+                            {
+                              translateY: scanLineAnim.interpolate({
+                                inputRange: [0, 1],
+                                outputRange: [0, SCAN_AREA_SIZE - 2],
+                              }),
+                            },
+                          ],
+                        },
+                      ]}
+                    />
+                  ) : null}
+                </View>
+                <View style={styles.overlaySide} />
+              </View>
+              <View style={styles.overlayBottom}>
+                <Text style={styles.instructionText}>
+                  Scannez le QR code affiché sur l&apos;autre appareil
+                </Text>
+                {processing ? (
+                  <View style={styles.processingContainer}>
+                    <ActivityIndicator
+                      size="small"
+                      color={colors.primary.main}
+                    />
+                    <Text style={styles.processingText}>Connexion...</Text>
+                  </View>
+                ) : null}
+              </View>
+            </View>
+          </CameraView>
+        </Animated.View>
+      </SafeAreaView>
+    </LinearGradient>
+  );
+};
+
+const styles = StyleSheet.create({
+  gradientContainer: { flex: 1 },
+  container: { flex: 1 },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: "rgba(255, 255, 255, 0.1)",
+    zIndex: 10,
+  },
+  backButton: { padding: 4 },
+  headerTitle: {
+    flex: 1,
+    fontSize: 20,
+    fontWeight: "600",
+    textAlign: "center",
+  },
+  placeholder: { width: 32 },
+  cameraContainer: { flex: 1 },
+  camera: { flex: 1 },
+  overlay: { flex: 1, backgroundColor: "transparent" },
+  overlayTop: { flex: 1, backgroundColor: "rgba(0, 0, 0, 0.6)" },
+  overlayMiddle: {
+    flexDirection: "row",
+    height: SCAN_AREA_SIZE + 32,
+  },
+  overlaySide: { flex: 1, backgroundColor: "rgba(0, 0, 0, 0.6)" },
+  scanArea: {
+    width: SCAN_AREA_SIZE,
+    height: SCAN_AREA_SIZE,
+    marginVertical: 16,
+    position: "relative",
+  },
+  corner: {
+    position: "absolute",
+    width: 24,
+    height: 24,
+    borderColor: colors.primary.main,
+    borderWidth: 3,
+  },
+  cornerTopLeft: {
+    top: 0,
+    left: 0,
+    borderRightWidth: 0,
+    borderBottomWidth: 0,
+  },
+  cornerTopRight: {
+    top: 0,
+    right: 0,
+    borderLeftWidth: 0,
+    borderBottomWidth: 0,
+  },
+  cornerBottomLeft: {
+    bottom: 0,
+    left: 0,
+    borderRightWidth: 0,
+    borderTopWidth: 0,
+  },
+  cornerBottomRight: {
+    bottom: 0,
+    right: 0,
+    borderLeftWidth: 0,
+    borderTopWidth: 0,
+  },
+  scanLine: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    height: 2,
+    backgroundColor: colors.primary.main,
+    shadowColor: colors.primary.main,
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 1,
+    shadowRadius: 4,
+    elevation: 4,
+  },
+  overlayBottom: {
+    flex: 1,
+    backgroundColor: "rgba(0, 0, 0, 0.6)",
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 32,
+  },
+  instructionText: {
+    color: colors.text.light,
+    fontSize: 16,
+    textAlign: "center",
+    marginBottom: 16,
+  },
+  processingContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  processingText: {
+    color: colors.text.light,
+    fontSize: 14,
+  },
+  permissionContainer: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 32,
+  },
+  permissionTitle: {
+    fontSize: 20,
+    fontWeight: "600",
+    marginTop: 24,
+    marginBottom: 12,
+    textAlign: "center",
+  },
+  permissionText: {
+    fontSize: 16,
+    textAlign: "center",
+    marginBottom: 32,
+  },
+  permissionButton: {
+    backgroundColor: colors.primary.main,
+    paddingHorizontal: 32,
+    paddingVertical: 14,
+    borderRadius: 12,
+  },
+  permissionButtonText: {
+    color: colors.text.light,
+    fontSize: 16,
+    fontWeight: "600",
+  },
+});
+
+export default DevicePairingScannerScreen;

--- a/src/screens/Auth/PhoneInputScreen.tsx
+++ b/src/screens/Auth/PhoneInputScreen.tsx
@@ -433,8 +433,8 @@ export const PhoneInputScreen: React.FC = () => {
                       >
                         <Ionicons
                           name="qr-code-outline"
-                          size={20}
-                          color={colors.text.light}
+                          size={18}
+                          color="rgba(255, 255, 255, 0.75)"
                           style={styles.qrButtonIcon}
                         />
                         <Text style={styles.qrButtonText}>
@@ -619,19 +619,13 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
-    borderWidth: 1.5,
-    borderColor: "rgba(255, 255, 255, 0.4)",
-    borderRadius: 12,
-    paddingVertical: spacing.base,
-    paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.sm,
     gap: spacing.sm,
   },
-  qrButtonIcon: {
-    marginRight: 2,
-  },
+  qrButtonIcon: {},
   qrButtonText: {
-    color: colors.text.light,
-    fontSize: typography.fontSize.md,
-    fontWeight: "600",
+    color: "rgba(255, 255, 255, 0.75)",
+    fontSize: typography.fontSize.base,
+    fontWeight: "500",
   },
 });

--- a/src/screens/Auth/PhoneInputScreen.tsx
+++ b/src/screens/Auth/PhoneInputScreen.tsx
@@ -12,6 +12,7 @@ import {
   TouchableWithoutFeedback,
   View,
 } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
 import { LinearGradient } from "expo-linear-gradient";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useNavigation, useRoute } from "@react-navigation/native";
@@ -406,15 +407,43 @@ export const PhoneInputScreen: React.FC = () => {
                   }}
                 />
               ) : (
-                <Button
-                  title={getLocalizedText("auth.continue")}
-                  variant="primary"
-                  size="large"
-                  fullWidth
-                  loading={loading}
-                  disabled={!isPhoneValid || loading}
-                  onPress={handleContinue}
-                />
+                <>
+                  <Button
+                    title={getLocalizedText("auth.continue")}
+                    variant="primary"
+                    size="large"
+                    fullWidth
+                    loading={loading}
+                    disabled={!isPhoneValid || loading}
+                    onPress={handleContinue}
+                  />
+                  {mode === "login" && (
+                    <>
+                      <View style={styles.divider}>
+                        <View style={styles.dividerLine} />
+                        <Text style={styles.dividerText}>ou</Text>
+                        <View style={styles.dividerLine} />
+                      </View>
+                      <TouchableOpacity
+                        style={styles.qrButton}
+                        onPress={() =>
+                          navigation.navigate("DevicePairingScanner")
+                        }
+                        activeOpacity={0.8}
+                      >
+                        <Ionicons
+                          name="qr-code-outline"
+                          size={20}
+                          color={colors.text.light}
+                          style={styles.qrButtonIcon}
+                        />
+                        <Text style={styles.qrButtonText}>
+                          {getLocalizedText("auth.loginViaQR")}
+                        </Text>
+                      </TouchableOpacity>
+                    </>
+                  )}
+                </>
               )}
             </View>
           </Animated.View>
@@ -569,5 +598,40 @@ const styles = StyleSheet.create({
   },
   buttons: {
     // Toujours présent dans le layout, disabled géré par le prop Button
+  },
+  divider: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginVertical: spacing.md,
+  },
+  dividerLine: {
+    flex: 1,
+    height: 1,
+    backgroundColor: "rgba(255, 255, 255, 0.25)",
+  },
+  dividerText: {
+    color: "rgba(255, 255, 255, 0.6)",
+    fontSize: typography.fontSize.sm,
+    marginHorizontal: spacing.md,
+    fontWeight: "500",
+  },
+  qrButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 1.5,
+    borderColor: "rgba(255, 255, 255, 0.4)",
+    borderRadius: 12,
+    paddingVertical: spacing.base,
+    paddingHorizontal: spacing.xl,
+    gap: spacing.sm,
+  },
+  qrButtonIcon: {
+    marginRight: 2,
+  },
+  qrButtonText: {
+    color: colors.text.light,
+    fontSize: typography.fontSize.md,
+    fontWeight: "600",
   },
 });

--- a/src/screens/Auth/__tests__/DevicePairingScannerScreen.test.tsx
+++ b/src/screens/Auth/__tests__/DevicePairingScannerScreen.test.tsx
@@ -1,0 +1,136 @@
+import React from "react";
+import { render, waitFor, fireEvent } from "@testing-library/react-native";
+import { DevicePairingScannerScreen } from "../DevicePairingScannerScreen";
+import { DeviceManagerService } from "../../../services/SecurityService";
+import { TokenService } from "../../../services/TokenService";
+
+const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
+const mockReset = jest.fn();
+const mockSignIn = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({
+    navigate: mockNavigate,
+    goBack: mockGoBack,
+    reset: mockReset,
+  }),
+}));
+jest.mock("expo-linear-gradient", () => ({
+  LinearGradient: ({ children }: any) => children,
+}));
+jest.mock("react-native-safe-area-context", () => ({
+  SafeAreaView: ({ children }: any) => children,
+}));
+jest.mock("@expo/vector-icons", () => ({ Ionicons: () => null }));
+jest.mock("expo-camera", () => ({
+  CameraView: ({ onBarcodeScanned, children }: any) => {
+    const { View, TouchableOpacity } = require("react-native");
+    return (
+      <View>
+        {children}
+        <TouchableOpacity
+          testID="mock-scan-trigger"
+          onPress={() =>
+            onBarcodeScanned?.({ data: "mock.jwt.token", type: "qr" })
+          }
+        />
+      </View>
+    );
+  },
+  useCameraPermissions: () => [{ granted: true }, jest.fn()],
+}));
+jest.mock("../../../context/ThemeContext", () => ({
+  useTheme: () => ({
+    getThemeColors: () => ({
+      text: { primary: "#fff", secondary: "#aaa" },
+      primary: "#6200ee",
+    }),
+  }),
+}));
+jest.mock("../../../context/AuthContext", () => ({
+  useAuth: () => ({ signIn: mockSignIn }),
+}));
+jest.mock("../../../services/SecurityService", () => ({
+  DeviceManagerService: { scanQRChallenge: jest.fn() },
+  SignalKeysService: {
+    uploadSignedPrekey: jest.fn().mockResolvedValue(undefined),
+    uploadPrekeys: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+jest.mock("../../../services/TokenService", () => ({
+  TokenService: {
+    saveTokens: jest.fn().mockResolvedValue(undefined),
+    decodeAccessToken: jest.fn(),
+  },
+}));
+jest.mock("../../../services/SignalKeyService", () => ({
+  SignalKeyService: {
+    generateKeyBundle: jest.fn().mockResolvedValue({
+      signedPreKey: { keyId: 1, publicKey: "pk", signature: "sig" },
+      preKeys: [],
+    }),
+  },
+}));
+jest.mock("../../../theme/colors", () => ({
+  colors: {
+    background: { gradient: { app: ["#000", "#111"] } },
+    text: { light: "#fff" },
+    primary: { main: "#6200ee" },
+  },
+}));
+
+describe("DevicePairingScannerScreen", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("renders without crashing", () => {
+    const { toJSON } = render(<DevicePairingScannerScreen />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it("navigates to ConversationsList on successful scan", async () => {
+    (DeviceManagerService.scanQRChallenge as jest.Mock).mockResolvedValueOnce({
+      accessToken: "access.token.here",
+      refreshToken: "refresh.token.here",
+    });
+    (TokenService.decodeAccessToken as jest.Mock).mockReturnValueOnce({
+      sub: "user-123",
+      deviceId: "device-456",
+      exp: 9999999999,
+    });
+
+    const { getByTestId } = render(<DevicePairingScannerScreen />);
+    fireEvent.press(getByTestId("mock-scan-trigger"));
+
+    await waitFor(() => {
+      expect(TokenService.saveTokens).toHaveBeenCalledWith({
+        accessToken: "access.token.here",
+        refreshToken: "refresh.token.here",
+      });
+      expect(mockSignIn).toHaveBeenCalledWith("user-123", "device-456");
+      expect(mockReset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: "ConversationsList" }],
+      });
+    });
+  });
+
+  it("shows error alert on scan failure", async () => {
+    const { Alert } = require("react-native");
+    jest.spyOn(Alert, "alert");
+    (DeviceManagerService.scanQRChallenge as jest.Mock).mockRejectedValueOnce(
+      Object.assign(new Error("Unauthorized"), { status: 401 }),
+    );
+
+    const { getByTestId } = render(<DevicePairingScannerScreen />);
+    fireEvent.press(getByTestId("mock-scan-trigger"));
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith(
+        "Connexion échouée",
+        expect.stringContaining("expiré"),
+        expect.any(Array),
+      );
+    });
+  });
+});

--- a/src/screens/Security/SecurityKeysScreen.tsx
+++ b/src/screens/Security/SecurityKeysScreen.tsx
@@ -61,7 +61,7 @@ interface SecurityKey {
 }
 
 // Module-level cache — survives re-renders and component remounts
-const _qrCache: {
+export const _qrCache: {
   challenge: string | null;
   deviceId: string;
   generatedAt: number;

--- a/src/screens/Security/SecurityKeysScreen.tsx
+++ b/src/screens/Security/SecurityKeysScreen.tsx
@@ -338,13 +338,21 @@ export const SecurityKeysScreen: React.FC = () => {
   };
 
   const fetchQRChallenge = useCallback(async (): Promise<void> => {
-    if (!currentDeviceId) return;
+    if (!currentDeviceId) {
+      console.warn("[QR] fetchQRChallenge: no currentDeviceId");
+      return;
+    }
+    console.log("[QR] Generating challenge for deviceId:", currentDeviceId);
     setQrLoading(true);
     setQrChallenge(null);
     setQrCountdown(300);
     try {
       const challenge =
         await DeviceManagerService.generateQRChallenge(currentDeviceId);
+      console.log(
+        "[QR] Challenge set, length:",
+        typeof challenge === "string" ? challenge.length : typeof challenge,
+      );
       setQrChallenge(challenge);
     } finally {
       setQrLoading(false);
@@ -356,7 +364,16 @@ export const SecurityKeysScreen: React.FC = () => {
     setShowQRModal(true);
     try {
       await fetchQRChallenge();
-    } catch {
+    } catch (err: unknown) {
+      const e = err as { status?: number; message?: string; body?: unknown };
+      console.error(
+        "[QR] handleShowQRCode error — status:",
+        e?.status,
+        "message:",
+        e?.message,
+        "body:",
+        JSON.stringify(e?.body),
+      );
       showToast(
         getLocalizedText("security.qrGenerateError") ||
           "Impossible de générer le QR code",
@@ -370,7 +387,16 @@ export const SecurityKeysScreen: React.FC = () => {
     triggerHaptic("light");
     try {
       await fetchQRChallenge();
-    } catch {
+    } catch (err: unknown) {
+      const e = err as { status?: number; message?: string; body?: unknown };
+      console.error(
+        "[QR] handleRefreshQR error — status:",
+        e?.status,
+        "message:",
+        e?.message,
+        "body:",
+        JSON.stringify(e?.body),
+      );
       showToast(
         getLocalizedText("security.qrGenerateError") ||
           "Impossible de générer le QR code",

--- a/src/screens/Security/SecurityKeysScreen.tsx
+++ b/src/screens/Security/SecurityKeysScreen.tsx
@@ -3,7 +3,7 @@
  * Security keys and connected devices management
  */
 
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useEffect, useCallback } from "react";
 import {
   View,
   Text,
@@ -16,6 +16,7 @@ import {
   Animated,
   Platform,
   Dimensions,
+  ActivityIndicator,
 } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
 import { useNavigation } from "@react-navigation/native";
@@ -24,6 +25,7 @@ import { useTheme } from "../../context/ThemeContext";
 import { useAuth } from "../../context/AuthContext";
 import * as Haptics from "expo-haptics";
 import Toast from "../../components/Toast/Toast";
+import QRCodeStyled from "react-native-qrcode-styled";
 
 import { copyToClipboard } from "../../utils/clipboard";
 import {
@@ -64,6 +66,8 @@ export const SecurityKeysScreen: React.FC = () => {
   const slideAnim = useRef(new Animated.Value(30)).current;
   const modalScale = useRef(new Animated.Value(0.9)).current;
   const modalOpacity = useRef(new Animated.Value(0)).current;
+  const qrModalScale = useRef(new Animated.Value(0.9)).current;
+  const qrModalOpacity = useRef(new Animated.Value(0)).current;
 
   const [devices, setDevices] = useState<ConnectedDevice[]>([]);
   const [loadingDevices, setLoadingDevices] = useState(true);
@@ -76,6 +80,10 @@ export const SecurityKeysScreen: React.FC = () => {
   );
   const [verificationCode, setVerificationCode] = useState("");
   const [showSecurityKeys, setShowSecurityKeys] = useState(false);
+  const [showQRModal, setShowQRModal] = useState(false);
+  const [qrChallenge, setQrChallenge] = useState<string | null>(null);
+  const [qrLoading, setQrLoading] = useState(false);
+  const [qrCountdown, setQrCountdown] = useState(300);
   const [toast, setToast] = useState<{
     visible: boolean;
     message: string;
@@ -94,6 +102,12 @@ export const SecurityKeysScreen: React.FC = () => {
     if (p === "desktop" || p === "macos" || p === "windows" || p === "linux")
       return "desktop";
     return "mobile";
+  };
+
+  const formatCountdown = (seconds: number): string => {
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return `${m}:${s.toString().padStart(2, "0")}`;
   };
 
   const formatLastActive = (isoString: string): string => {
@@ -184,6 +198,49 @@ export const SecurityKeysScreen: React.FC = () => {
       ]).start();
     }
   }, [showSecurityCodeModal]);
+
+  useEffect(() => {
+    if (showQRModal) {
+      Animated.parallel([
+        Animated.spring(qrModalScale, {
+          toValue: 1,
+          tension: 50,
+          friction: 7,
+          useNativeDriver: true,
+        }),
+        Animated.timing(qrModalOpacity, {
+          toValue: 1,
+          duration: 300,
+          useNativeDriver: true,
+        }),
+      ]).start();
+    } else {
+      Animated.parallel([
+        Animated.timing(qrModalScale, {
+          toValue: 0.9,
+          duration: 200,
+          useNativeDriver: true,
+        }),
+        Animated.timing(qrModalOpacity, {
+          toValue: 0,
+          duration: 200,
+          useNativeDriver: true,
+        }),
+      ]).start();
+    }
+  }, [showQRModal]);
+
+  useEffect(() => {
+    if (!showQRModal || !qrChallenge) return;
+    const id = setInterval(() => {
+      setQrCountdown((prev) => (prev <= 1 ? 0 : prev - 1));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [showQRModal, qrChallenge]);
+
+  useEffect(() => {
+    if (qrCountdown === 0 && showQRModal) setQrChallenge(null);
+  }, [qrCountdown, showQRModal]);
 
   const triggerHaptic = (type: "light" | "medium" | "heavy" = "light") => {
     if (Platform.OS === "ios") {
@@ -280,15 +337,47 @@ export const SecurityKeysScreen: React.FC = () => {
     }
   };
 
-  const handleScanQRCode = () => {
+  const fetchQRChallenge = useCallback(async (): Promise<void> => {
+    if (!currentDeviceId) return;
+    setQrLoading(true);
+    setQrChallenge(null);
+    setQrCountdown(300);
+    try {
+      const challenge =
+        await DeviceManagerService.generateQRChallenge(currentDeviceId);
+      setQrChallenge(challenge);
+    } finally {
+      setQrLoading(false);
+    }
+  }, [currentDeviceId]);
+
+  const handleShowQRCode = useCallback(async () => {
     triggerHaptic("light");
-    Alert.alert(
-      "",
-      getLocalizedText("security.qrScannerComingSoon"),
-      [{ text: getLocalizedText("common.ok") }],
-      { cancelable: true },
-    );
-  };
+    setShowQRModal(true);
+    try {
+      await fetchQRChallenge();
+    } catch {
+      showToast(
+        getLocalizedText("security.qrGenerateError") ||
+          "Impossible de générer le QR code",
+        "error",
+      );
+      setShowQRModal(false);
+    }
+  }, [fetchQRChallenge]);
+
+  const handleRefreshQR = useCallback(async () => {
+    triggerHaptic("light");
+    try {
+      await fetchQRChallenge();
+    } catch {
+      showToast(
+        getLocalizedText("security.qrGenerateError") ||
+          "Impossible de générer le QR code",
+        "error",
+      );
+    }
+  }, [fetchQRChallenge]);
 
   const getDeviceIcon = (type: string): { name: any; color: string } => {
     const iconColor = accentColor;
@@ -968,7 +1057,7 @@ export const SecurityKeysScreen: React.FC = () => {
 
           <View style={styles.actionsSection}>
             <TouchableOpacity
-              onPress={handleScanQRCode}
+              onPress={handleShowQRCode}
               activeOpacity={0.9}
               style={styles.actionButtonContainer}
             >
@@ -1195,6 +1284,153 @@ export const SecurityKeysScreen: React.FC = () => {
                   {getLocalizedText("security.verify")}
                 </Text>
               </LinearGradient>
+            </TouchableOpacity>
+          </Animated.View>
+        </Animated.View>
+      </Modal>
+
+      <Modal
+        visible={showQRModal}
+        transparent
+        animationType="none"
+        onRequestClose={() => setShowQRModal(false)}
+      >
+        <Animated.View
+          style={[styles.modalOverlay, { opacity: qrModalOpacity }]}
+        >
+          <TouchableOpacity
+            style={styles.modalBackdrop}
+            activeOpacity={1}
+            onPress={() => setShowQRModal(false)}
+          />
+          <Animated.View
+            style={[
+              styles.modalContent,
+              {
+                backgroundColor: themeColors.background.primary,
+                transform: [{ scale: qrModalScale }],
+                ...Platform.select({
+                  ios: {
+                    shadowColor: "#000",
+                    shadowOffset: { width: 0, height: -4 },
+                    shadowOpacity: 0.3,
+                    shadowRadius: 20,
+                  },
+                  android: { elevation: 24 },
+                }),
+              },
+            ]}
+          >
+            <View style={styles.modalHeader}>
+              <Text
+                style={[
+                  styles.modalTitle,
+                  {
+                    color: themeColors.text.primary,
+                    fontSize: getFontSize("xl"),
+                  },
+                ]}
+              >
+                {getLocalizedText("security.scanQRCode")}
+              </Text>
+              <TouchableOpacity
+                onPress={() => setShowQRModal(false)}
+                style={[
+                  styles.modalCloseButton,
+                  { backgroundColor: themeColors.background.secondary },
+                ]}
+                activeOpacity={0.7}
+              >
+                <Ionicons
+                  name="close"
+                  size={20}
+                  color={themeColors.text.primary}
+                />
+              </TouchableOpacity>
+            </View>
+
+            <Text
+              style={[
+                styles.modalSubtitle,
+                {
+                  color: themeColors.text.secondary,
+                  fontSize: getFontSize("sm"),
+                },
+              ]}
+            >
+              {getLocalizedText("security.qrInstructions") ||
+                "Scannez ce code avec l'appareil à connecter"}
+            </Text>
+
+            <View style={styles.qrContainer}>
+              {qrLoading ? (
+                <ActivityIndicator size="large" color={accentColor} />
+              ) : qrChallenge ? (
+                <QRCodeStyled
+                  data={qrChallenge}
+                  style={{ backgroundColor: "#FFFFFF" }}
+                  padding={12}
+                  width={200}
+                />
+              ) : (
+                <View style={styles.qrExpiredContainer}>
+                  <Ionicons
+                    name="time-outline"
+                    size={48}
+                    color={themeColors.text.tertiary}
+                  />
+                  <Text
+                    style={[
+                      styles.qrExpiredText,
+                      {
+                        color: themeColors.text.secondary,
+                        fontSize: getFontSize("sm"),
+                      },
+                    ]}
+                  >
+                    {getLocalizedText("security.qrExpired") || "QR code expiré"}
+                  </Text>
+                </View>
+              )}
+            </View>
+
+            {qrChallenge && !qrLoading && (
+              <Text
+                style={[
+                  styles.qrCountdownText,
+                  {
+                    color: themeColors.text.secondary,
+                    fontSize: getFontSize("sm"),
+                  },
+                ]}
+              >
+                {getLocalizedText("security.qrExpiresIn") || "Expire dans"}{" "}
+                {formatCountdown(qrCountdown)}
+              </Text>
+            )}
+
+            <TouchableOpacity
+              onPress={handleRefreshQR}
+              disabled={qrLoading}
+              activeOpacity={0.8}
+              style={[
+                styles.qrRefreshButton,
+                {
+                  backgroundColor: accentColor + "15",
+                  borderColor: accentColor + "40",
+                  opacity: qrLoading ? 0.5 : 1,
+                },
+              ]}
+            >
+              <Ionicons name="refresh" size={18} color={accentColor} />
+              <Text
+                style={[
+                  styles.qrRefreshText,
+                  { color: accentColor, fontSize: getFontSize("base") },
+                ]}
+              >
+                {getLocalizedText("security.qrRefresh") || "Actualiser"}
+              </Text>
             </TouchableOpacity>
           </Animated.View>
         </Animated.View>
@@ -1583,6 +1819,40 @@ const styles = StyleSheet.create({
   },
   hideKeysButtonText: {
     fontWeight: "500",
+    letterSpacing: 0.2,
+  },
+  qrContainer: {
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: 224,
+    paddingVertical: 16,
+  },
+  qrExpiredContainer: {
+    alignItems: "center",
+    gap: 12,
+  },
+  qrExpiredText: {
+    fontWeight: "500",
+    textAlign: "center",
+  },
+  qrCountdownText: {
+    textAlign: "center",
+    fontWeight: "500",
+    marginBottom: 20,
+  },
+  qrRefreshButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 14,
+    paddingHorizontal: 20,
+    borderRadius: 12,
+    borderWidth: 1,
+    gap: 8,
+    marginTop: 8,
+  },
+  qrRefreshText: {
+    fontWeight: "600",
     letterSpacing: 0.2,
   },
 });

--- a/src/screens/Security/SecurityKeysScreen.tsx
+++ b/src/screens/Security/SecurityKeysScreen.tsx
@@ -35,6 +35,12 @@ import {
 
 const { width: SCREEN_WIDTH } = Dimensions.get("window");
 
+const formatCountdown = (seconds: number): string => {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, "0")}`;
+};
+
 interface ConnectedDevice {
   id: string;
   name: string;
@@ -54,6 +60,310 @@ interface SecurityKey {
   verified: boolean;
 }
 
+// Module-level cache — survives re-renders and component remounts
+const _qrCache: {
+  challenge: string | null;
+  deviceId: string;
+  generatedAt: number;
+  inFlight: Promise<string> | null;
+} = { challenge: null, deviceId: "", generatedAt: 0, inFlight: null };
+
+const QRCodeModal: React.FC<{
+  visible: boolean;
+  onClose: () => void;
+  deviceId: string;
+  themeColors: ReturnType<ReturnType<typeof useTheme>["getThemeColors"]>;
+  accentColor: string;
+  getFontSize: ReturnType<typeof useTheme>["getFontSize"];
+  getLocalizedText: ReturnType<typeof useTheme>["getLocalizedText"];
+}> = ({
+  visible,
+  onClose,
+  deviceId,
+  themeColors,
+  accentColor,
+  getFontSize,
+  getLocalizedText,
+}) => {
+  const qrModalScale = useRef(new Animated.Value(0.9)).current;
+  const qrModalOpacity = useRef(new Animated.Value(0)).current;
+  const [qrChallenge, setQrChallenge] = useState<string | null>(null);
+  const [qrLoading, setQrLoading] = useState(false);
+  const [qrCountdown, setQrCountdown] = useState(300);
+
+  const fetchChallenge = useCallback(
+    async (force = false) => {
+      if (!deviceId) return;
+      const now = Date.now();
+
+      // Cache hit — serve immediately without any loading state
+      if (!force && _qrCache.deviceId === deviceId && _qrCache.challenge) {
+        const age = now - _qrCache.generatedAt;
+        if (age < 270_000) {
+          setQrChallenge(_qrCache.challenge);
+          setQrCountdown(Math.max(1, 300 - Math.floor(age / 1000)));
+          setQrLoading(false);
+          return;
+        }
+      }
+
+      // Join in-flight request for the same device instead of firing a duplicate
+      if (!force && _qrCache.inFlight && _qrCache.deviceId === deviceId) {
+        setQrLoading(true);
+        try {
+          const challenge = await _qrCache.inFlight;
+          const age = Date.now() - _qrCache.generatedAt;
+          setQrChallenge(challenge);
+          setQrCountdown(Math.max(1, 300 - Math.floor(age / 1000)));
+        } finally {
+          setQrLoading(false);
+        }
+        return;
+      }
+
+      // Fresh fetch (either forced refresh or no usable cache)
+      _qrCache.deviceId = deviceId;
+      if (force) {
+        _qrCache.challenge = null;
+        setQrChallenge(null);
+      }
+      setQrLoading(true);
+      setQrCountdown(300);
+
+      const promise = DeviceManagerService.generateQRChallenge(deviceId);
+      _qrCache.inFlight = promise;
+      try {
+        const challenge = await promise;
+        _qrCache.challenge = challenge;
+        _qrCache.generatedAt = Date.now();
+        _qrCache.inFlight = null;
+        setQrChallenge(challenge);
+        setQrCountdown(300);
+      } catch (err) {
+        _qrCache.inFlight = null;
+        throw err;
+      } finally {
+        setQrLoading(false);
+      }
+    },
+    [deviceId],
+  );
+
+  // Pre-fetch as soon as deviceId is available (modal is always mounted)
+  useEffect(() => {
+    if (deviceId) {
+      fetchChallenge().catch(() => {});
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deviceId]);
+
+  useEffect(() => {
+    if (visible) {
+      Animated.parallel([
+        Animated.spring(qrModalScale, {
+          toValue: 1,
+          tension: 50,
+          friction: 7,
+          useNativeDriver: true,
+        }),
+        Animated.timing(qrModalOpacity, {
+          toValue: 1,
+          duration: 300,
+          useNativeDriver: true,
+        }),
+      ]).start();
+      // Re-fetch only if cache is stale and nothing is already in-flight
+      const isFresh =
+        _qrCache.deviceId === deviceId &&
+        !!_qrCache.challenge &&
+        Date.now() - _qrCache.generatedAt < 270_000;
+      if (!isFresh && !_qrCache.inFlight) {
+        fetchChallenge().catch(() => {});
+      } else if (isFresh) {
+        // Sync countdown with remaining cache age
+        const elapsed = Math.floor((Date.now() - _qrCache.generatedAt) / 1000);
+        setQrCountdown(Math.max(1, 300 - elapsed));
+      }
+    } else {
+      Animated.parallel([
+        Animated.timing(qrModalScale, {
+          toValue: 0.9,
+          duration: 200,
+          useNativeDriver: true,
+        }),
+        Animated.timing(qrModalOpacity, {
+          toValue: 0,
+          duration: 200,
+          useNativeDriver: true,
+        }),
+      ]).start();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible]);
+
+  useEffect(() => {
+    if (!visible || !qrChallenge) return;
+    const id = setInterval(() => {
+      setQrCountdown((prev) => (prev <= 1 ? 0 : prev - 1));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [visible, qrChallenge]);
+
+  useEffect(() => {
+    if (qrCountdown === 0 && visible) setQrChallenge(null);
+  }, [qrCountdown, visible]);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="none"
+      onRequestClose={onClose}
+    >
+      <View style={styles.modalOverlay}>
+        <Animated.View
+          style={[styles.modalBackdrop, { opacity: qrModalOpacity }]}
+        >
+          <TouchableOpacity
+            style={StyleSheet.absoluteFillObject}
+            activeOpacity={1}
+            onPress={onClose}
+          />
+        </Animated.View>
+        <Animated.View
+          style={[
+            styles.modalContent,
+            {
+              backgroundColor: themeColors.background.primary,
+              opacity: qrModalOpacity,
+              transform: [{ scale: qrModalScale }],
+              ...Platform.select({
+                ios: {
+                  shadowColor: "#000",
+                  shadowOffset: { width: 0, height: -4 },
+                  shadowOpacity: 0.3,
+                  shadowRadius: 20,
+                },
+                android: { elevation: 24 },
+              }),
+            },
+          ]}
+        >
+          <View style={styles.modalHeader}>
+            <Text
+              style={[
+                styles.modalTitle,
+                {
+                  color: themeColors.text.primary,
+                  fontSize: getFontSize("xl"),
+                },
+              ]}
+            >
+              {getLocalizedText("security.scanQRCode")}
+            </Text>
+            <TouchableOpacity
+              onPress={onClose}
+              style={[
+                styles.modalCloseButton,
+                { backgroundColor: themeColors.background.secondary },
+              ]}
+              activeOpacity={0.7}
+            >
+              <Ionicons
+                name="close"
+                size={20}
+                color={themeColors.text.primary}
+              />
+            </TouchableOpacity>
+          </View>
+          <Text
+            style={[
+              styles.modalSubtitle,
+              {
+                color: themeColors.text.secondary,
+                fontSize: getFontSize("sm"),
+              },
+            ]}
+          >
+            {getLocalizedText("security.qrInstructions") ||
+              "Scannez ce code avec l'appareil à connecter"}
+          </Text>
+          <View style={styles.qrContainer}>
+            {qrLoading ? (
+              <ActivityIndicator size="large" color={accentColor} />
+            ) : qrChallenge ? (
+              <QRCodeStyled
+                data={qrChallenge}
+                style={{ backgroundColor: "#FFFFFF" }}
+                padding={12}
+                width={200}
+              />
+            ) : (
+              <View style={styles.qrExpiredContainer}>
+                <Ionicons
+                  name="time-outline"
+                  size={48}
+                  color={themeColors.text.tertiary}
+                />
+                <Text
+                  style={[
+                    styles.qrExpiredText,
+                    {
+                      color: themeColors.text.secondary,
+                      fontSize: getFontSize("sm"),
+                    },
+                  ]}
+                >
+                  {getLocalizedText("security.qrExpired") || "QR code expiré"}
+                </Text>
+              </View>
+            )}
+          </View>
+          {qrChallenge && !qrLoading && (
+            <Text
+              style={[
+                styles.qrCountdownText,
+                {
+                  color: themeColors.text.secondary,
+                  fontSize: getFontSize("sm"),
+                },
+              ]}
+            >
+              {getLocalizedText("security.qrExpiresIn") || "Expire dans"}{" "}
+              {formatCountdown(qrCountdown)}
+            </Text>
+          )}
+          <TouchableOpacity
+            onPress={() => {
+              void fetchChallenge(true);
+            }}
+            disabled={qrLoading}
+            activeOpacity={0.8}
+            style={[
+              styles.qrRefreshButton,
+              {
+                backgroundColor: accentColor + "15",
+                borderColor: accentColor + "40",
+                opacity: qrLoading ? 0.5 : 1,
+              },
+            ]}
+          >
+            <Ionicons name="refresh" size={18} color={accentColor} />
+            <Text
+              style={[
+                styles.qrRefreshText,
+                { color: accentColor, fontSize: getFontSize("base") },
+              ]}
+            >
+              {getLocalizedText("security.qrRefresh") || "Actualiser"}
+            </Text>
+          </TouchableOpacity>
+        </Animated.View>
+      </View>
+    </Modal>
+  );
+};
+
 export const SecurityKeysScreen: React.FC = () => {
   const navigation = useNavigation();
   const { getThemeColors, getFontSize, getLocalizedText } = useTheme();
@@ -66,9 +376,6 @@ export const SecurityKeysScreen: React.FC = () => {
   const slideAnim = useRef(new Animated.Value(30)).current;
   const modalScale = useRef(new Animated.Value(0.9)).current;
   const modalOpacity = useRef(new Animated.Value(0)).current;
-  const qrModalScale = useRef(new Animated.Value(0.9)).current;
-  const qrModalOpacity = useRef(new Animated.Value(0)).current;
-
   const [devices, setDevices] = useState<ConnectedDevice[]>([]);
   const [loadingDevices, setLoadingDevices] = useState(true);
 
@@ -81,9 +388,6 @@ export const SecurityKeysScreen: React.FC = () => {
   const [verificationCode, setVerificationCode] = useState("");
   const [showSecurityKeys, setShowSecurityKeys] = useState(false);
   const [showQRModal, setShowQRModal] = useState(false);
-  const [qrChallenge, setQrChallenge] = useState<string | null>(null);
-  const [qrLoading, setQrLoading] = useState(false);
-  const [qrCountdown, setQrCountdown] = useState(300);
   const [toast, setToast] = useState<{
     visible: boolean;
     message: string;
@@ -102,12 +406,6 @@ export const SecurityKeysScreen: React.FC = () => {
     if (p === "desktop" || p === "macos" || p === "windows" || p === "linux")
       return "desktop";
     return "mobile";
-  };
-
-  const formatCountdown = (seconds: number): string => {
-    const m = Math.floor(seconds / 60);
-    const s = seconds % 60;
-    return `${m}:${s.toString().padStart(2, "0")}`;
   };
 
   const formatLastActive = (isoString: string): string => {
@@ -198,49 +496,6 @@ export const SecurityKeysScreen: React.FC = () => {
       ]).start();
     }
   }, [showSecurityCodeModal]);
-
-  useEffect(() => {
-    if (showQRModal) {
-      Animated.parallel([
-        Animated.spring(qrModalScale, {
-          toValue: 1,
-          tension: 50,
-          friction: 7,
-          useNativeDriver: true,
-        }),
-        Animated.timing(qrModalOpacity, {
-          toValue: 1,
-          duration: 300,
-          useNativeDriver: true,
-        }),
-      ]).start();
-    } else {
-      Animated.parallel([
-        Animated.timing(qrModalScale, {
-          toValue: 0.9,
-          duration: 200,
-          useNativeDriver: true,
-        }),
-        Animated.timing(qrModalOpacity, {
-          toValue: 0,
-          duration: 200,
-          useNativeDriver: true,
-        }),
-      ]).start();
-    }
-  }, [showQRModal]);
-
-  useEffect(() => {
-    if (!showQRModal || !qrChallenge) return;
-    const id = setInterval(() => {
-      setQrCountdown((prev) => (prev <= 1 ? 0 : prev - 1));
-    }, 1000);
-    return () => clearInterval(id);
-  }, [showQRModal, qrChallenge]);
-
-  useEffect(() => {
-    if (qrCountdown === 0 && showQRModal) setQrChallenge(null);
-  }, [qrCountdown, showQRModal]);
 
   const triggerHaptic = (type: "light" | "medium" | "heavy" = "light") => {
     if (Platform.OS === "ios") {
@@ -337,73 +592,10 @@ export const SecurityKeysScreen: React.FC = () => {
     }
   };
 
-  const fetchQRChallenge = useCallback(async (): Promise<void> => {
-    if (!currentDeviceId) {
-      console.warn("[QR] fetchQRChallenge: no currentDeviceId");
-      return;
-    }
-    console.log("[QR] Generating challenge for deviceId:", currentDeviceId);
-    setQrLoading(true);
-    setQrChallenge(null);
-    setQrCountdown(300);
-    try {
-      const challenge =
-        await DeviceManagerService.generateQRChallenge(currentDeviceId);
-      console.log(
-        "[QR] Challenge set, length:",
-        typeof challenge === "string" ? challenge.length : typeof challenge,
-      );
-      setQrChallenge(challenge);
-    } finally {
-      setQrLoading(false);
-    }
-  }, [currentDeviceId]);
-
-  const handleShowQRCode = useCallback(async () => {
+  const handleShowQRCode = useCallback(() => {
     triggerHaptic("light");
     setShowQRModal(true);
-    try {
-      await fetchQRChallenge();
-    } catch (err: unknown) {
-      const e = err as { status?: number; message?: string; body?: unknown };
-      console.error(
-        "[QR] handleShowQRCode error — status:",
-        e?.status,
-        "message:",
-        e?.message,
-        "body:",
-        JSON.stringify(e?.body),
-      );
-      showToast(
-        getLocalizedText("security.qrGenerateError") ||
-          "Impossible de générer le QR code",
-        "error",
-      );
-      setShowQRModal(false);
-    }
-  }, [fetchQRChallenge]);
-
-  const handleRefreshQR = useCallback(async () => {
-    triggerHaptic("light");
-    try {
-      await fetchQRChallenge();
-    } catch (err: unknown) {
-      const e = err as { status?: number; message?: string; body?: unknown };
-      console.error(
-        "[QR] handleRefreshQR error — status:",
-        e?.status,
-        "message:",
-        e?.message,
-        "body:",
-        JSON.stringify(e?.body),
-      );
-      showToast(
-        getLocalizedText("security.qrGenerateError") ||
-          "Impossible de générer le QR code",
-        "error",
-      );
-    }
-  }, [fetchQRChallenge]);
+  }, []);
 
   const getDeviceIcon = (type: string): { name: any; color: string } => {
     const iconColor = accentColor;
@@ -1315,151 +1507,15 @@ export const SecurityKeysScreen: React.FC = () => {
         </Animated.View>
       </Modal>
 
-      <Modal
+      <QRCodeModal
         visible={showQRModal}
-        transparent
-        animationType="none"
-        onRequestClose={() => setShowQRModal(false)}
-      >
-        <View style={styles.modalOverlay}>
-          <TouchableOpacity
-            style={styles.modalBackdrop}
-            activeOpacity={1}
-            onPress={() => setShowQRModal(false)}
-          />
-          <Animated.View
-            style={[
-              styles.modalContent,
-              {
-                backgroundColor: themeColors.background.primary,
-                opacity: qrModalOpacity,
-                transform: [{ scale: qrModalScale }],
-                ...Platform.select({
-                  ios: {
-                    shadowColor: "#000",
-                    shadowOffset: { width: 0, height: -4 },
-                    shadowOpacity: 0.3,
-                    shadowRadius: 20,
-                  },
-                  android: { elevation: 24 },
-                }),
-              },
-            ]}
-          >
-            <View style={styles.modalHeader}>
-              <Text
-                style={[
-                  styles.modalTitle,
-                  {
-                    color: themeColors.text.primary,
-                    fontSize: getFontSize("xl"),
-                  },
-                ]}
-              >
-                {getLocalizedText("security.scanQRCode")}
-              </Text>
-              <TouchableOpacity
-                onPress={() => setShowQRModal(false)}
-                style={[
-                  styles.modalCloseButton,
-                  { backgroundColor: themeColors.background.secondary },
-                ]}
-                activeOpacity={0.7}
-              >
-                <Ionicons
-                  name="close"
-                  size={20}
-                  color={themeColors.text.primary}
-                />
-              </TouchableOpacity>
-            </View>
-
-            <Text
-              style={[
-                styles.modalSubtitle,
-                {
-                  color: themeColors.text.secondary,
-                  fontSize: getFontSize("sm"),
-                },
-              ]}
-            >
-              {getLocalizedText("security.qrInstructions") ||
-                "Scannez ce code avec l'appareil à connecter"}
-            </Text>
-
-            <View style={styles.qrContainer}>
-              {qrLoading ? (
-                <ActivityIndicator size="large" color={accentColor} />
-              ) : qrChallenge ? (
-                <QRCodeStyled
-                  data={qrChallenge}
-                  style={{ backgroundColor: "#FFFFFF" }}
-                  padding={12}
-                  width={200}
-                />
-              ) : (
-                <View style={styles.qrExpiredContainer}>
-                  <Ionicons
-                    name="time-outline"
-                    size={48}
-                    color={themeColors.text.tertiary}
-                  />
-                  <Text
-                    style={[
-                      styles.qrExpiredText,
-                      {
-                        color: themeColors.text.secondary,
-                        fontSize: getFontSize("sm"),
-                      },
-                    ]}
-                  >
-                    {getLocalizedText("security.qrExpired") || "QR code expiré"}
-                  </Text>
-                </View>
-              )}
-            </View>
-
-            {qrChallenge && !qrLoading && (
-              <Text
-                style={[
-                  styles.qrCountdownText,
-                  {
-                    color: themeColors.text.secondary,
-                    fontSize: getFontSize("sm"),
-                  },
-                ]}
-              >
-                {getLocalizedText("security.qrExpiresIn") || "Expire dans"}{" "}
-                {formatCountdown(qrCountdown)}
-              </Text>
-            )}
-
-            <TouchableOpacity
-              onPress={handleRefreshQR}
-              disabled={qrLoading}
-              activeOpacity={0.8}
-              style={[
-                styles.qrRefreshButton,
-                {
-                  backgroundColor: accentColor + "15",
-                  borderColor: accentColor + "40",
-                  opacity: qrLoading ? 0.5 : 1,
-                },
-              ]}
-            >
-              <Ionicons name="refresh" size={18} color={accentColor} />
-              <Text
-                style={[
-                  styles.qrRefreshText,
-                  { color: accentColor, fontSize: getFontSize("base") },
-                ]}
-              >
-                {getLocalizedText("security.qrRefresh") || "Actualiser"}
-              </Text>
-            </TouchableOpacity>
-          </Animated.View>
-        </View>
-      </Modal>
+        onClose={() => setShowQRModal(false)}
+        deviceId={currentDeviceId ?? ""}
+        themeColors={themeColors}
+        accentColor={accentColor}
+        getFontSize={getFontSize}
+        getLocalizedText={getLocalizedText}
+      />
 
       <Toast
         visible={toast.visible}

--- a/src/screens/Security/SecurityKeysScreen.tsx
+++ b/src/screens/Security/SecurityKeysScreen.tsx
@@ -1321,9 +1321,7 @@ export const SecurityKeysScreen: React.FC = () => {
         animationType="none"
         onRequestClose={() => setShowQRModal(false)}
       >
-        <Animated.View
-          style={[styles.modalOverlay, { opacity: qrModalOpacity }]}
-        >
+        <View style={styles.modalOverlay}>
           <TouchableOpacity
             style={styles.modalBackdrop}
             activeOpacity={1}
@@ -1334,6 +1332,7 @@ export const SecurityKeysScreen: React.FC = () => {
               styles.modalContent,
               {
                 backgroundColor: themeColors.background.primary,
+                opacity: qrModalOpacity,
                 transform: [{ scale: qrModalScale }],
                 ...Platform.select({
                   ios: {
@@ -1459,7 +1458,7 @@ export const SecurityKeysScreen: React.FC = () => {
               </Text>
             </TouchableOpacity>
           </Animated.View>
-        </Animated.View>
+        </View>
       </Modal>
 
       <Toast

--- a/src/screens/Security/__tests__/SecurityKeysScreen.test.tsx
+++ b/src/screens/Security/__tests__/SecurityKeysScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, waitFor } from "@testing-library/react-native";
+import { render, fireEvent, waitFor, act } from "@testing-library/react-native";
 import { SecurityKeysScreen } from "../SecurityKeysScreen";
 
 const mockGoBack = jest.fn();
@@ -37,18 +37,63 @@ jest.mock("../../../components/Toast/Toast", () => () => null);
 jest.mock("../../../utils/clipboard", () => ({
   copyToClipboard: jest.fn(),
 }));
+jest.mock("react-native-qrcode-styled", () => () => null);
+
+const mockListDevices = jest.fn();
+const mockRevokeDevice = jest.fn();
+const mockGenerateQRChallenge = jest.fn();
+jest.mock("../../../services/SecurityService", () => ({
+  DeviceManagerService: {
+    listDevices: (...a: unknown[]) => mockListDevices(...a),
+    revokeDevice: (...a: unknown[]) => mockRevokeDevice(...a),
+    generateQRChallenge: (...a: unknown[]) => mockGenerateQRChallenge(...a),
+  },
+}));
 
 describe("SecurityKeysScreen", () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockListDevices.mockResolvedValue([]);
+    mockGenerateQRChallenge.mockResolvedValue("jwt-challenge-token");
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
 
   it("renders without crashing", () => {
     const { toJSON } = render(<SecurityKeysScreen />);
     expect(toJSON()).toBeTruthy();
   });
 
-  it("renders security keys title", () => {
+  it("fetches device list on mount", async () => {
+    render(<SecurityKeysScreen />);
+    await waitFor(() => expect(mockListDevices).toHaveBeenCalled());
+  });
+
+  it("renders devices returned by the API", async () => {
+    mockListDevices.mockResolvedValue([
+      {
+        id: "test-device-id",
+        deviceName: "Mon iPhone",
+        deviceType: "ios",
+        lastActive: new Date().toISOString(),
+        isVerified: true,
+        isActive: true,
+      },
+    ]);
+    const { findByText } = render(<SecurityKeysScreen />);
+    expect(await findByText("Mon iPhone")).toBeTruthy();
+  });
+
+  it("opens QR modal and calls generateQRChallenge when QR button pressed", async () => {
     const { getByText } = render(<SecurityKeysScreen />);
-    // The screen renders some title text
-    expect(getByText).toBeTruthy();
+    await waitFor(() => expect(mockListDevices).toHaveBeenCalled());
+
+    const qrButton = getByText("security.scanQRCode");
+    await act(async () => {
+      fireEvent.press(qrButton);
+    });
+
+    await waitFor(() =>
+      expect(mockGenerateQRChallenge).toHaveBeenCalledWith("test-device-id"),
+    );
   });
 });

--- a/src/screens/Security/__tests__/SecurityKeysScreen.test.tsx
+++ b/src/screens/Security/__tests__/SecurityKeysScreen.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, fireEvent, waitFor, act } from "@testing-library/react-native";
-import { SecurityKeysScreen } from "../SecurityKeysScreen";
+import { SecurityKeysScreen, _qrCache } from "../SecurityKeysScreen";
 
 const mockGoBack = jest.fn();
 jest.mock("@react-navigation/native", () => ({
@@ -56,6 +56,11 @@ describe("SecurityKeysScreen", () => {
     mockListDevices.mockResolvedValue([]);
     mockGenerateQRChallenge.mockResolvedValue("jwt-challenge-token");
     jest.spyOn(console, "warn").mockImplementation(() => {});
+    // Reset module-level cache so each test starts fresh
+    _qrCache.challenge = null;
+    _qrCache.deviceId = "";
+    _qrCache.generatedAt = 0;
+    _qrCache.inFlight = null;
   });
 
   it("renders without crashing", () => {
@@ -83,17 +88,21 @@ describe("SecurityKeysScreen", () => {
     expect(await findByText("Mon iPhone")).toBeTruthy();
   });
 
-  it("opens QR modal and calls generateQRChallenge when QR button pressed", async () => {
+  it("pre-fetches QR challenge on mount and opens modal on button press", async () => {
     const { getByText } = render(<SecurityKeysScreen />);
     await waitFor(() => expect(mockListDevices).toHaveBeenCalled());
+
+    // generateQRChallenge is called immediately on mount (pre-fetch), not on button press
+    await waitFor(() =>
+      expect(mockGenerateQRChallenge).toHaveBeenCalledWith("test-device-id"),
+    );
 
     const qrButton = getByText("security.scanQRCode");
     await act(async () => {
       fireEvent.press(qrButton);
     });
 
-    await waitFor(() =>
-      expect(mockGenerateQRChallenge).toHaveBeenCalledWith("test-device-id"),
-    );
+    // Cache is fresh — no additional API call on button press
+    expect(mockGenerateQRChallenge).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/SecurityService.ts
+++ b/src/services/SecurityService.ts
@@ -195,6 +195,13 @@ export const DeviceManagerService = {
     });
     return { accessToken: raw.access_token, refreshToken: raw.refresh_token };
   },
+
+  async generateQRChallenge(deviceId: string): Promise<string> {
+    return apiFetch<string>(
+      `/qr-code/challenge/${encodeURIComponent(deviceId)}`,
+      { method: "POST" },
+    );
+  },
 };
 
 // ─── Signal Protocol keys ────────────────────────────────────────────────────

--- a/src/services/SecurityService.ts
+++ b/src/services/SecurityService.ts
@@ -2,6 +2,7 @@ import { AuthService } from "./AuthService";
 import { TokenService } from "./TokenService";
 import { DeviceService } from "./DeviceService";
 import { getApiBaseUrl } from "./apiBase";
+import type { TokenPair } from "../types/auth";
 
 type ApiError = Error & { status?: number; body?: unknown };
 
@@ -157,6 +158,42 @@ export const DeviceManagerService = {
     await apiFetch<void>(`/device/${encodeURIComponent(deviceId)}`, {
       method: "DELETE",
     });
+  },
+
+  /**
+   * POST /auth/qr-code/scan
+   * Exchange a QR challenge JWT (scanned from an authenticated device) for tokens.
+   * Called from an unauthenticated device — no access token required.
+   */
+  async scanQRChallenge(challenge: string): Promise<TokenPair> {
+    let authenticatedDeviceId = "";
+    const parts = challenge.split(".");
+    if (parts.length === 3) {
+      try {
+        const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+        const padded = base64 + "==".slice(0, (4 - (base64.length % 4)) % 4);
+        const payload = JSON.parse(atob(padded)) as {
+          deviceId?: string;
+          sub?: string;
+        };
+        authenticatedDeviceId = payload.deviceId ?? payload.sub ?? "";
+      } catch {}
+    }
+
+    const { deviceName, deviceType } = await DeviceService.getDeviceInfo();
+    const raw = await apiFetch<{
+      access_token: string;
+      refresh_token: string;
+    }>("/qr-code/scan", {
+      method: "POST",
+      body: JSON.stringify({
+        challenge,
+        authenticatedDeviceId,
+        deviceName,
+        deviceType,
+      }),
+    });
+    return { accessToken: raw.access_token, refreshToken: raw.refresh_token };
   },
 };
 

--- a/src/services/SecurityService.ts
+++ b/src/services/SecurityService.ts
@@ -197,10 +197,43 @@ export const DeviceManagerService = {
   },
 
   async generateQRChallenge(deviceId: string): Promise<string> {
-    return apiFetch<string>(
-      `/qr-code/challenge/${encodeURIComponent(deviceId)}`,
-      { method: "POST" },
+    const token = await TokenService.getAccessToken();
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Accept: "text/plain, application/json",
+      "x-device-type": "mobile",
+    };
+    if (token) headers["Authorization"] = `Bearer ${token}`;
+
+    const response = await fetch(
+      `${getAuthBaseUrl()}/qr-code/challenge/${encodeURIComponent(deviceId)}`,
+      { method: "POST", headers },
     );
+
+    if (!response.ok) {
+      const body = await response.json().catch(() => ({}));
+      const err = new Error(
+        (body as { message?: string })?.message ?? `HTTP ${response.status}`,
+      ) as ApiError;
+      err.status = response.status;
+      err.body = body;
+      console.error("[QR] generateQRChallenge failed:", response.status, body);
+      throw err;
+    }
+
+    const text = await response.text();
+    console.log(
+      "[QR] challenge received, length:",
+      text.length,
+      "starts:",
+      text.slice(0, 30),
+    );
+    // NestJS sends string primitives as plain text — handle both formats
+    try {
+      return JSON.parse(text) as string;
+    } catch {
+      return text;
+    }
   },
 };
 

--- a/src/services/SecurityService.ts
+++ b/src/services/SecurityService.ts
@@ -177,13 +177,17 @@ export const DeviceManagerService = {
           sub?: string;
         };
         authenticatedDeviceId = payload.deviceId ?? payload.sub ?? "";
-      } catch {}
+      } catch {
+        // malformed JWT payload — proceed without authenticatedDeviceId
+      }
     }
 
     const { deviceName, deviceType } = await DeviceService.getDeviceInfo();
     const raw = await apiFetch<{
-      access_token: string;
-      refresh_token: string;
+      access_token?: string;
+      refresh_token?: string;
+      accessToken?: string;
+      refreshToken?: string;
     }>("/qr-code/scan", {
       method: "POST",
       body: JSON.stringify({
@@ -193,7 +197,10 @@ export const DeviceManagerService = {
         deviceType,
       }),
     });
-    return { accessToken: raw.access_token, refreshToken: raw.refresh_token };
+    return {
+      accessToken: raw.access_token ?? raw.accessToken ?? "",
+      refreshToken: raw.refresh_token ?? raw.refreshToken ?? "",
+    };
   },
 
   async generateQRChallenge(deviceId: string): Promise<string> {
@@ -217,17 +224,10 @@ export const DeviceManagerService = {
       ) as ApiError;
       err.status = response.status;
       err.body = body;
-      console.error("[QR] generateQRChallenge failed:", response.status, body);
       throw err;
     }
 
     const text = await response.text();
-    console.log(
-      "[QR] challenge received, length:",
-      text.length,
-      "starts:",
-      text.slice(0, 30),
-    );
     // NestJS sends string primitives as plain text — handle both formats
     try {
       return JSON.parse(text) as string;


### PR DESCRIPTION
## Summary
- Add QR code login flow: Phone A generates a challenge QR, Phone B scans it via `DevicePairingScannerScreen`
- Fix token format mismatch: backend returns camelCase (`accessToken`/`refreshToken`), now supported with snake_case fallback
- Extract `QRCodeModal` as isolated component so countdown timer doesn't re-render the device list behind it
- Add module-level `_qrCache` so QR challenge pre-fetched on screen mount is served instantly on first modal open — no spinner on first click
- Remove all debug `console.log` / `console.error` calls added during development

## Test plan
- [ ] Unit tests green
- [ ] Lint clean
- [ ] Open SecurityKeysScreen → click "Scan QR Code" → QR appears immediately (no spinner on first click)
- [ ] Device list behind modal stays fixed while modal is open
- [ ] QR countdown ticks correctly from remaining time when re-opening modal
- [ ] "Actualiser" button forces fresh challenge
- [ ] Phone B scan redirects to ConversationsList after successful auth
- [ ] Tested on iOS simulator
- [ ] Tested on Android emulator

Closes WHISPR-134