### PR TITLE
refactor(groups): retire onglets Statistiques et Historique (mort UI)

### DIFF
--- a/src/screens/Groups/GroupDetailsScreen.tsx
+++ b/src/screens/Groups/GroupDetailsScreen.tsx
@@ -54,8 +54,6 @@ import {
   groupsAPI,
   GroupDetails,
   GroupMember,
-  GroupStats,
-  GroupLog,
   GroupSettings,
 } from "../../services/groups/api";
 import { messagingAPI } from "../../services/messaging/api";
@@ -125,13 +123,11 @@ export const GroupDetailsScreen: React.FC = () => {
 
   const [groupDetails, setGroupDetails] = useState<GroupDetails | null>(null);
   const [members, setMembers] = useState<GroupMember[]>([]);
-  const [stats, setStats] = useState<GroupStats | null>(null);
-  const [logs, setLogs] = useState<GroupLog[]>([]);
   const [settings, setSettings] = useState<GroupSettings | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [activeTab, setActiveTab] = useState<
-    "info" | "members" | "stats" | "history" | "settings"
+    "info" | "members" | "settings"
   >("info");
   const [showLeaveModal, setShowLeaveModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -175,16 +171,12 @@ export const GroupDetailsScreen: React.FC = () => {
         groupsAPI.getGroupMembers(groupId, {
           conversationId: conversationKey,
         }),
-        groupsAPI.getGroupStats(groupId, {
-          conversationId: conversationKey,
-        }),
-        groupsAPI.getGroupLogs(groupId),
         groupsAPI.getGroupSettings(groupId, {
           conversationId: conversationKey,
         }),
       ]);
 
-      const [detailsR, membersR, statsR, logsR, settingsR] = results;
+      const [detailsR, membersR, settingsR] = results;
 
       if (detailsR.status === "fulfilled") {
         setGroupDetails(detailsR.value);
@@ -219,22 +211,6 @@ export const GroupDetailsScreen: React.FC = () => {
           "getGroupMembers failed",
           membersR.reason,
         );
-      }
-
-      if (statsR.status === "fulfilled") {
-        setStats(statsR.value);
-      } else {
-        logger.warn(
-          "GroupDetailsScreen",
-          "getGroupStats failed",
-          statsR.reason,
-        );
-      }
-
-      if (logsR.status === "fulfilled") {
-        setLogs(logsR.value.logs);
-      } else {
-        logger.warn("GroupDetailsScreen", "getGroupLogs failed", logsR.reason);
       }
 
       if (settingsR.status === "fulfilled") {
@@ -845,16 +821,6 @@ export const GroupDetailsScreen: React.FC = () => {
             },
             { key: "members", label: "Membres", icon: "people-outline" },
             {
-              key: "stats",
-              label: "Statistiques",
-              icon: "stats-chart-outline",
-            },
-            {
-              key: "history",
-              label: "Historique",
-              icon: "time-outline",
-            },
-            {
               key: "settings",
               label: "Paramètres",
               icon: "settings-outline",
@@ -940,56 +906,6 @@ export const GroupDetailsScreen: React.FC = () => {
                   year: "numeric",
                 })
               : "-"}
-          </Text>
-        </View>
-        <View
-          style={[
-            styles.infoRow,
-            { borderBottomColor: withOpacity(colors.ui.divider, 0.3) },
-          ]}
-        >
-          <View style={styles.infoRowLeft}>
-            <Ionicons
-              name="time-outline"
-              size={20}
-              color={withOpacity(colors.text.light, 0.7)}
-            />
-            <Text
-              style={[
-                styles.infoLabel,
-                { color: withOpacity(colors.text.light, 0.7) },
-              ]}
-            >
-              Dernière activité
-            </Text>
-          </View>
-          <Text style={[styles.infoValue, { color: colors.text.light }]}>
-            {stats?.lastActivity
-              ? new Date(stats.lastActivity).toLocaleDateString("fr-FR", {
-                  day: "numeric",
-                  month: "short",
-                })
-              : "-"}
-          </Text>
-        </View>
-        <View style={styles.infoRow}>
-          <View style={styles.infoRowLeft}>
-            <Ionicons
-              name="chatbubbles-outline"
-              size={20}
-              color={withOpacity(colors.text.light, 0.7)}
-            />
-            <Text
-              style={[
-                styles.infoLabel,
-                { color: withOpacity(colors.text.light, 0.7) },
-              ]}
-            >
-              Messages
-            </Text>
-          </View>
-          <Text style={[styles.infoValue, { color: colors.text.light }]}>
-            {stats?.messageCount || 0}
           </Text>
         </View>
       </View>
@@ -1199,197 +1115,6 @@ export const GroupDetailsScreen: React.FC = () => {
             )}
           </AnimatedTouchableOpacity>
         ))}
-      </View>
-    </Animated.View>
-  );
-
-  const renderStatsTab = () => (
-    <Animated.View entering={FadeIn.delay(100).duration(300)}>
-      <View style={styles.statsCard}>
-        <View style={styles.statsGrid}>
-          <Animated.View
-            style={[
-              styles.statItem,
-              { backgroundColor: withOpacity(colors.primary.main, 0.2) },
-            ]}
-            entering={FadeInDown.delay(150).springify()}
-          >
-            <LinearGradient
-              colors={[colors.primary.main, colors.secondary.main]}
-              start={{ x: 0, y: 0 }}
-              end={{ x: 1, y: 1 }}
-              style={styles.statIconContainer}
-            >
-              <Ionicons name="people" size={24} color={colors.text.light} />
-            </LinearGradient>
-            <Text style={[styles.statValue, { color: colors.text.light }]}>
-              {stats?.memberCount || 0}
-            </Text>
-            <Text
-              style={[
-                styles.statLabel,
-                { color: withOpacity(colors.text.light, 0.7) },
-              ]}
-            >
-              Membres
-            </Text>
-          </Animated.View>
-
-          <Animated.View
-            style={[
-              styles.statItem,
-              { backgroundColor: withOpacity(colors.secondary.main, 0.2) },
-            ]}
-            entering={FadeInDown.delay(200).springify()}
-          >
-            <LinearGradient
-              colors={[colors.secondary.main, colors.primary.main]}
-              start={{ x: 0, y: 0 }}
-              end={{ x: 1, y: 1 }}
-              style={styles.statIconContainer}
-            >
-              <Ionicons
-                name="shield-checkmark"
-                size={24}
-                color={colors.text.light}
-              />
-            </LinearGradient>
-            <Text style={[styles.statValue, { color: colors.text.light }]}>
-              {stats?.adminCount || 0}
-            </Text>
-            <Text
-              style={[
-                styles.statLabel,
-                { color: withOpacity(colors.text.light, 0.7) },
-              ]}
-            >
-              Admins
-            </Text>
-          </Animated.View>
-
-          <Animated.View
-            style={[
-              styles.statItem,
-              { backgroundColor: withOpacity(colors.primary.main, 0.2) },
-            ]}
-            entering={FadeInDown.delay(250).springify()}
-          >
-            <LinearGradient
-              colors={[colors.primary.main, colors.secondary.main]}
-              start={{ x: 0, y: 0 }}
-              end={{ x: 1, y: 1 }}
-              style={styles.statIconContainer}
-            >
-              <Ionicons
-                name="chatbubbles"
-                size={24}
-                color={colors.text.light}
-              />
-            </LinearGradient>
-            <Text style={[styles.statValue, { color: colors.text.light }]}>
-              {stats?.messageCount || 0}
-            </Text>
-            <Text
-              style={[
-                styles.statLabel,
-                { color: withOpacity(colors.text.light, 0.7) },
-              ]}
-            >
-              Messages
-            </Text>
-          </Animated.View>
-        </View>
-      </View>
-    </Animated.View>
-  );
-
-  const renderHistoryTab = () => (
-    <Animated.View entering={FadeIn.delay(100).duration(300)}>
-      <View style={styles.historyCard}>
-        {logs.length === 0 ? (
-          <View style={styles.emptyState}>
-            <Ionicons
-              name="time-outline"
-              size={48}
-              color={withOpacity(colors.text.light, 0.5)}
-            />
-            <Text
-              style={[
-                styles.emptyText,
-                { color: withOpacity(colors.text.light, 0.7) },
-              ]}
-            >
-              Aucun historique disponible
-            </Text>
-          </View>
-        ) : (
-          logs.map((log, index) => (
-            <Animated.View
-              key={log.id}
-              style={[
-                styles.logItem,
-                { borderBottomColor: withOpacity(colors.ui.divider, 0.3) },
-              ]}
-              entering={FadeInDown.delay(150 + index * 50).springify()}
-            >
-              <View style={styles.logIconContainer}>
-                <Ionicons
-                  name={
-                    log.action_type === "group_created"
-                      ? "add-circle"
-                      : log.action_type === "member_added"
-                        ? "person-add"
-                        : log.action_type === "member_removed"
-                          ? "person-remove"
-                          : log.action_type === "role_changed"
-                            ? "swap-horizontal"
-                            : log.action_type === "admin_transferred"
-                              ? "shield-checkmark"
-                              : "settings"
-                  }
-                  size={20}
-                  color={colors.primary.main}
-                />
-              </View>
-              <View style={styles.logContent}>
-                <Text style={[styles.logAction, { color: colors.text.light }]}>
-                  {log.action_type === "group_created"
-                    ? "Groupe créé"
-                    : log.action_type === "member_added"
-                      ? "Membre ajouté"
-                      : log.action_type === "member_removed"
-                        ? "Membre retiré"
-                        : log.action_type === "role_changed"
-                          ? "Rôle modifié"
-                          : log.action_type === "admin_transferred"
-                            ? "Administration transférée"
-                            : "Paramètres modifiés"}
-                </Text>
-                <Text
-                  style={[
-                    styles.logActor,
-                    { color: withOpacity(colors.text.light, 0.7) },
-                  ]}
-                >
-                  par {log.actor_name}
-                </Text>
-                <Text
-                  style={[
-                    styles.logTime,
-                    { color: withOpacity(colors.text.light, 0.5) },
-                  ]}
-                >
-                  {new Date(log.timestamp).toLocaleDateString("fr-FR", {
-                    day: "numeric",
-                    month: "short",
-                    hour: "2-digit",
-                    minute: "2-digit",
-                  })}
-                </Text>
-              </View>
-            </Animated.View>
-          ))
-        )}
       </View>
     </Animated.View>
   );
@@ -1712,10 +1437,6 @@ export const GroupDetailsScreen: React.FC = () => {
         return renderInfoTab();
       case "members":
         return renderMembersTab();
-      case "stats":
-        return renderStatsTab();
-      case "history":
-        return renderHistoryTab();
       case "settings":
         return renderSettingsTab();
       default:
@@ -2528,73 +2249,6 @@ const styles = StyleSheet.create({
     marginBottom: 4,
   },
   memberJoined: {
-    fontSize: typography.fontSize.xs,
-  },
-  statsCard: {
-    borderRadius: 16,
-    overflow: "hidden",
-  },
-  statsGrid: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: 12,
-  },
-  statItem: {
-    flex: 1,
-    minWidth: "30%",
-    padding: 20,
-    borderRadius: 16,
-    alignItems: "center",
-  },
-  statIconContainer: {
-    width: 56,
-    height: 56,
-    borderRadius: 28,
-    justifyContent: "center",
-    alignItems: "center",
-    marginBottom: 12,
-  },
-  statValue: {
-    fontSize: typography.fontSize.xxl,
-    fontWeight: typography.fontWeight.bold,
-    marginBottom: 4,
-  },
-  statLabel: {
-    fontSize: typography.fontSize.sm,
-    textAlign: "center",
-  },
-  historyCard: {
-    borderRadius: 16,
-    overflow: "hidden",
-  },
-  logItem: {
-    flexDirection: "row",
-    padding: 16,
-    borderBottomWidth: 1,
-    backgroundColor: "rgba(255, 255, 255, 0.05)",
-  },
-  logIconContainer: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    backgroundColor: "rgba(255, 255, 255, 0.1)",
-    justifyContent: "center",
-    alignItems: "center",
-    marginRight: 12,
-  },
-  logContent: {
-    flex: 1,
-  },
-  logAction: {
-    fontSize: typography.fontSize.base,
-    fontWeight: typography.fontWeight.semiBold,
-    marginBottom: 4,
-  },
-  logActor: {
-    fontSize: typography.fontSize.sm,
-    marginBottom: 4,
-  },
-  logTime: {
     fontSize: typography.fontSize.xs,
   },
   settingsCard: {

--- a/src/screens/Groups/__tests__/GroupDetailsScreen.test.tsx
+++ b/src/screens/Groups/__tests__/GroupDetailsScreen.test.tsx
@@ -97,8 +97,6 @@ jest.mock("../../../services/groups/api", () => ({
   groupsAPI: {
     getGroupDetails: jest.fn(),
     getGroupMembers: jest.fn(),
-    getGroupStats: jest.fn(),
-    getGroupLogs: jest.fn(),
     getGroupSettings: jest.fn(),
     leaveGroup: jest.fn(),
     deleteGroup: jest.fn(),
@@ -139,11 +137,6 @@ describe("GroupDetailsScreen", () => {
       member_count: 3,
     });
     mockedGroupsAPI.getGroupMembers.mockResolvedValue({ members: [] } as any);
-    mockedGroupsAPI.getGroupStats.mockResolvedValue({
-      message_count: 0,
-      member_count: 3,
-    } as any);
-    mockedGroupsAPI.getGroupLogs.mockResolvedValue({ logs: [] } as any);
     mockedGroupsAPI.getGroupSettings.mockResolvedValue({} as any);
   });
 
@@ -175,20 +168,6 @@ describe("GroupDetailsScreen", () => {
     render(<GroupDetailsScreen />);
     await waitFor(() => {
       expect(mockedGroupsAPI.getGroupMembers).toHaveBeenCalled();
-    });
-  });
-
-  it("loads group stats on mount", async () => {
-    render(<GroupDetailsScreen />);
-    await waitFor(() => {
-      expect(mockedGroupsAPI.getGroupStats).toHaveBeenCalled();
-    });
-  });
-
-  it("loads group logs on mount", async () => {
-    render(<GroupDetailsScreen />);
-    await waitFor(() => {
-      expect(mockedGroupsAPI.getGroupLogs).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary
- Supprime les onglets Statistiques et Historique du GroupDetailsScreen (mort UI permanente)
- Retire le code mort associe : `renderStatsTab`, `renderHistoryTab`, etats `stats`/`logs`, appels API `getGroupStats`/`getGroupLogs`, imports `GroupStats`/`GroupLog`, 10 styles orphelins
- Met a jour le test pour supprimer les cas devenus invalides (stats/logs sur mount)

## Audit permissions communication
Le wire-up est deja en place : `openPermissionSelector` -> Alert 3 options (`Tous les membres`, `Moderateurs+`, `Admins uniquement`) -> `updateGroupSetting` -> API `PUT /conversations/:id` avec `metadata.group_settings`. Aucun travail additionnel requis.

## Test plan
- [x] 24/24 tests GroupDetailsScreen verts
- [x] tsc --noEmit propre (0 erreurs)
- [x] Aucune reference orpheline stats/logs dans le composant