### PR TITLE
ci(cd): aligne le bump infra sur la branche source au lieu de main

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -116,12 +116,24 @@ jobs:
           fi
           echo "✅ Image found in registry"
 
+      - name: Determine trigger branch
+        id: branch
+        env:
+          TRIGGER_BRANCH: ${{ github.event.workflow_run.head_branch || 'main' }}
+        run: |
+          echo "trigger_branch=${TRIGGER_BRANCH}" >> $GITHUB_OUTPUT
+          if [ "$TRIGGER_BRANCH" = "main" ]; then
+            echo "infra_branch=main" >> $GITHUB_OUTPUT
+          else
+            echo "infra_branch=deploy/preprod" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout infrastructure repository
         uses: actions/checkout@v5
         with:
           repository: whispr-messenger/infrastructure
           path: infrastructure
-          ref: main
+          ref: ${{ steps.branch.outputs.infra_branch }}
           token: ${{ steps.generate_token.outputs.token }}
           fetch-depth: 0
 
@@ -157,7 +169,7 @@ jobs:
           COMMIT_SHA: ${{ steps.validate_commit.outputs.commit_sha }}
           EVENT_NAME: ${{ github.event_name }}
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
-          INFRA_BRANCH: main
+          INFRA_BRANCH: ${{ steps.branch.outputs.infra_branch }}
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary
- Ajoute un step `Determine trigger branch` qui dérive `infra_branch` depuis `github.event.workflow_run.head_branch`
- `deploy/preprod` → bump sur `infrastructure/deploy/preprod`, `main` → bump sur `infrastructure/main`
- Aligné sur le pattern exact de `user-service/.github/workflows/cd.yml`

## Changements
- `.github/workflows/cd.yml` uniquement (3 lignes modifiées + 12 ajoutées)
- Fallback `main` conservé si `workflow_run.head_branch` est vide (workflow_dispatch)

## Test plan
- [ ] Prochain merge sur `deploy/preprod` → CD bump auto sur `infrastructure/deploy/preprod` sans intervention manuelle
- [ ] Merge sur `main` → bump sur `infrastructure/main` (comportement préservé)