### PR TITLE
fix(security): compute real SHA-256 fingerprints for security keys

### DIFF
--- a/src/screens/Security/SecurityKeysScreen.tsx
+++ b/src/screens/Security/SecurityKeysScreen.tsx
@@ -27,9 +27,12 @@ import * as Haptics from "expo-haptics";
 import Toast from "../../components/Toast/Toast";
 import QRCodeStyled from "react-native-qrcode-styled";
 
+import * as Crypto from "expo-crypto";
+
 import { copyToClipboard } from "../../utils/clipboard";
 import {
   DeviceManagerService,
+  SignalKeysService,
   type DeviceInfo,
 } from "../../services/SecurityService";
 
@@ -56,8 +59,12 @@ interface SecurityKey {
   deviceId: string;
   deviceName: string;
   fingerprint: string;
-  createdAt: string;
   verified: boolean;
+}
+
+function formatFingerprint(hex: string): string {
+  const truncated = hex.slice(0, 32);
+  return truncated.match(/.{1,4}/g)?.join(" ") ?? hex;
 }
 
 // Module-level cache — survives re-renders and component remounts
@@ -367,7 +374,7 @@ const QRCodeModal: React.FC<{
 export const SecurityKeysScreen: React.FC = () => {
   const navigation = useNavigation();
   const { getThemeColors, getFontSize, getLocalizedText } = useTheme();
-  const { deviceId: currentDeviceId } = useAuth();
+  const { userId, deviceId: currentDeviceId } = useAuth();
   const themeColors = getThemeColors();
   const accentColor = "#9692AC";
   const accentColorDark = "#727596";
@@ -436,7 +443,7 @@ export const SecurityKeysScreen: React.FC = () => {
     ]).start();
 
     DeviceManagerService.listDevices()
-      .then((apiDevices: DeviceInfo[]) => {
+      .then(async (apiDevices: DeviceInfo[]) => {
         const mapped: ConnectedDevice[] = apiDevices.map((d) => ({
           id: d.id,
           name: d.deviceName,
@@ -445,16 +452,35 @@ export const SecurityKeysScreen: React.FC = () => {
           isCurrent: d.id === currentDeviceId,
         }));
         setDevices(mapped);
-        setSecurityKeys(
-          mapped.map((d, i) => ({
-            id: String(i + 1),
-            deviceId: d.id,
-            deviceName: d.name,
-            fingerprint: "—",
-            createdAt: new Date().toISOString(),
-            verified: d.isCurrent,
-          })),
+
+        const keys: SecurityKey[] = await Promise.all(
+          mapped.map(async (d, i) => {
+            let fingerprint = "—";
+            if (userId) {
+              try {
+                const bundle = await SignalKeysService.getKeyBundle(
+                  userId,
+                  d.id,
+                );
+                const raw = await Crypto.digestStringAsync(
+                  Crypto.CryptoDigestAlgorithm.SHA256,
+                  bundle.identity_key + d.id,
+                );
+                fingerprint = formatFingerprint(raw);
+              } catch {
+                // keep "—" if bundle unavailable
+              }
+            }
+            return {
+              id: String(i + 1),
+              deviceId: d.id,
+              deviceName: d.name,
+              fingerprint,
+              verified: d.isCurrent,
+            };
+          }),
         );
+        setSecurityKeys(keys);
       })
       .catch(() => {
         showToast(
@@ -611,15 +637,6 @@ export const SecurityKeysScreen: React.FC = () => {
       default:
         return { name: "device-desktop", color: iconColor };
     }
-  };
-
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString("fr-FR", {
-      day: "numeric",
-      month: "long",
-      year: "numeric",
-    });
   };
 
   const DeviceCard = ({
@@ -985,25 +1002,6 @@ export const SecurityKeysScreen: React.FC = () => {
                     color={themeColors.text.tertiary}
                   />
                 </TouchableOpacity>
-              </View>
-              <View style={styles.keyDateRow}>
-                <Ionicons
-                  name="calendar-outline"
-                  size={12}
-                  color={themeColors.text.tertiary}
-                />
-                <Text
-                  style={[
-                    styles.keyDate,
-                    {
-                      color: themeColors.text.tertiary,
-                      fontSize: getFontSize("xs"),
-                    },
-                  ]}
-                >
-                  {getLocalizedText("security.createdOn")}{" "}
-                  {formatDate(securityKey.createdAt)}
-                </Text>
               </View>
             </View>
           </View>

--- a/src/screens/Security/__tests__/SecurityKeysScreen.test.tsx
+++ b/src/screens/Security/__tests__/SecurityKeysScreen.test.tsx
@@ -16,7 +16,15 @@ jest.mock("expo-haptics", () => ({
   ImpactFeedbackStyle: { Light: "light", Medium: "medium", Heavy: "heavy" },
 }));
 jest.mock("../../../context/AuthContext", () => ({
-  useAuth: () => ({ deviceId: "test-device-id" }),
+  useAuth: () => ({ userId: "test-user-id", deviceId: "test-device-id" }),
+}));
+jest.mock("expo-crypto", () => ({
+  digestStringAsync: jest
+    .fn()
+    .mockResolvedValue(
+      "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899",
+    ),
+  CryptoDigestAlgorithm: { SHA256: "SHA-256" },
 }));
 jest.mock("../../../context/ThemeContext", () => ({
   useTheme: () => ({
@@ -42,11 +50,15 @@ jest.mock("react-native-qrcode-styled", () => () => null);
 const mockListDevices = jest.fn();
 const mockRevokeDevice = jest.fn();
 const mockGenerateQRChallenge = jest.fn();
+const mockGetKeyBundle = jest.fn();
 jest.mock("../../../services/SecurityService", () => ({
   DeviceManagerService: {
     listDevices: (...a: unknown[]) => mockListDevices(...a),
     revokeDevice: (...a: unknown[]) => mockRevokeDevice(...a),
     generateQRChallenge: (...a: unknown[]) => mockGenerateQRChallenge(...a),
+  },
+  SignalKeysService: {
+    getKeyBundle: (...a: unknown[]) => mockGetKeyBundle(...a),
   },
 }));
 
@@ -55,6 +67,15 @@ describe("SecurityKeysScreen", () => {
     jest.clearAllMocks();
     mockListDevices.mockResolvedValue([]);
     mockGenerateQRChallenge.mockResolvedValue("jwt-challenge-token");
+    mockGetKeyBundle.mockResolvedValue({
+      identity_key: "dGVzdC1pZGVudGl0eS1rZXk=",
+      signed_prekey: {
+        key_id: 1,
+        public_key: "cHVibGljS2V5",
+        signature: "c2ln",
+      },
+      one_time_prekeys: [],
+    });
     jest.spyOn(console, "warn").mockImplementation(() => {});
     // Reset module-level cache so each test starts fresh
     _qrCache.challenge = null;


### PR DESCRIPTION
## Summary
- Replace hardcoded "—" fingerprint with real `SHA-256(identity_key || deviceId)` computed via `expo-crypto`
- Fetch each device's Signal key bundle from the auth service in parallel after the device list loads
- Remove `createdAt` display from the security key card (field does not exist in the backend schema — only `lastActive` is exposed)
- Fall back to "—" gracefully if the key bundle fetch fails for a device

## Test plan
- [x] Unit tests green (`SecurityKeysScreen.test.tsx` — 4/4)
- [x] Lint clean (0 errors)
- [x] `expo-crypto` and `SignalKeysService` mocked in tests