### PR TITLE
fix(chat): retry stream sur 401 apres refresh token pour blob et thumbnail 1v1

### DIFF
--- a/src/components/Calls/__tests__/CallParticipantTile.web.test.tsx
+++ b/src/components/Calls/__tests__/CallParticipantTile.web.test.tsx
@@ -14,6 +14,12 @@ jest.mock("livekit-client", () => ({
 // elements and the useRef refs populate as expected.
 jest.mock("react-native", () => require("react-native-web"));
 
+// Avatar → useResolvedMediaUrl → AuthService → DeviceService → expo-device
+// expo-device ne resout pas dans jest-expo node. On mocke AuthService ici.
+jest.mock("../../../services/AuthService", () => ({
+  AuthService: { refreshTokens: jest.fn().mockResolvedValue(undefined) },
+}));
+
 import { CallParticipantTile } from "../CallParticipantTile.web";
 
 type MockTrack = {

--- a/src/hooks/__tests__/streamMediaToRenderableUri.test.ts
+++ b/src/hooks/__tests__/streamMediaToRenderableUri.test.ts
@@ -17,6 +17,13 @@ jest.mock("react-native", () => ({
   Platform: { OS: "web" },
 }));
 
+// AuthService est importe par useResolvedMediaUrl pour le retry 401 ;
+// on le mock ici pour eviter que expo-device ne soit resolu dans le
+// contexte jest-node (il necessite un module natif).
+jest.mock("../../services/AuthService", () => ({
+  AuthService: { refreshTokens: jest.fn().mockResolvedValue(undefined) },
+}));
+
 import {
   probeMediaUrlThrottled,
   streamMediaToRenderableUri,

--- a/src/hooks/useResolvedMediaUrl.ts
+++ b/src/hooks/useResolvedMediaUrl.ts
@@ -19,6 +19,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Platform } from "react-native";
 import { TokenService } from "../services/TokenService";
+import { AuthService } from "../services/AuthService";
 import * as FileSystem from "expo-file-system/legacy";
 
 type NativeCacheEntry = { resolvedUri: string; storedAt: number };
@@ -511,7 +512,7 @@ export function useResolvedMediaUrl(uri: string | undefined): ResolvedMediaUrl {
     (async () => {
       revokeBlobUrl();
       try {
-        const token = await TokenService.getAccessToken();
+        let token = await TokenService.getAccessToken();
         const headers: Record<string, string> = {};
         if (token) headers["Authorization"] = `Bearer ${token}`;
 
@@ -566,14 +567,43 @@ export function useResolvedMediaUrl(uri: string | undefined): ResolvedMediaUrl {
         // endpoint. We never hand the presigned URL to the renderer.
         // Use the throttled variant so a chat-screen burst doesn't trip
         // the server-side 30 req/s short throttle.
-        const renderableUri =
-          Platform.OS === "web"
-            ? await streamMediaToRenderableUriThrottled(
-                uri,
-                token,
-                abortController.signal,
-              )
-            : await writeDiskCache(uri, token);
+        //
+        // WHISPR-1143 — si le stream echoue avec 401 (token expire), on
+        // rafraichit le token une seule fois et on reessaie. Le media-service
+        // retourne 401 pour les tokens invalides/expires ; les avatars et
+        // thumbnails sont en PUBLIC_READABLE_CONTEXTS (tout user authentifie
+        // peut y acceder) mais le token doit etre valide.
+        let renderableUri: string;
+        try {
+          renderableUri =
+            Platform.OS === "web"
+              ? await streamMediaToRenderableUriThrottled(
+                  uri,
+                  token,
+                  abortController.signal,
+                )
+              : await writeDiskCache(uri, token);
+        } catch (streamErr) {
+          // retry une seule fois apres refresh sur 401
+          const is401 =
+            streamErr instanceof Error && /HTTP 401/.test(streamErr.message);
+          if (!is401 || cancelled) throw streamErr;
+          try {
+            await AuthService.refreshTokens();
+          } catch {
+            // refresh echoue → on laisse l'erreur originale remonter
+            throw streamErr;
+          }
+          token = await TokenService.getAccessToken();
+          renderableUri =
+            Platform.OS === "web"
+              ? await streamMediaToRenderableUriThrottled(
+                  uri,
+                  token,
+                  abortController.signal,
+                )
+              : await writeDiskCache(uri, token);
+        }
         if (cancelled) {
           if (
             renderableUri.startsWith("blob:") &&


### PR DESCRIPTION
## Summary
- `useResolvedMediaUrl` capturait le token une seule fois via `TokenService.getAccessToken()` sans verifier l'expiration
- Quand le token expire (~15 min), media-service retourne 401 et l'avatar/thumbnail disparait definitvement jusqu'au refresh page
- Fix : catch 401 a la couche hook, appel `AuthService.refreshTokens()`, token frais, retry stream une seule fois
- Mocks `AuthService` ajoutes dans les tests touches par la nouvelle chaine d'import (`expo-device` indisponible en jest-expo node)

## Test plan
- [ ] Tests unitaires verts (`streamMediaToRenderableUri.test.ts` 16 tests, `CallParticipantTile.web.test.tsx` 5 tests)
- [ ] TypeScript clean (`tsc --noEmit` sans erreur)
- [ ] Lint clean (0 erreur)
- [ ] Tester avatar 1v1 apres 15+ min de session (token expire) - l'avatar reste visible
- [ ] Tester thumbnail media dans chat apres token expire - le media se charge

Closes WHISPR-1143