### PR TITLE
feat(security): add safety number verification for direct conversations

### DIFF
--- a/src/components/Chat/ConversationItem.tsx
+++ b/src/components/Chat/ConversationItem.tsx
@@ -30,17 +30,21 @@ const EMPTY_GROUP_AVATARS: Array<{ uri?: string; name: string }> = [];
 interface ConversationItemProps {
   conversation: Conversation;
   onPress: (conversationId: string) => void;
+  onLongPress?: () => void;
   index?: number;
   editMode?: boolean;
   isSelected?: boolean;
+  isContactVerified?: boolean;
 }
 
 export const ConversationItem: React.FC<ConversationItemProps> = ({
   conversation,
   onPress,
+  onLongPress,
   index = 0,
   editMode = false,
   isSelected = false,
+  isContactVerified = false,
 }) => {
   useTheme();
   const { userId: currentUserId } = useAuth();
@@ -309,6 +313,7 @@ export const ConversationItem: React.FC<ConversationItemProps> = ({
           Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
           onPress(conversation.id);
         }}
+        onLongPress={onLongPress}
         activeOpacity={0.7}
       >
         <View style={styles.content}>
@@ -399,6 +404,14 @@ export const ConversationItem: React.FC<ConversationItemProps> = ({
                   size={14}
                   color="rgba(255, 255, 255, 0.6)"
                   style={styles.mutedIcon}
+                />
+              )}
+              {isContactVerified && conversation.type === "direct" && (
+                <Ionicons
+                  name="lock-closed"
+                  size={12}
+                  color="#4CAF50"
+                  style={{ marginLeft: 4 }}
                 />
               )}
               {formattedTime ? (
@@ -600,6 +613,8 @@ export default memo(ConversationItem, (prevProps, nextProps) => {
     JSON.stringify(prevLastMessage?.metadata) ===
       JSON.stringify(nextLastMessage?.metadata) &&
     prevEditMode === nextEditMode &&
-    prevIsSelected === nextIsSelected
+    prevIsSelected === nextIsSelected &&
+    (prevProps as ConversationItemProps).isContactVerified ===
+      (nextProps as ConversationItemProps).isContactVerified
   );
 });

--- a/src/components/Chat/SafetyNumberModal.tsx
+++ b/src/components/Chat/SafetyNumberModal.tsx
@@ -7,6 +7,7 @@ import {
   StyleSheet,
   ActivityIndicator,
 } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
 import { Ionicons } from "@expo/vector-icons";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useAuth } from "../../context/AuthContext";
@@ -108,42 +109,78 @@ export const SafetyNumberModal: React.FC<SafetyNumberModalProps> = ({
       <View style={styles.sheet}>
         <View style={styles.handle} />
 
+        {/* Header */}
         <View style={styles.header}>
-          <Text style={styles.title}>Safety Number</Text>
+          <View style={styles.headerLeft}>
+            <View style={styles.lockIconWrap}>
+              <Ionicons
+                name={alreadyVerified ? "lock-closed" : "shield-checkmark"}
+                size={18}
+                color={
+                  alreadyVerified ? colors.ui.success : colors.primary.main
+                }
+              />
+            </View>
+            <Text style={styles.title}>Safety Number</Text>
+          </View>
           <TouchableOpacity
             onPress={onClose}
             style={styles.closeButton}
             testID="safety-close-btn"
           >
-            <Ionicons name="close" size={22} color="rgba(255,255,255,0.6)" />
+            <Ionicons name="close" size={20} color={colors.secondary.light} />
           </TouchableOpacity>
         </View>
 
+        {/* Subtitle */}
         <Text style={styles.subtitle}>
-          Vérifiez ce code avec{" "}
-          <Text style={styles.contactName}>{contactName}</Text> pour confirmer
-          que votre conversation est chiffrée de bout en bout.
+          Comparez ce code avec{" "}
+          <Text style={styles.contactName}>{contactName}</Text> (en personne ou
+          par appel) pour confirmer que la conversation est bien chiffrée de
+          bout en bout.
         </Text>
 
+        {/* Loading */}
         {loading && (
           <View style={styles.center}>
-            <ActivityIndicator color={colors.primary.main} />
+            <ActivityIndicator color={colors.primary.main} size="large" />
+            <Text style={styles.loadingText}>Calcul en cours...</Text>
           </View>
         )}
 
+        {/* Error */}
         {error && (
           <View style={styles.center}>
+            <Ionicons
+              name="warning-outline"
+              size={32}
+              color={colors.ui.error}
+            />
             <Text style={styles.errorText}>{error}</Text>
           </View>
         )}
 
+        {/* Grid 3×4 */}
         {groups.length === 12 && (
           <View style={styles.grid}>
             {[0, 1, 2].map((row) => (
               <View key={row} style={styles.gridRow}>
                 {groups.slice(row * 4, row * 4 + 4).map((g, col) => (
-                  <View key={col} style={styles.groupCell}>
-                    <Text style={styles.groupText}>{g}</Text>
+                  <View
+                    key={col}
+                    style={[
+                      styles.groupCell,
+                      alreadyVerified && styles.groupCellVerified,
+                    ]}
+                  >
+                    <Text
+                      style={[
+                        styles.groupText,
+                        alreadyVerified && styles.groupTextVerified,
+                      ]}
+                    >
+                      {g}
+                    </Text>
                   </View>
                 ))}
               </View>
@@ -151,20 +188,35 @@ export const SafetyNumberModal: React.FC<SafetyNumberModalProps> = ({
           </View>
         )}
 
+        {/* Already verified banner */}
         {alreadyVerified && (
           <View style={styles.verifiedBanner}>
-            <Ionicons name="lock-closed" size={16} color="#4CAF50" />
+            <Ionicons
+              name="checkmark-circle"
+              size={18}
+              color={colors.ui.success}
+            />
             <Text style={styles.verifiedText}>Contact vérifié</Text>
           </View>
         )}
 
+        {/* Verify button */}
         {!alreadyVerified && !loading && !error && groups.length === 12 && (
-          <TouchableOpacity
-            style={styles.verifyButton}
-            onPress={handleMarkVerified}
-            activeOpacity={0.85}
-          >
-            <Text style={styles.verifyButtonText}>Marquer comme vérifié</Text>
+          <TouchableOpacity onPress={handleMarkVerified} activeOpacity={0.85}>
+            <LinearGradient
+              colors={["#FE7A5C", "#F04882"]}
+              start={{ x: 0, y: 0 }}
+              end={{ x: 1, y: 0 }}
+              style={styles.verifyButton}
+            >
+              <Ionicons
+                name="checkmark-circle-outline"
+                size={18}
+                color="#fff"
+                style={{ marginRight: 8 }}
+              />
+              <Text style={styles.verifyButtonText}>Marquer comme vérifié</Text>
+            </LinearGradient>
           </TouchableOpacity>
         )}
       </View>
@@ -175,51 +227,80 @@ export const SafetyNumberModal: React.FC<SafetyNumberModalProps> = ({
 const styles = StyleSheet.create({
   backdrop: {
     flex: 1,
-    backgroundColor: "rgba(0,0,0,0.5)",
+    backgroundColor: "rgba(0,0,0,0.6)",
   },
   sheet: {
-    backgroundColor: "#1A1F3A",
-    borderTopLeftRadius: 24,
-    borderTopRightRadius: 24,
+    backgroundColor: colors.background.dark,
+    borderTopLeftRadius: 28,
+    borderTopRightRadius: 28,
     paddingHorizontal: 20,
-    paddingBottom: 36,
+    paddingBottom: 40,
+    borderTopWidth: 1,
+    borderLeftWidth: 1,
+    borderRightWidth: 1,
+    borderColor: `${colors.secondary.medium}60`,
   },
   handle: {
-    width: 40,
+    width: 36,
     height: 4,
-    backgroundColor: "rgba(255,255,255,0.2)",
+    backgroundColor: colors.secondary.main,
     borderRadius: 2,
     alignSelf: "center",
     marginTop: 12,
-    marginBottom: 16,
+    marginBottom: 20,
+    opacity: 0.5,
   },
   header: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
-    marginBottom: 12,
+    marginBottom: 14,
+  },
+  headerLeft: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+  },
+  lockIconWrap: {
+    width: 34,
+    height: 34,
+    borderRadius: 10,
+    backgroundColor: `${colors.secondary.medium}80`,
+    justifyContent: "center",
+    alignItems: "center",
   },
   title: {
     fontSize: 18,
     fontWeight: "700",
-    color: "#FFFFFF",
+    color: colors.text.light,
+    letterSpacing: 0.3,
   },
   closeButton: {
-    padding: 4,
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: `${colors.secondary.medium}60`,
+    justifyContent: "center",
+    alignItems: "center",
   },
   subtitle: {
-    fontSize: 14,
-    color: "rgba(255,255,255,0.65)",
-    lineHeight: 20,
-    marginBottom: 24,
+    fontSize: 13,
+    color: colors.secondary.light,
+    lineHeight: 19,
+    marginBottom: 20,
   },
   contactName: {
-    color: "#FFFFFF",
+    color: colors.text.light,
     fontWeight: "600",
   },
   center: {
     alignItems: "center",
-    paddingVertical: 24,
+    paddingVertical: 28,
+    gap: 10,
+  },
+  loadingText: {
+    color: colors.secondary.light,
+    fontSize: 13,
   },
   errorText: {
     color: colors.ui.error,
@@ -227,50 +308,62 @@ const styles = StyleSheet.create({
     textAlign: "center",
   },
   grid: {
-    gap: 10,
-    marginBottom: 24,
+    gap: 8,
+    marginBottom: 20,
   },
   gridRow: {
     flexDirection: "row",
-    gap: 10,
+    gap: 8,
   },
   groupCell: {
     flex: 1,
-    backgroundColor: "rgba(255,255,255,0.08)",
+    backgroundColor: `${colors.secondary.medium}50`,
     borderRadius: 10,
-    paddingVertical: 12,
+    paddingVertical: 13,
     alignItems: "center",
+    borderWidth: 1,
+    borderColor: `${colors.secondary.main}40`,
+  },
+  groupCellVerified: {
+    backgroundColor: `${colors.ui.success}15`,
+    borderColor: `${colors.ui.success}40`,
   },
   groupText: {
-    fontSize: 16,
+    fontSize: 15,
     fontWeight: "600",
-    color: "#FFFFFF",
-    letterSpacing: 1,
+    color: colors.text.light,
+    letterSpacing: 1.5,
+  },
+  groupTextVerified: {
+    color: colors.ui.success,
   },
   verifiedBanner: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
     gap: 8,
-    paddingVertical: 14,
+    paddingVertical: 13,
     borderRadius: 12,
-    backgroundColor: "rgba(76,175,80,0.12)",
-    marginBottom: 8,
+    backgroundColor: `${colors.ui.success}18`,
+    borderWidth: 1,
+    borderColor: `${colors.ui.success}30`,
+    marginBottom: 4,
   },
   verifiedText: {
-    color: "#4CAF50",
+    color: colors.ui.success,
     fontWeight: "600",
-    fontSize: 15,
+    fontSize: 14,
   },
   verifyButton: {
-    backgroundColor: colors.primary.main,
     paddingVertical: 14,
-    borderRadius: 12,
+    borderRadius: 14,
+    flexDirection: "row",
     alignItems: "center",
+    justifyContent: "center",
   },
   verifyButtonText: {
-    color: "#FFFFFF",
-    fontWeight: "600",
+    color: colors.text.light,
+    fontWeight: "700",
     fontSize: 15,
   },
 });

--- a/src/components/Chat/SafetyNumberModal.tsx
+++ b/src/components/Chat/SafetyNumberModal.tsx
@@ -1,0 +1,276 @@
+import React, { useEffect, useState } from "react";
+import {
+  View,
+  Text,
+  Modal,
+  TouchableOpacity,
+  StyleSheet,
+  ActivityIndicator,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useAuth } from "../../context/AuthContext";
+import { SignalKeysService } from "../../services/SecurityService";
+import { computeSafetyNumber } from "../../services/E2EEService";
+import { colors } from "../../theme/colors";
+
+const SAFETY_STORAGE_PREFIX = "@whispr:safety:";
+
+interface SafetyNumberModalProps {
+  visible: boolean;
+  onClose: () => void;
+  contactUserId: string;
+  contactName: string;
+  onVerified: (contactUserId: string) => void;
+}
+
+export const SafetyNumberModal: React.FC<SafetyNumberModalProps> = ({
+  visible,
+  onClose,
+  contactUserId,
+  contactName,
+  onVerified,
+}) => {
+  const { userId, deviceId } = useAuth();
+  const [safetyNumber, setSafetyNumber] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [alreadyVerified, setAlreadyVerified] = useState(false);
+
+  useEffect(() => {
+    if (!visible || !userId || !deviceId || !contactUserId) return;
+
+    let cancelled = false;
+    setLoading(true);
+    setSafetyNumber(null);
+    setError(null);
+
+    const storageKey = `${SAFETY_STORAGE_PREFIX}${userId}:${contactUserId}`;
+
+    Promise.all([
+      SignalKeysService.getKeyBundle(userId, deviceId),
+      SignalKeysService.listDevices(contactUserId).then((r) => {
+        const firstDevice = r.deviceIds[0];
+        if (!firstDevice) throw new Error("NO_DEVICE");
+        return SignalKeysService.getKeyBundle(contactUserId, firstDevice);
+      }),
+      AsyncStorage.getItem(storageKey),
+    ])
+      .then(([myBundle, theirBundle, stored]) => {
+        if (cancelled) return;
+        setAlreadyVerified(stored === "verified");
+        return computeSafetyNumber(
+          myBundle.identity_key,
+          userId,
+          theirBundle.identity_key,
+          contactUserId,
+        );
+      })
+      .then((num) => {
+        if (cancelled || !num) return;
+        setSafetyNumber(num);
+      })
+      .catch(() => {
+        if (!cancelled) setError("Impossible de calculer le Safety Number.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [visible, userId, deviceId, contactUserId]);
+
+  const handleMarkVerified = async () => {
+    if (!userId) return;
+    const storageKey = `${SAFETY_STORAGE_PREFIX}${userId}:${contactUserId}`;
+    await AsyncStorage.setItem(storageKey, "verified");
+    setAlreadyVerified(true);
+    onVerified(contactUserId);
+    onClose();
+  };
+
+  const groups = safetyNumber ? safetyNumber.split(" ") : [];
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <TouchableOpacity
+        style={styles.backdrop}
+        activeOpacity={1}
+        onPress={onClose}
+      />
+      <View style={styles.sheet}>
+        <View style={styles.handle} />
+
+        <View style={styles.header}>
+          <Text style={styles.title}>Safety Number</Text>
+          <TouchableOpacity
+            onPress={onClose}
+            style={styles.closeButton}
+            testID="safety-close-btn"
+          >
+            <Ionicons name="close" size={22} color="rgba(255,255,255,0.6)" />
+          </TouchableOpacity>
+        </View>
+
+        <Text style={styles.subtitle}>
+          Vérifiez ce code avec{" "}
+          <Text style={styles.contactName}>{contactName}</Text> pour confirmer
+          que votre conversation est chiffrée de bout en bout.
+        </Text>
+
+        {loading && (
+          <View style={styles.center}>
+            <ActivityIndicator color={colors.primary.main} />
+          </View>
+        )}
+
+        {error && (
+          <View style={styles.center}>
+            <Text style={styles.errorText}>{error}</Text>
+          </View>
+        )}
+
+        {groups.length === 12 && (
+          <View style={styles.grid}>
+            {[0, 1, 2].map((row) => (
+              <View key={row} style={styles.gridRow}>
+                {groups.slice(row * 4, row * 4 + 4).map((g, col) => (
+                  <View key={col} style={styles.groupCell}>
+                    <Text style={styles.groupText}>{g}</Text>
+                  </View>
+                ))}
+              </View>
+            ))}
+          </View>
+        )}
+
+        {alreadyVerified && (
+          <View style={styles.verifiedBanner}>
+            <Ionicons name="lock-closed" size={16} color="#4CAF50" />
+            <Text style={styles.verifiedText}>Contact vérifié</Text>
+          </View>
+        )}
+
+        {!alreadyVerified && !loading && !error && groups.length === 12 && (
+          <TouchableOpacity
+            style={styles.verifyButton}
+            onPress={handleMarkVerified}
+            activeOpacity={0.85}
+          >
+            <Text style={styles.verifyButtonText}>Marquer comme vérifié</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.5)",
+  },
+  sheet: {
+    backgroundColor: "#1A1F3A",
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    paddingHorizontal: 20,
+    paddingBottom: 36,
+  },
+  handle: {
+    width: 40,
+    height: 4,
+    backgroundColor: "rgba(255,255,255,0.2)",
+    borderRadius: 2,
+    alignSelf: "center",
+    marginTop: 12,
+    marginBottom: 16,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 12,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "700",
+    color: "#FFFFFF",
+  },
+  closeButton: {
+    padding: 4,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: "rgba(255,255,255,0.65)",
+    lineHeight: 20,
+    marginBottom: 24,
+  },
+  contactName: {
+    color: "#FFFFFF",
+    fontWeight: "600",
+  },
+  center: {
+    alignItems: "center",
+    paddingVertical: 24,
+  },
+  errorText: {
+    color: colors.ui.error,
+    fontSize: 14,
+    textAlign: "center",
+  },
+  grid: {
+    gap: 10,
+    marginBottom: 24,
+  },
+  gridRow: {
+    flexDirection: "row",
+    gap: 10,
+  },
+  groupCell: {
+    flex: 1,
+    backgroundColor: "rgba(255,255,255,0.08)",
+    borderRadius: 10,
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  groupText: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#FFFFFF",
+    letterSpacing: 1,
+  },
+  verifiedBanner: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    paddingVertical: 14,
+    borderRadius: 12,
+    backgroundColor: "rgba(76,175,80,0.12)",
+    marginBottom: 8,
+  },
+  verifiedText: {
+    color: "#4CAF50",
+    fontWeight: "600",
+    fontSize: 15,
+  },
+  verifyButton: {
+    backgroundColor: colors.primary.main,
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: "center",
+  },
+  verifyButtonText: {
+    color: "#FFFFFF",
+    fontWeight: "600",
+    fontSize: 15,
+  },
+});

--- a/src/components/Chat/SwipeableConversationItem.tsx
+++ b/src/components/Chat/SwipeableConversationItem.tsx
@@ -23,9 +23,11 @@ interface SwipeableConversationItemProps {
   onToggleRead?: (conversationId: string, isCurrentlyUnread: boolean) => void;
   onArchive?: (conversationId: string) => void;
   onPin?: (conversationId: string) => void;
+  onLongPress?: (conversationId: string) => void;
   index?: number;
   editMode?: boolean;
   isSelected?: boolean;
+  isContactVerified?: boolean;
 }
 
 export const SwipeableConversationItem: React.FC<
@@ -38,9 +40,11 @@ export const SwipeableConversationItem: React.FC<
   onToggleRead,
   onArchive,
   onPin,
+  onLongPress,
   index = 0,
   editMode = false,
   isSelected = false,
+  isContactVerified = false,
 }) => {
   const swipeableRef = useRef<Swipeable>(null);
   const [isSwiping, setIsSwiping] = useState(false);
@@ -194,6 +198,7 @@ export const SwipeableConversationItem: React.FC<
         index={index}
         editMode={editMode}
         isSelected={isSelected}
+        isContactVerified={isContactVerified}
       />
     );
   }
@@ -224,9 +229,13 @@ export const SwipeableConversationItem: React.FC<
           <ConversationItem
             conversation={conversation}
             onPress={handlePress}
+            onLongPress={
+              onLongPress ? () => onLongPress(conversation.id) : undefined
+            }
             index={index}
             editMode={editMode}
             isSelected={isSelected}
+            isContactVerified={isContactVerified}
           />
         </View>
       </Swipeable>

--- a/src/components/Chat/__tests__/SafetyNumberModal.test.tsx
+++ b/src/components/Chat/__tests__/SafetyNumberModal.test.tsx
@@ -1,0 +1,132 @@
+import React from "react";
+import { render, fireEvent, waitFor, act } from "@testing-library/react-native";
+import { SafetyNumberModal } from "../SafetyNumberModal";
+
+jest.mock("expo-linear-gradient", () => ({
+  LinearGradient: ({ children }: any) => children,
+}));
+jest.mock("@expo/vector-icons", () => ({ Ionicons: () => null }));
+
+jest.mock("../../../context/AuthContext", () => ({
+  useAuth: () => ({ userId: "user-a", deviceId: "device-a" }),
+}));
+
+const mockGetKeyBundle = jest.fn();
+const mockListDevices = jest.fn();
+jest.mock("../../../services/SecurityService", () => ({
+  SignalKeysService: {
+    getKeyBundle: (...a: unknown[]) => mockGetKeyBundle(...a),
+    listDevices: (...a: unknown[]) => mockListDevices(...a),
+  },
+}));
+
+const mockComputeSafetyNumber = jest.fn();
+jest.mock("../../../services/E2EEService", () => ({
+  computeSafetyNumber: (...a: unknown[]) => mockComputeSafetyNumber(...a),
+}));
+
+const mockGetItem = jest.fn();
+const mockSetItem = jest.fn();
+const mockGetAllKeys = jest.fn();
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  __esModule: true,
+  default: {
+    getItem: (...a: unknown[]) => mockGetItem(...a),
+    setItem: (...a: unknown[]) => mockSetItem(...a),
+    getAllKeys: (...a: unknown[]) => mockGetAllKeys(...a),
+    multiGet: jest.fn().mockResolvedValue([]),
+  },
+}));
+
+const MY_BUNDLE = {
+  identity_key: "bXlLZXk=",
+  signed_prekey: { key_id: 1, public_key: "cHViS2V5", signature: "c2ln" },
+  one_time_prekeys: [],
+};
+const THEIR_BUNDLE = {
+  identity_key: "dGhlaXJLZXk=",
+  signed_prekey: { key_id: 2, public_key: "dGhlaXJQdWI=", signature: "c2ln" },
+  one_time_prekeys: [],
+};
+
+describe("SafetyNumberModal", () => {
+  const defaultProps = {
+    visible: true,
+    onClose: jest.fn(),
+    contactUserId: "user-b",
+    contactName: "Bob",
+    onVerified: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetKeyBundle.mockImplementation((userId: string) => {
+      if (userId === "user-a") return Promise.resolve(MY_BUNDLE);
+      return Promise.resolve(THEIR_BUNDLE);
+    });
+    mockListDevices.mockResolvedValue({
+      userId: "user-b",
+      deviceIds: ["device-b"],
+    });
+    mockComputeSafetyNumber.mockResolvedValue(
+      "12345 67890 11111 22222 33333 44444 55555 66666 77777 88888 99999 00000",
+    );
+    mockGetItem.mockResolvedValue(null);
+    mockGetAllKeys.mockResolvedValue([]);
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  it("renders without crashing", () => {
+    const { toJSON } = render(<SafetyNumberModal {...defaultProps} />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it("displays safety number groups after loading", async () => {
+    const { findByText } = render(<SafetyNumberModal {...defaultProps} />);
+    expect(await findByText("12345")).toBeTruthy();
+    expect(await findByText("67890")).toBeTruthy();
+  });
+
+  it("shows error when getKeyBundle fails", async () => {
+    mockGetKeyBundle.mockRejectedValue(new Error("Network error"));
+    const { findByText } = render(<SafetyNumberModal {...defaultProps} />);
+    expect(
+      await findByText("Impossible de calculer le Safety Number."),
+    ).toBeTruthy();
+  });
+
+  it("calls onClose when close button pressed", async () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(
+      <SafetyNumberModal {...defaultProps} onClose={onClose} />,
+    );
+    await waitFor(() => expect(mockComputeSafetyNumber).toHaveBeenCalled());
+    await act(async () => {
+      fireEvent.press(getByTestId("safety-close-btn"));
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("marks contact as verified and calls onVerified", async () => {
+    const onVerified = jest.fn();
+    const onClose = jest.fn();
+    mockSetItem.mockResolvedValue(undefined);
+    const { findByText } = render(
+      <SafetyNumberModal
+        {...defaultProps}
+        onVerified={onVerified}
+        onClose={onClose}
+      />,
+    );
+    const btn = await findByText("Marquer comme vérifié");
+    await act(async () => {
+      fireEvent.press(btn);
+    });
+    expect(mockSetItem).toHaveBeenCalledWith(
+      "@whispr:safety:user-a:user-b",
+      "verified",
+    );
+    expect(onVerified).toHaveBeenCalledWith("user-b");
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/screens/Chat/ConversationsListScreen.tsx
+++ b/src/screens/Chat/ConversationsListScreen.tsx
@@ -78,6 +78,10 @@ import { BellIcon } from "../../components/Common/BellIcon";
 import { InboxPanel } from "../../components/Common/InboxPanel";
 import { SafariPWABanner } from "../../components/Common/SafariPWABanner";
 import { useInboxStore } from "../../store/inboxStore";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { SafetyNumberModal } from "../../components/Chat/SafetyNumberModal";
+
+const SAFETY_STORAGE_PREFIX = "@whispr:safety:";
 
 type NavigationProp = StackNavigationProp<AuthStackParamList, "Chat">;
 
@@ -217,6 +221,13 @@ export const ConversationsListScreen: React.FC = () => {
   const [messageSearchConvIds, setMessageSearchConvIds] = useState<Set<string>>(
     new Set(),
   );
+  const [verifiedContacts, setVerifiedContacts] = useState<
+    Record<string, boolean>
+  >({});
+  const [safetyModalTarget, setSafetyModalTarget] = useState<{
+    contactUserId: string;
+    contactName: string;
+  } | null>(null);
   const { getThemeColors } = useTheme();
   const themeColors = getThemeColors();
 
@@ -318,6 +329,27 @@ export const ConversationsListScreen: React.FC = () => {
     fetchConversations();
     loadManuallyUnreadIds();
   }, [fetchConversations, loadManuallyUnreadIds, userId]);
+
+  useEffect(() => {
+    if (!userId) return;
+    const prefix = `${SAFETY_STORAGE_PREFIX}${userId}:`;
+    AsyncStorage.getAllKeys()
+      .then((keys) => {
+        const safetyKeys = (keys as string[]).filter((k) =>
+          k.startsWith(prefix),
+        );
+        return AsyncStorage.multiGet(safetyKeys);
+      })
+      .then((pairs) => {
+        const map: Record<string, boolean> = {};
+        for (const [key, value] of pairs as [string, string | null][]) {
+          const contactId = key.slice(prefix.length);
+          if (contactId && value === "verified") map[contactId] = true;
+        }
+        setVerifiedContacts(map);
+      })
+      .catch(() => undefined);
+  }, [userId]);
 
   // Refresh conversations when WebSocket reconnects to pick up messages
   // that were missed during the disconnection window
@@ -537,21 +569,46 @@ export const ConversationsListScreen: React.FC = () => {
     [pinConversation],
   );
 
+  const handleLongPress = useCallback(
+    (conversationId: string) => {
+      const conv = conversations.find((c) => c.id === conversationId);
+      if (!conv || conv.type !== "direct") return;
+      const contactId = conv.member_user_ids?.find((id) => id !== userId);
+      if (!contactId) return;
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+      setSafetyModalTarget({
+        contactUserId: contactId,
+        contactName: getConversationDisplayName(conv),
+      });
+    },
+    [conversations, userId],
+  );
+
   const renderItem = useCallback(
-    ({ item, index }: { item: Conversation; index: number }) => (
-      <SwipeableConversationItem
-        conversation={item}
-        onPress={handleConversationPress}
-        onDelete={handleDelete}
-        onMute={handleMute}
-        onToggleRead={handleToggleRead}
-        onArchive={handleArchive}
-        onPin={handlePin}
-        index={index}
-        editMode={editMode}
-        isSelected={selectedConversations.has(item.id)}
-      />
-    ),
+    ({ item, index }: { item: Conversation; index: number }) => {
+      const contactId =
+        item.type === "direct"
+          ? item.member_user_ids?.find((id) => id !== userId)
+          : undefined;
+      return (
+        <SwipeableConversationItem
+          conversation={item}
+          onPress={handleConversationPress}
+          onDelete={handleDelete}
+          onMute={handleMute}
+          onToggleRead={handleToggleRead}
+          onArchive={handleArchive}
+          onPin={handlePin}
+          onLongPress={item.type === "direct" ? handleLongPress : undefined}
+          index={index}
+          editMode={editMode}
+          isSelected={selectedConversations.has(item.id)}
+          isContactVerified={
+            contactId ? verifiedContacts[contactId] === true : false
+          }
+        />
+      );
+    },
     [
       handleConversationPress,
       handleDelete,
@@ -559,8 +616,11 @@ export const ConversationsListScreen: React.FC = () => {
       handleToggleRead,
       handleArchive,
       handlePin,
+      handleLongPress,
       editMode,
       selectedConversations,
+      verifiedContacts,
+      userId,
     ],
   );
 
@@ -823,6 +883,21 @@ export const ConversationsListScreen: React.FC = () => {
               onHide={() => setToast({ ...toast, visible: false })}
             />
           </SafeAreaView>
+
+          {safetyModalTarget && (
+            <SafetyNumberModal
+              visible={!!safetyModalTarget}
+              onClose={() => setSafetyModalTarget(null)}
+              contactUserId={safetyModalTarget.contactUserId}
+              contactName={safetyModalTarget.contactName}
+              onVerified={(contactUserId) => {
+                setVerifiedContacts((prev) => ({
+                  ...prev,
+                  [contactUserId]: true,
+                }));
+              }}
+            />
+          )}
 
           {editMode && (
             <View

--- a/src/services/E2EEService.ts
+++ b/src/services/E2EEService.ts
@@ -5,7 +5,11 @@ import {
   encodeBase64,
   encodeUTF8,
 } from "tweetnacl-util";
-import { getRandomBytes } from "expo-crypto";
+import {
+  getRandomBytes,
+  digestStringAsync,
+  CryptoDigestAlgorithm,
+} from "expo-crypto";
 import { Platform } from "react-native";
 import * as FileSystem from "expo-file-system/legacy";
 import { TokenService } from "./TokenService";
@@ -68,6 +72,46 @@ function concatBytes(...parts: Uint8Array[]): Uint8Array {
     offset += p.length;
   }
   return out;
+}
+
+function compareBytes(a: Uint8Array, b: Uint8Array): number {
+  const len = Math.min(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return a.length - b.length;
+}
+
+function bytesToHex(b: Uint8Array): string {
+  return Array.from(b, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export async function computeSafetyNumber(
+  myIdentityKey: string,
+  myUserId: string,
+  theirIdentityKey: string,
+  theirUserId: string,
+): Promise<string> {
+  const ikA = decodeBase64(myIdentityKey);
+  const ikB = decodeBase64(theirIdentityKey);
+  const aFirst = compareBytes(ikA, ikB) <= 0;
+  const orderedKeyHex = aFirst
+    ? bytesToHex(ikA) + bytesToHex(ikB)
+    : bytesToHex(ikB) + bytesToHex(ikA);
+  const idABytes = uuidToBytes(myUserId) ?? decodeUTF8(myUserId);
+  const idBBytes = uuidToBytes(theirUserId) ?? decodeUTF8(theirUserId);
+  const orderedIdHex = aFirst
+    ? bytesToHex(idABytes) + bytesToHex(idBBytes)
+    : bytesToHex(idBBytes) + bytesToHex(idABytes);
+  const hash = await digestStringAsync(
+    CryptoDigestAlgorithm.SHA256,
+    orderedKeyHex + orderedIdHex,
+  );
+  const decimal = BigInt("0x" + hash)
+    .toString(10)
+    .padStart(60, "0")
+    .slice(-60);
+  return (decimal.match(/.{1,5}/g) ?? []).join(" ");
 }
 
 function safeJsonParse(raw: string): unknown | null {


### PR DESCRIPTION
## Summary
- Implements spec §7.1 safety number algorithm: `SHA-256(ordered IKs || ordered userIds)` → 60 decimal digits in 12 groups of 5, computed purely client-side
- Long-pressing a direct conversation opens the Safety Number modal showing the 12-group grid and a "Marquer comme vérifié" button
- Verified contacts display a green lock icon next to their name in the conversations list
- Verification state is persisted in AsyncStorage under `@whispr:safety:{myUserId}:{contactUserId}`
- Fetches identity keys via existing `GET /signal/keys/:userId/devices/:deviceId` endpoint — no backend changes needed

## Test plan
- [x] Unit tests green (1438 passing, 153 suites)
- [x] Lint clean
- [x] `SafetyNumberModal` has 5 dedicated tests covering render, display, error, close, and verify flows
- [ ] Test on iOS simulator: long-press a direct conversation → modal opens with 12 groups
- [ ] Test on Android emulator: same
- [ ] Mark contact as verified → green lock appears in list, persists across app restart
- [ ] Verify web layout unaffected (@danger-zone-mobile-layout tag preserved)

Closes feat/safety-number-verification