### PR TITLE
fix(security): improve SafetyNumberModal error messages for missing Signal keys

### DIFF
--- a/src/components/Chat/SafetyNumberModal.tsx
+++ b/src/components/Chat/SafetyNumberModal.tsx
@@ -48,13 +48,30 @@ export const SafetyNumberModal: React.FC<SafetyNumberModalProps> = ({
 
     const storageKey = `${SAFETY_STORAGE_PREFIX}${userId}:${contactUserId}`;
 
-    Promise.all([
-      SignalKeysService.getKeyBundle(userId, deviceId),
-      SignalKeysService.listDevices(contactUserId).then((r) => {
+    const myBundlePromise = SignalKeysService.getKeyBundle(
+      userId,
+      deviceId,
+    ).catch(() => {
+      throw new Error("NO_OWN_KEYS");
+    });
+
+    const theirBundlePromise = SignalKeysService.listDevices(contactUserId)
+      .catch(() => {
+        throw new Error("NO_DEVICE");
+      })
+      .then((r) => {
         const firstDevice = r.deviceIds[0];
         if (!firstDevice) throw new Error("NO_DEVICE");
-        return SignalKeysService.getKeyBundle(contactUserId, firstDevice);
-      }),
+        return SignalKeysService.getKeyBundle(contactUserId, firstDevice).catch(
+          () => {
+            throw new Error("NO_THEIR_KEYS");
+          },
+        );
+      });
+
+    Promise.all([
+      myBundlePromise,
+      theirBundlePromise,
       AsyncStorage.getItem(storageKey),
     ])
       .then(([myBundle, theirBundle, stored]) => {
@@ -71,8 +88,19 @@ export const SafetyNumberModal: React.FC<SafetyNumberModalProps> = ({
         if (cancelled || !num) return;
         setSafetyNumber(num);
       })
-      .catch(() => {
-        if (!cancelled) setError("Impossible de calculer le Safety Number.");
+      .catch((err: Error) => {
+        if (cancelled) return;
+        if (err.message === "NO_DEVICE" || err.message === "NO_THEIR_KEYS") {
+          setError(
+            "Ce contact n'a pas encore de clés Signal enregistrées. Il doit se connecter au moins une fois depuis l'app.",
+          );
+        } else if (err.message === "NO_OWN_KEYS") {
+          setError(
+            "Vos clés Signal ne sont pas encore enregistrées. Reconnectez-vous.",
+          );
+        } else {
+          setError("Impossible de calculer le Safety Number.");
+        }
       })
       .finally(() => {
         if (!cancelled) setLoading(false);

--- a/src/components/Chat/__tests__/SafetyNumberModal.test.tsx
+++ b/src/components/Chat/__tests__/SafetyNumberModal.test.tsx
@@ -87,11 +87,26 @@ describe("SafetyNumberModal", () => {
     expect(await findByText("67890")).toBeTruthy();
   });
 
-  it("shows error when getKeyBundle fails", async () => {
+  it("shows error when own keys are missing", async () => {
     mockGetKeyBundle.mockRejectedValue(new Error("Network error"));
     const { findByText } = render(<SafetyNumberModal {...defaultProps} />);
     expect(
-      await findByText("Impossible de calculer le Safety Number."),
+      await findByText(
+        "Vos clés Signal ne sont pas encore enregistrées. Reconnectez-vous.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("shows error when contact has no Signal keys", async () => {
+    mockGetKeyBundle.mockImplementation((userId: string) => {
+      if (userId === "user-a") return Promise.resolve(MY_BUNDLE);
+      return Promise.reject(new Error("404"));
+    });
+    const { findByText } = render(<SafetyNumberModal {...defaultProps} />);
+    expect(
+      await findByText(
+        "Ce contact n'a pas encore de clés Signal enregistrées. Il doit se connecter au moins une fois depuis l'app.",
+      ),
     ).toBeTruthy();
   });
 


### PR DESCRIPTION
## Summary
- Distinguishes between 3 error cases instead of one generic message:
  - Contact has no devices / no Signal keys → "Ce contact n'a pas encore de clés Signal enregistrées..."
  - Own keys missing → "Vos clés Signal ne sont pas encore enregistrées. Reconnectez-vous."
  - Other network error → fallback message
- Adds a dedicated test case for each error scenario (6 tests total)

## Root cause
Gabriel Lopez had no Signal keys uploaded on the server, triggering the same generic catch as a network error.