### PR TITLE
feat(notifications): activer remote-notification iOS et ajouter tests APNS

### DIFF
--- a/app.json
+++ b/app.json
@@ -26,7 +26,7 @@
         "NSMicrophoneUsageDescription": "Whispr a besoin du micro pour les appels voix et video.",
         "NSCameraUsageDescription": "Whispr a besoin de la camera pour les appels video.",
         "NSContactsUsageDescription": "Whispr accede aux contacts pour trouver vos amis sur l'application.",
-        "UIBackgroundModes": ["voip", "audio"]
+        "UIBackgroundModes": ["voip", "audio", "remote-notification"]
       }
     },
     "android": {

--- a/src/services/__tests__/NotificationService.test.ts
+++ b/src/services/__tests__/NotificationService.test.ts
@@ -15,6 +15,22 @@ jest.mock("../apiBase", () =>
   ),
 );
 
+// expo-notifications est chargé dynamiquement via require() dans loadExpoNotifications()
+// - Platform.OS doit valoir "ios" ou "android" pour que le module soit chargé
+// - jest.mock ici intercepte le require() au runtime
+const mockGetPermissionsAsync = jest.fn();
+const mockRequestPermissionsAsync = jest.fn();
+const mockGetDevicePushTokenAsync = jest.fn();
+const mockAddPushTokenListener = jest.fn();
+jest.mock("expo-notifications", () => ({
+  getPermissionsAsync: (...args: any[]) => mockGetPermissionsAsync(...args),
+  requestPermissionsAsync: (...args: any[]) =>
+    mockRequestPermissionsAsync(...args),
+  getDevicePushTokenAsync: (...args: any[]) =>
+    mockGetDevicePushTokenAsync(...args),
+  addPushTokenListener: (...args: any[]) => mockAddPushTokenListener(...args),
+}));
+
 import { NotificationService } from "../NotificationService";
 import { TokenService } from "../TokenService";
 import { AuthService } from "../AuthService";
@@ -174,5 +190,160 @@ describe("NotificationService 401 retry & error handling", () => {
   it("falls back to 'HTTP <status>' when the error body has no message", async () => {
     mockFetch.mockResolvedValueOnce(mockResponse({ status: 503 }));
     await expect(NotificationService.getBadge()).rejects.toThrow("HTTP 503");
+  });
+});
+
+describe("NotificationService.initPushRegistration", () => {
+  const Platform = require("react-native").Platform;
+
+  beforeEach(() => {
+    Platform.OS = "ios";
+    mockGetPermissionsAsync.mockReset();
+    mockRequestPermissionsAsync.mockReset();
+    mockGetDevicePushTokenAsync.mockReset();
+    mockAddPushTokenListener.mockReset();
+    // listener stub retourne une subscription supprimable
+    mockAddPushTokenListener.mockReturnValue({ remove: jest.fn() });
+
+    const mockedDevice = require("../DeviceService").DeviceService as any;
+    mockedDevice.getOrCreateDeviceId.mockResolvedValue("dev-ios");
+  });
+
+  afterEach(() => {
+    // nettoyer le listener entre tests pour éviter les fuites d'état
+    NotificationService.tearDownPushRegistration();
+  });
+
+  it("demande la permission si elle n'est pas encore accordée, puis enregistre le token APNS", async () => {
+    mockGetPermissionsAsync.mockResolvedValue({ status: "undetermined" });
+    mockRequestPermissionsAsync.mockResolvedValue({ status: "granted" });
+    mockGetDevicePushTokenAsync.mockResolvedValue({
+      type: "ios",
+      data: "apns-token-abc123",
+    });
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 204 }));
+
+    await NotificationService.initPushRegistration("user-ios-1");
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://api.test/notification/api/v1/devices");
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body);
+    expect(body.fcm_token).toBe("apns-token-abc123");
+    expect(body.platform).toBe("ios");
+    expect(body.user_id).toBe("user-ios-1");
+  });
+
+  it("ne fait rien si la permission est refusée", async () => {
+    mockGetPermissionsAsync.mockResolvedValue({ status: "undetermined" });
+    mockRequestPermissionsAsync.mockResolvedValue({ status: "denied" });
+
+    await NotificationService.initPushRegistration("user-ios-2");
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockGetDevicePushTokenAsync).not.toHaveBeenCalled();
+  });
+
+  it("saute requestPermissionsAsync si la permission est déjà accordée", async () => {
+    mockGetPermissionsAsync.mockResolvedValue({ status: "granted" });
+    mockGetDevicePushTokenAsync.mockResolvedValue({
+      type: "ios",
+      data: "apns-token-xyz",
+    });
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 204 }));
+
+    await NotificationService.initPushRegistration("user-ios-3");
+
+    expect(mockRequestPermissionsAsync).not.toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("abonne un listener de rotation de token APNS", async () => {
+    mockGetPermissionsAsync.mockResolvedValue({ status: "granted" });
+    mockGetDevicePushTokenAsync.mockResolvedValue({
+      type: "ios",
+      data: "apns-token-init",
+    });
+    mockFetch.mockResolvedValue(mockResponse({ status: 204 }));
+
+    await NotificationService.initPushRegistration("user-ios-4");
+
+    expect(mockAddPushTokenListener).toHaveBeenCalledTimes(1);
+
+    // simule une rotation de token APNS
+    const rotationCallback = mockAddPushTokenListener.mock.calls[0][0];
+    rotationCallback({ type: "ios", data: "apns-token-rotated" });
+
+    // le callback déclenche une promesse fire-and-forget — on vide la file
+    // de microtâches en plusieurs passes pour laisser registerDevice() s'exécuter
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const rotatedBody = JSON.parse(mockFetch.mock.calls[1][1].body);
+    expect(rotatedBody.fcm_token).toBe("apns-token-rotated");
+  });
+
+  it("n'abonne pas un second listener si appelé deux fois (idempotent)", async () => {
+    mockGetPermissionsAsync.mockResolvedValue({ status: "granted" });
+    mockGetDevicePushTokenAsync.mockResolvedValue({
+      type: "ios",
+      data: "apns-token-a",
+    });
+    mockFetch.mockResolvedValue(mockResponse({ status: 204 }));
+
+    await NotificationService.initPushRegistration("user-ios-5");
+    await NotificationService.initPushRegistration("user-ios-5");
+
+    expect(mockAddPushTokenListener).toHaveBeenCalledTimes(1);
+  });
+
+  it("est no-op sur web (Platform.OS === 'web')", async () => {
+    Platform.OS = "web";
+
+    await NotificationService.initPushRegistration("user-web");
+
+    expect(mockGetPermissionsAsync).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("swallowe les erreurs réseau sans propager (best-effort)", async () => {
+    mockGetPermissionsAsync.mockResolvedValue({ status: "granted" });
+    mockGetDevicePushTokenAsync.mockRejectedValue(new Error("APNS indispo"));
+
+    await expect(
+      NotificationService.initPushRegistration("user-ios-6"),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("NotificationService.tearDownPushRegistration", () => {
+  const Platform = require("react-native").Platform;
+
+  beforeEach(() => {
+    Platform.OS = "ios";
+    mockGetPermissionsAsync.mockReset();
+    mockRequestPermissionsAsync.mockReset();
+    mockGetDevicePushTokenAsync.mockReset();
+    mockAddPushTokenListener.mockReset();
+  });
+
+  it("supprime le listener de rotation au logout", async () => {
+    const removeSub = jest.fn();
+    mockAddPushTokenListener.mockReturnValue({ remove: removeSub });
+    mockGetPermissionsAsync.mockResolvedValue({ status: "granted" });
+    mockGetDevicePushTokenAsync.mockResolvedValue({
+      type: "ios",
+      data: "apns-tok",
+    });
+    mockFetch.mockResolvedValue(mockResponse({ status: 204 }));
+
+    await NotificationService.initPushRegistration("user-logout");
+    NotificationService.tearDownPushRegistration();
+
+    expect(removeSub).toHaveBeenCalledTimes(1);
+  });
+
+  it("est sans effet si aucun listener n'est enregistré (idempotent)", () => {
+    expect(() => NotificationService.tearDownPushRegistration()).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- Ajoute `remote-notification` dans `UIBackgroundModes` (app.json) — manquant depuis WHISPR-1181, empêchait iOS de wakeup l'app en arrière-plan sur push APNS
- Ajoute 9 tests Jest pour `initPushRegistration` et `tearDownPushRegistration` : permission undetermined/denied/granted, rotation token APNS, idempotence listener, no-op sur web, swallow erreur réseau, cleanup au logout

## Test plan
- [x] 21 tests Jest verts (`npm test -- --watchAll=false --testPathPattern=NotificationService`)
- [x] TypeScript clean (`tsc --noEmit`)
- [x] Zéro console.log
- [ ] Build iOS natif à valider après WHISPR-1174 (clé .p8 Apple)

## Dépendance
WHISPR-1174 (clé .p8 Apple Developer) doit être créée manuellement par Tudy pour que le backend APNS envoie réellement — le code mobile est prêt et fonctionnel sans ça.

Closes WHISPR-1177