### PR TITLE
fix(ui): desactive boutons sans action + badge Bientot

### DIFF
--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1019,6 +1019,7 @@ const localizedTexts: Record<Language, Record<string, string>> = {
     "common.next": "Suivant",
     "common.retry": "Réessayer",
     "common.optional": "optionnel",
+    "common.soon": "Bientôt",
     "common.copyError": "Impossible de copier dans le presse-papiers.",
 
     // Confirmation forte (typed-confirm)
@@ -1367,6 +1368,7 @@ const localizedTexts: Record<Language, Record<string, string>> = {
     "common.next": "Next",
     "common.retry": "Retry",
     "common.optional": "optional",
+    "common.soon": "Soon",
     "common.copyError": "Unable to copy to clipboard.",
 
     // Strong confirmation (typed-confirm)

--- a/src/screens/Admin/AdminDemosScreen.tsx
+++ b/src/screens/Admin/AdminDemosScreen.tsx
@@ -3,8 +3,8 @@
  * Accessible uniquement aux administrateurs via AdminGate.
  *
  * Les deux modeles (Zeyou / Maya) ne sont pas encore implementes dans
- * moderation-service (seul NudeNet est en prod). Les boutons sont donc
- * des placeholders avec TODO explicite.
+ * moderation-service (seul NudeNet est en prod). Les boutons sont desactives
+ * en attendant l'integration - cf WHISPR-admin-demos.
  */
 
 import React from "react";
@@ -46,18 +46,6 @@ const DEMO_MODELS: DemoModel[] = [
 export const AdminDemosScreen: React.FC = () => {
   const navigation = useNavigation<any>();
 
-  // TODO(WHISPR-admin-demos): brancher sur les vrais endpoints moderation-service
-  // quand Zeyou et Maya seront deployes. Pour l'instant ces boutons sont des stubs.
-  const handleTestImage = (modelId: string) => {
-    console.log(`[AdminDemos] Test image - modele: ${modelId}`);
-    // TODO: ouvrir un picker image + appeler POST /moderation/demo/image?model=<modelId>
-  };
-
-  const handleTestText = (modelId: string) => {
-    console.log(`[AdminDemos] Test texte - modele: ${modelId}`);
-    // TODO: ouvrir une saisie texte + appeler POST /moderation/demo/text?model=<modelId>
-  };
-
   return (
     <LinearGradient
       colors={colors.background.gradient.app}
@@ -85,8 +73,8 @@ export const AdminDemosScreen: React.FC = () => {
             showsVerticalScrollIndicator={false}
           >
             <Text style={styles.intro}>
-              Demonstration des modeles de moderation IA pour les prospects. Les
-              boutons sont des placeholders en attente de l'integration backend.
+              Demonstration des modeles de moderation IA pour les prospects. L'integration
+              backend est en cours - les boutons seront actives a la livraison de Zeyou et Maya.
             </Text>
 
             {DEMO_MODELS.map((model) => (
@@ -102,36 +90,44 @@ export const AdminDemosScreen: React.FC = () => {
                     color={colors.primary.main}
                   />
                   <Text style={styles.cardTitle}>{model.title}</Text>
+                  <View style={styles.comingSoonBadge}>
+                    <Text style={styles.comingSoonText}>Bientôt</Text>
+                  </View>
                 </View>
 
                 <Text style={styles.cardDescription}>{model.description}</Text>
 
                 <View style={styles.buttonRow}>
                   <TouchableOpacity
-                    style={styles.demoButton}
-                    onPress={() => handleTestImage(model.id)}
-                    activeOpacity={0.7}
+                    style={[styles.demoButton, styles.demoButtonDisabled]}
+                    disabled={true}
+                    activeOpacity={1}
                     testID={`btn-image-${model.id}`}
+                    accessibilityState={{ disabled: true }}
+                    accessibilityHint="Disponible quand le modele sera deploye"
                   >
-                    <Ionicons name="image-outline" size={16} color="#FFFFFF" />
-                    <Text style={styles.demoButtonText}>Tester sur image</Text>
+                    <Ionicons name="image-outline" size={16} color="rgba(255,255,255,0.35)" />
+                    <Text style={[styles.demoButtonText, styles.demoButtonTextDisabled]}>Tester sur image</Text>
                   </TouchableOpacity>
 
                   <TouchableOpacity
-                    style={[styles.demoButton, styles.demoButtonSecondary]}
-                    onPress={() => handleTestText(model.id)}
-                    activeOpacity={0.7}
+                    style={[styles.demoButton, styles.demoButtonSecondary, styles.demoButtonDisabled]}
+                    disabled={true}
+                    activeOpacity={1}
                     testID={`btn-text-${model.id}`}
+                    accessibilityState={{ disabled: true }}
+                    accessibilityHint="Disponible quand le modele sera deploye"
                   >
                     <Ionicons
                       name="text-outline"
                       size={16}
-                      color="rgba(255,255,255,0.8)"
+                      color="rgba(255,255,255,0.25)"
                     />
                     <Text
                       style={[
                         styles.demoButtonText,
                         styles.demoButtonTextSecondary,
+                        styles.demoButtonTextDisabled,
                       ]}
                     >
                       Tester sur texte
@@ -230,6 +226,9 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: "rgba(255, 255, 255, 0.2)",
   },
+  demoButtonDisabled: {
+    opacity: 0.45,
+  },
   demoButtonText: {
     fontSize: 13,
     fontWeight: "600",
@@ -237,6 +236,23 @@ const styles = StyleSheet.create({
   },
   demoButtonTextSecondary: {
     color: "rgba(255, 255, 255, 0.8)",
+  },
+  demoButtonTextDisabled: {
+    color: "rgba(255, 255, 255, 0.35)",
+  },
+  comingSoonBadge: {
+    marginLeft: "auto",
+    backgroundColor: "rgba(255, 255, 255, 0.12)",
+    borderRadius: 10,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.2)",
+  },
+  comingSoonText: {
+    fontSize: 11,
+    color: "rgba(255, 255, 255, 0.6)",
+    fontWeight: "500",
   },
   bottomSpacer: {
     height: 40,

--- a/src/screens/Admin/__tests__/AdminDemosScreen.test.tsx
+++ b/src/screens/Admin/__tests__/AdminDemosScreen.test.tsx
@@ -28,12 +28,10 @@ jest.mock("../../../theme/colors", () => ({
   },
 }));
 
-// Mock moderationStore : isStaff = true pour le cas admin
 jest.mock("../../../store/moderationStore", () => ({
   useIsStaff: jest.fn(() => true),
 }));
 
-// Mock AdminGate : rend les enfants directement quand isStaff = true
 jest.mock("../../../components/Moderation", () => ({
   AdminGate: ({ children }: any) => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -60,11 +58,28 @@ describe("AdminDemosScreen", () => {
     });
   });
 
-  it("affiche les boutons placeholder pour chaque modele", async () => {
+  it("affiche les boutons desactives pour chaque modele", async () => {
+    const { getAllByTestId } = render(<AdminDemosScreen />);
+    await waitFor(() => {
+      const imageButtons = getAllByTestId(/^btn-image-/);
+      const textButtons = getAllByTestId(/^btn-text-/);
+      expect(imageButtons).toHaveLength(2);
+      expect(textButtons).toHaveLength(2);
+      // les boutons doivent etre desactives - pas encore integres backend
+      imageButtons.forEach((btn) => {
+        expect(btn.props.accessibilityState?.disabled).toBe(true);
+      });
+      textButtons.forEach((btn) => {
+        expect(btn.props.accessibilityState?.disabled).toBe(true);
+      });
+    });
+  });
+
+  it("affiche le badge Bientot sur chaque card", async () => {
     const { getAllByText } = render(<AdminDemosScreen />);
     await waitFor(() => {
-      expect(getAllByText("Tester sur image")).toHaveLength(2);
-      expect(getAllByText("Tester sur texte")).toHaveLength(2);
+      const badges = getAllByText("Bientôt");
+      expect(badges).toHaveLength(2);
     });
   });
 

--- a/src/screens/Settings/AboutContentScreen.tsx
+++ b/src/screens/Settings/AboutContentScreen.tsx
@@ -2,15 +2,13 @@
  * AboutContentScreen — contenu, securite, liens legaux et CTA signalement (WHISPR).
  */
 
-import React, { useCallback } from "react";
+import React from "react";
 import {
   View,
   Text,
   StyleSheet,
   ScrollView,
   TouchableOpacity,
-  Alert,
-  Platform,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { LinearGradient } from "expo-linear-gradient";
@@ -25,18 +23,6 @@ export const AboutContentScreen: React.FC = () => {
   const insets = useSafeAreaInsets();
   const { getThemeColors, getFontSize, getLocalizedText } = useTheme();
   const themeColors = getThemeColors();
-
-  const onReportPress = useCallback(() => {
-    if (Platform.OS === "web") {
-      window.alert(getLocalizedText("about.reportComingSoon"));
-      return;
-    }
-    Alert.alert(
-      getLocalizedText("about.reportContent"),
-      getLocalizedText("about.reportComingSoon"),
-      [{ text: getLocalizedText("common.ok") }],
-    );
-  }, [getLocalizedText]);
 
   const bodyStyle = [
     styles.bodyText,
@@ -247,11 +233,13 @@ export const AboutContentScreen: React.FC = () => {
           <TouchableOpacity
             style={[
               styles.reportButton,
-              { backgroundColor: themeColors.primary },
+              { backgroundColor: themeColors.primary, opacity: 0.45 },
             ]}
-            onPress={onReportPress}
+            disabled={true}
             accessibilityRole="button"
+            accessibilityState={{ disabled: true }}
             accessibilityHint={getLocalizedText("about.reportComingSoon")}
+            testID="btn-report-content"
           >
             <Ionicons name="flag-outline" size={22} color="#FFFFFF" />
             <Text
@@ -262,6 +250,11 @@ export const AboutContentScreen: React.FC = () => {
             >
               {getLocalizedText("about.reportContent")}
             </Text>
+            <View style={styles.reportComingSoonBadge}>
+              <Text style={styles.reportComingSoonText}>
+                {getLocalizedText("common.soon")}
+              </Text>
+            </View>
           </TouchableOpacity>
         </View>
       </ScrollView>
@@ -324,6 +317,19 @@ const styles = StyleSheet.create({
   reportButtonLabel: {
     color: "#FFFFFF",
     fontWeight: "700",
+  },
+  reportComingSoonBadge: {
+    position: "absolute",
+    right: 14,
+    backgroundColor: "rgba(255,255,255,0.18)",
+    borderRadius: 10,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+  },
+  reportComingSoonText: {
+    color: "rgba(255,255,255,0.85)",
+    fontSize: 11,
+    fontWeight: "600",
   },
 });
 

--- a/src/screens/Settings/__tests__/AboutContentScreen.test.tsx
+++ b/src/screens/Settings/__tests__/AboutContentScreen.test.tsx
@@ -65,4 +65,19 @@ describe("AboutContentScreen", () => {
     fireEvent.press(getByLabelText("about.testImageAnalysis"));
     expect(mockNavigate).toHaveBeenCalledWith("ModerationTest");
   });
+
+  it("le bouton Signaler est desactive - pas de navigation ni Alert", () => {
+    const { getByTestId } = render(<AboutContentScreen />);
+    const reportBtn = getByTestId("btn-report-content");
+    // accessibilityState.disabled doit etre true
+    expect(reportBtn.props.accessibilityState?.disabled).toBe(true);
+    // presser le bouton desactive ne doit pas appeler navigate
+    fireEvent.press(reportBtn);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("affiche le badge soon sur le bouton Signaler", () => {
+    const { getByText } = render(<AboutContentScreen />);
+    expect(getByText("common.soon")).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary
- AdminDemosScreen: boutons Tester image/texte (Zeyou, Maya) desactives avec badge Bientot - le backend moderation-service n'expose pas encore ces endpoints
- AboutContentScreen: bouton Signaler desactive + badge Soon - supprime l'Alert \"coming soon\" qui pretendait faire quelque chose sans rien faire
- ThemeContext: cle \`common.soon\` ajoutee en FR et EN
- Tests: 2 nouveaux asserts sur \`accessibilityState.disabled\` pour les boutons concernes

## Test plan
- [x] Tests unitaires verts (12/12)
- [x] TypeScript clean (\`tsc --noEmit\`)
- [x] Lint 0 erreur
- [x] Pas de console.log ni TODO dans le diff

Closes WHISPR-dead-buttons-audit