### PR TITLE
fix(auth): 2FA bypass, backup code login, identity key preservation

### DIFF
--- a/src/navigation/AuthNavigator.tsx
+++ b/src/navigation/AuthNavigator.tsx
@@ -108,6 +108,11 @@ export type AuthStackParamList = {
   TwoFactorSetup: undefined;
   TwoFactorVerify: { secret: string };
   TwoFactorBackupCodes: { codes: string[] };
+  TwoFactorVerifyLogin: {
+    verificationId: string;
+    deviceInfo: import("../types/auth").DeviceInfo;
+    signalKeyBundle: import("../types/auth").SignalKeyBundleDto;
+  };
   RecoveryCodes: undefined;
   RecoveryCodeEntry: undefined;
   ConversationsList: undefined;
@@ -456,6 +461,14 @@ export const AuthNavigator: React.FC = () => {
         <Stack.Screen
           name="TwoFactorBackupCodes"
           component={TwoFactorBackupCodesScreen}
+          options={{ gestureEnabled: false }}
+        />
+        <Stack.Screen
+          name="TwoFactorVerifyLogin"
+          getComponent={() =>
+            require("../screens/Auth/TwoFactorVerifyLoginScreen")
+              .TwoFactorVerifyLoginScreen
+          }
           options={{ gestureEnabled: false }}
         />
         <Stack.Screen

--- a/src/screens/Auth/OtpScreen.tsx
+++ b/src/screens/Auth/OtpScreen.tsx
@@ -22,6 +22,7 @@ import { AuthService } from "../../services/AuthService";
 import { TokenService } from "../../services/TokenService";
 import { SignalKeyService } from "../../services/SignalKeyService";
 import { SignalKeysService } from "../../services/SecurityService";
+import { DeviceService } from "../../services/DeviceService";
 import { UserService } from "../../services/UserService";
 import { colors, spacing, typography } from "../../theme";
 import type { AuthStackParamList } from "../../navigation/AuthNavigator";
@@ -171,6 +172,23 @@ export const OtpScreen: React.FC = () => {
         if (!confirmResult.verified) {
           setError(getLocalizedText("auth.codeIncorrect"));
           shake();
+          setLoading(false);
+          submittingRef.current = false;
+          return;
+        }
+
+        // Si le compte a la 2FA activée, préparer les clés et rediriger
+        // vers l'écran de vérification TOTP / backup code avant le login.
+        if (confirmResult.requires2FA) {
+          const [deviceInfo, signalKeyBundle] = await Promise.all([
+            DeviceService.getDeviceInfo(),
+            SignalKeyService.generateKeyBundle("login"),
+          ]);
+          navigation.navigate("TwoFactorVerifyLogin", {
+            verificationId,
+            deviceInfo,
+            signalKeyBundle,
+          });
           setLoading(false);
           submittingRef.current = false;
           return;

--- a/src/screens/Auth/TwoFactorVerifyLoginScreen.tsx
+++ b/src/screens/Auth/TwoFactorVerifyLoginScreen.tsx
@@ -1,0 +1,486 @@
+import React, { useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  Animated,
+  View,
+} from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import { useNavigation, useRoute } from "@react-navigation/native";
+import type { RouteProp } from "@react-navigation/native";
+import type { StackNavigationProp } from "@react-navigation/stack";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "../../context/ThemeContext";
+import { useAuth } from "../../context/AuthContext";
+import { AuthService } from "../../services/AuthService";
+import { TwoFactorService } from "../../services/TwoFactorService";
+import { TokenService } from "../../services/TokenService";
+import { UserService } from "../../services/UserService";
+import Toast from "../../components/Toast/Toast";
+import type { AuthStackParamList } from "../../navigation/AuthNavigator";
+
+type NavigationProp = StackNavigationProp<
+  AuthStackParamList,
+  "TwoFactorVerifyLogin"
+>;
+type RoutePropType = RouteProp<AuthStackParamList, "TwoFactorVerifyLogin">;
+
+type Tab = "totp" | "backup";
+
+export const TwoFactorVerifyLoginScreen: React.FC = () => {
+  const navigation = useNavigation<NavigationProp>();
+  const route = useRoute<RoutePropType>();
+  const { verificationId, deviceInfo, signalKeyBundle } = route.params;
+
+  const { getThemeColors, getFontSize, getLocalizedText } = useTheme();
+  const themeColors = getThemeColors();
+  const { signIn } = useAuth();
+
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+  const slideAnim = useRef(new Animated.Value(30)).current;
+
+  const [tab, setTab] = useState<Tab>("totp");
+  const [totpCode, setTotpCode] = useState("");
+  const [backupCode, setBackupCode] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [toast, setToast] = useState<{
+    visible: boolean;
+    message: string;
+    type: "success" | "error" | "info" | "warning";
+  }>({ visible: false, message: "", type: "info" });
+
+  const showToast = (
+    message: string,
+    type: "success" | "error" | "info" | "warning" = "error",
+  ) => {
+    setToast({ visible: true, message, type });
+  };
+
+  useEffect(() => {
+    Animated.parallel([
+      Animated.timing(fadeAnim, {
+        toValue: 1,
+        duration: 600,
+        useNativeDriver: true,
+      }),
+      Animated.timing(slideAnim, {
+        toValue: 0,
+        duration: 600,
+        useNativeDriver: true,
+      }),
+    ]).start();
+  }, []);
+
+  const finishLogin = async (tokens: {
+    accessToken: string;
+    refreshToken: string;
+  }) => {
+    await TokenService.saveTokens(tokens);
+    const payload = TokenService.decodeAccessToken(tokens.accessToken);
+    if (!payload) throw new Error("Invalid token");
+    signIn(payload.sub, payload.deviceId);
+    await UserService.getInstance().bootstrapAccount(payload.sub, "");
+    navigation.reset({ index: 0, routes: [{ name: "ConversationsList" }] });
+  };
+
+  const handleTotpSubmit = async () => {
+    if (totpCode.length < 6) {
+      showToast(getLocalizedText("twoFactor.invalidCode"));
+      return;
+    }
+    setLoading(true);
+    try {
+      const tokens = await AuthService.loginAfter2FA(
+        verificationId,
+        totpCode,
+        deviceInfo,
+        signalKeyBundle,
+      );
+      await finishLogin(tokens);
+    } catch (err) {
+      const status = (err as { status?: number })?.status;
+      const msg =
+        status === 400 || status === 401
+          ? getLocalizedText("twoFactor.invalidCode")
+          : getLocalizedText("auth.errorConnection");
+      showToast(msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleBackupSubmit = async () => {
+    const trimmed = backupCode.replace(/\s/g, "");
+    if (trimmed.length < 8) {
+      showToast(getLocalizedText("twoFactor.invalidCode"));
+      return;
+    }
+    setLoading(true);
+    try {
+      const tokens = await TwoFactorService.useBackupCode(
+        trimmed,
+        verificationId,
+      );
+      await finishLogin(tokens);
+    } catch (err) {
+      const status = (err as { status?: number })?.status;
+      const msg =
+        status === 400 || status === 401
+          ? getLocalizedText("twoFactor.invalidCode")
+          : getLocalizedText("auth.errorConnection");
+      showToast(msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const accentColor = themeColors.primary;
+
+  return (
+    <LinearGradient
+      colors={themeColors.background.gradient as any}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 1 }}
+      style={styles.container}
+    >
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+      >
+        <Animated.View
+          style={[
+            styles.flex,
+            { opacity: fadeAnim, transform: [{ translateY: slideAnim }] },
+          ]}
+        >
+          <ScrollView
+            style={styles.flex}
+            contentContainerStyle={styles.scrollContent}
+            showsVerticalScrollIndicator={false}
+            keyboardShouldPersistTaps="handled"
+          >
+            {/* Header */}
+            <View style={styles.header}>
+              <TouchableOpacity
+                style={[
+                  styles.backButton,
+                  { backgroundColor: themeColors.background.secondary + "80" },
+                ]}
+                onPress={() => navigation.goBack()}
+                accessibilityRole="button"
+                accessibilityLabel="Retour"
+              >
+                <Ionicons
+                  name="arrow-back"
+                  size={22}
+                  color={themeColors.text.primary}
+                />
+              </TouchableOpacity>
+              <View style={styles.headerText}>
+                <Text
+                  style={[
+                    styles.title,
+                    {
+                      color: themeColors.text.primary,
+                      fontSize: getFontSize("xxl"),
+                    },
+                  ]}
+                >
+                  {getLocalizedText("twoFactor.loginTitle")}
+                </Text>
+                <Text
+                  style={[
+                    styles.subtitle,
+                    {
+                      color: themeColors.text.secondary,
+                      fontSize: getFontSize("sm"),
+                    },
+                  ]}
+                >
+                  {getLocalizedText("twoFactor.loginSubtitle")}
+                </Text>
+              </View>
+            </View>
+
+            {/* Onglets */}
+            <View
+              style={[
+                styles.tabRow,
+                { backgroundColor: themeColors.background.secondary },
+              ]}
+            >
+              <TouchableOpacity
+                style={[
+                  styles.tab,
+                  tab === "totp" && {
+                    backgroundColor: accentColor + "30",
+                    borderBottomWidth: 2,
+                    borderBottomColor: accentColor,
+                  },
+                ]}
+                onPress={() => setTab("totp")}
+                accessibilityRole="tab"
+                accessibilityState={{ selected: tab === "totp" }}
+              >
+                <Text
+                  style={[
+                    styles.tabText,
+                    {
+                      color:
+                        tab === "totp"
+                          ? accentColor
+                          : themeColors.text.secondary,
+                      fontSize: getFontSize("sm"),
+                    },
+                  ]}
+                >
+                  {getLocalizedText("twoFactor.tabTotp")}
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[
+                  styles.tab,
+                  tab === "backup" && {
+                    backgroundColor: accentColor + "30",
+                    borderBottomWidth: 2,
+                    borderBottomColor: accentColor,
+                  },
+                ]}
+                onPress={() => setTab("backup")}
+                accessibilityRole="tab"
+                accessibilityState={{ selected: tab === "backup" }}
+              >
+                <Text
+                  style={[
+                    styles.tabText,
+                    {
+                      color:
+                        tab === "backup"
+                          ? accentColor
+                          : themeColors.text.secondary,
+                      fontSize: getFontSize("sm"),
+                    },
+                  ]}
+                >
+                  {getLocalizedText("twoFactor.tabBackupCode")}
+                </Text>
+              </TouchableOpacity>
+            </View>
+
+            {/* TOTP */}
+            {tab === "totp" && (
+              <View style={styles.section}>
+                <Text
+                  style={[
+                    styles.inputLabel,
+                    {
+                      color: themeColors.text.secondary,
+                      fontSize: getFontSize("sm"),
+                    },
+                  ]}
+                >
+                  {getLocalizedText("twoFactor.enterTotpCode")}
+                </Text>
+                <TextInput
+                  style={[
+                    styles.codeInput,
+                    {
+                      backgroundColor: themeColors.background.secondary,
+                      color: themeColors.text.primary,
+                      borderColor: accentColor + "40",
+                      fontSize: getFontSize("xl"),
+                    },
+                  ]}
+                  value={totpCode}
+                  onChangeText={setTotpCode}
+                  placeholder="000000"
+                  placeholderTextColor={themeColors.text.secondary + "80"}
+                  maxLength={6}
+                  keyboardType="number-pad"
+                  autoFocus={tab === "totp"}
+                  accessibilityLabel={getLocalizedText(
+                    "twoFactor.enterTotpCode",
+                  )}
+                />
+                <TouchableOpacity
+                  onPress={handleTotpSubmit}
+                  disabled={loading}
+                  activeOpacity={0.85}
+                  accessibilityRole="button"
+                >
+                  <LinearGradient
+                    colors={[accentColor, accentColor + "CC"]}
+                    start={{ x: 0, y: 0 }}
+                    end={{ x: 1, y: 0 }}
+                    style={styles.submitButton}
+                  >
+                    {loading ? (
+                      <ActivityIndicator size="small" color="#FFFFFF" />
+                    ) : (
+                      <Text
+                        style={[
+                          styles.submitButtonText,
+                          { fontSize: getFontSize("base") },
+                        ]}
+                      >
+                        {getLocalizedText("auth.continue")}
+                      </Text>
+                    )}
+                  </LinearGradient>
+                </TouchableOpacity>
+              </View>
+            )}
+
+            {/* Backup code */}
+            {tab === "backup" && (
+              <View style={styles.section}>
+                <Text
+                  style={[
+                    styles.inputLabel,
+                    {
+                      color: themeColors.text.secondary,
+                      fontSize: getFontSize("sm"),
+                    },
+                  ]}
+                >
+                  {getLocalizedText("twoFactor.enterBackupCode")}
+                </Text>
+                <TextInput
+                  style={[
+                    styles.codeInput,
+                    {
+                      backgroundColor: themeColors.background.secondary,
+                      color: themeColors.text.primary,
+                      borderColor: accentColor + "40",
+                      fontSize: getFontSize("base"),
+                      letterSpacing: 2,
+                    },
+                  ]}
+                  value={backupCode}
+                  onChangeText={setBackupCode}
+                  placeholder="XXXX-XXXX-XXXX-XXXX"
+                  placeholderTextColor={themeColors.text.secondary + "80"}
+                  maxLength={19}
+                  autoCapitalize="characters"
+                  autoFocus={tab === "backup"}
+                  accessibilityLabel={getLocalizedText(
+                    "twoFactor.enterBackupCode",
+                  )}
+                />
+                <TouchableOpacity
+                  onPress={handleBackupSubmit}
+                  disabled={loading}
+                  activeOpacity={0.85}
+                  accessibilityRole="button"
+                >
+                  <LinearGradient
+                    colors={[accentColor, accentColor + "CC"]}
+                    start={{ x: 0, y: 0 }}
+                    end={{ x: 1, y: 0 }}
+                    style={styles.submitButton}
+                  >
+                    {loading ? (
+                      <ActivityIndicator size="small" color="#FFFFFF" />
+                    ) : (
+                      <Text
+                        style={[
+                          styles.submitButtonText,
+                          { fontSize: getFontSize("base") },
+                        ]}
+                      >
+                        {getLocalizedText("auth.continue")}
+                      </Text>
+                    )}
+                  </LinearGradient>
+                </TouchableOpacity>
+              </View>
+            )}
+          </ScrollView>
+        </Animated.View>
+      </KeyboardAvoidingView>
+
+      <Toast
+        visible={toast.visible}
+        message={toast.message}
+        type={toast.type}
+        duration={3500}
+        onHide={() => setToast((prev) => ({ ...prev, visible: false }))}
+      />
+    </LinearGradient>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  flex: { flex: 1 },
+  scrollContent: { paddingBottom: 48 },
+  header: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    paddingHorizontal: 20,
+    paddingTop: 60,
+    paddingBottom: 24,
+    gap: 12,
+  },
+  backButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: "center",
+    justifyContent: "center",
+    ...Platform.select({
+      ios: {
+        shadowColor: "#000",
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.1,
+        shadowRadius: 4,
+      },
+      android: { elevation: 2 },
+    }),
+  },
+  headerText: { flex: 1, gap: 4 },
+  title: { fontWeight: "800" },
+  subtitle: { opacity: 0.8 },
+  tabRow: {
+    flexDirection: "row",
+    marginHorizontal: 20,
+    borderRadius: 12,
+    overflow: "hidden",
+    marginBottom: 24,
+  },
+  tab: {
+    flex: 1,
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  tabText: { fontWeight: "600" },
+  section: { paddingHorizontal: 20 },
+  inputLabel: { marginBottom: 8 },
+  codeInput: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingVertical: 16,
+    paddingHorizontal: 20,
+    textAlign: "center",
+    fontFamily: Platform.OS === "ios" ? "Menlo" : "monospace",
+    marginBottom: 20,
+  },
+  submitButton: {
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 16,
+    borderRadius: 14,
+  },
+  submitButtonText: {
+    color: "#FFFFFF",
+    fontWeight: "600",
+  },
+});
+
+export default TwoFactorVerifyLoginScreen;

--- a/src/screens/Auth/__tests__/OtpScreen.test.tsx
+++ b/src/screens/Auth/__tests__/OtpScreen.test.tsx
@@ -84,6 +84,18 @@ jest.mock("../../../services/SignalKeyService", () => ({
     }),
   },
 }));
+jest.mock("../../../services/DeviceService", () => ({
+  DeviceService: {
+    getDeviceInfo: jest.fn().mockResolvedValue({
+      deviceId: "dev1",
+      deviceName: "iPhone",
+      deviceType: "mobile",
+      model: "iPhone14",
+      osVersion: "17.0",
+      appVersion: "1.0.0",
+    }),
+  },
+}));
 jest.mock("../../../services/SecurityService", () => ({
   SignalKeysService: {
     uploadSignedPrekey: jest.fn().mockResolvedValue({}),
@@ -168,5 +180,60 @@ describe("OtpScreen", () => {
       },
       { timeout: 8000 },
     );
+  }, 10000);
+
+
+  it("navigue vers TwoFactorVerifyLogin quand requires2FA est true", async () => {
+    mockedAuthService.confirmVerification.mockResolvedValue({
+      verified: true,
+      requires2FA: true,
+    });
+
+    const { getAllByDisplayValue } = render(<OtpScreen />);
+
+    await act(async () => {
+      fireEvent.changeText(getAllByDisplayValue("")[0], "123456");
+    });
+
+    await waitFor(
+      () => {
+        expect(mockNavigate).toHaveBeenCalledWith(
+          "TwoFactorVerifyLogin",
+          expect.objectContaining({ verificationId: "vid123" }),
+        );
+      },
+      { timeout: 8000 },
+    );
+    // login ne doit PAS être appelé
+    expect(mockedAuthService.login).not.toHaveBeenCalled();
+  }, 10000);
+
+  it("flow normal login quand requires2FA est absent", async () => {
+    mockedAuthService.confirmVerification.mockResolvedValue({ verified: true });
+    mockedAuthService.login.mockResolvedValue({
+      accessToken: "tok",
+      refreshToken: "ref",
+    });
+    mockedTokenService.decodeAccessToken.mockReturnValue({
+      sub: "user1",
+      deviceId: "dev1",
+    } as any);
+
+    const { getAllByDisplayValue } = render(<OtpScreen />);
+
+    await act(async () => {
+      fireEvent.changeText(getAllByDisplayValue("")[0], "123456");
+    });
+
+    await waitFor(
+      () => {
+        expect(mockReset).toHaveBeenCalledWith({
+          index: 0,
+          routes: [{ name: "ConversationsList" }],
+        });
+      },
+      { timeout: 8000 },
+    );
+    expect(mockNavigate).not.toHaveBeenCalledWith("TwoFactorVerifyLogin", expect.anything());
   }, 10000);
 });

--- a/src/screens/Auth/__tests__/TwoFactorVerifyLoginScreen.test.tsx
+++ b/src/screens/Auth/__tests__/TwoFactorVerifyLoginScreen.test.tsx
@@ -1,0 +1,206 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from "react";
+import { render, fireEvent, waitFor, act } from "@testing-library/react-native";
+import { TwoFactorVerifyLoginScreen } from "../TwoFactorVerifyLoginScreen";
+import { AuthService } from "../../../services/AuthService";
+import { TwoFactorService } from "../../../services/TwoFactorService";
+import { TokenService } from "../../../services/TokenService";
+
+const mockReset = jest.fn();
+const mockGoBack = jest.fn();
+const mockSignIn = jest.fn();
+
+const ROUTE_PARAMS = {
+  verificationId: "vid-abc",
+  deviceInfo: {
+    deviceId: "dev1",
+    deviceName: "iPhone",
+    deviceType: "mobile",
+    model: "iPhone14",
+    osVersion: "17.0",
+    appVersion: "1.0.0",
+  },
+  signalKeyBundle: {
+    identityKey: "idkey",
+    signedPreKey: { keyId: 1, publicKey: "spk", signature: "sig" },
+    preKeys: [],
+  },
+};
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({
+    goBack: mockGoBack,
+    reset: mockReset,
+    navigate: jest.fn(),
+  }),
+  useRoute: () => ({ params: ROUTE_PARAMS }),
+}));
+jest.mock("expo-linear-gradient", () => ({
+  LinearGradient: ({ children }: any) => children,
+}));
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+jest.mock("../../../context/ThemeContext", () => ({
+  useTheme: () => ({
+    getThemeColors: () => ({
+      background: {
+        gradient: ["#000", "#111"],
+        primary: "#000",
+        secondary: "#111",
+      },
+      text: { primary: "#fff", secondary: "#aaa", tertiary: "#555" },
+      primary: "#6200ee",
+    }),
+    getFontSize: () => 16,
+    getLocalizedText: (key: string) => key,
+  }),
+}));
+jest.mock("../../../context/AuthContext", () => ({
+  useAuth: () => ({
+    isAuthenticated: false,
+    isLoading: false,
+    userId: null,
+    deviceId: null,
+    signIn: mockSignIn,
+    signOut: jest.fn(),
+  }),
+}));
+jest.mock("../../../services/AuthService", () => ({
+  AuthService: {
+    loginAfter2FA: jest.fn(),
+  },
+}));
+jest.mock("../../../services/TwoFactorService", () => ({
+  TwoFactorService: {
+    useBackupCode: jest.fn(),
+  },
+}));
+jest.mock("../../../services/TokenService", () => ({
+  TokenService: {
+    saveTokens: jest.fn().mockResolvedValue(undefined),
+    decodeAccessToken: jest.fn(),
+  },
+}));
+jest.mock("../../../services/UserService", () => ({
+  UserService: {
+    getInstance: () => ({
+      bootstrapAccount: jest.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+jest.mock("../../../components/Toast/Toast", () => {
+  const { View } = require("react-native");
+  return ({ visible }: any) => (visible ? <View testID="toast" /> : null);
+});
+
+const mockedAuth = AuthService as jest.Mocked<typeof AuthService>;
+const mockedTwoFactor = TwoFactorService as jest.Mocked<typeof TwoFactorService>;
+const mockedToken = TokenService as jest.Mocked<typeof TokenService>;
+
+describe("TwoFactorVerifyLoginScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedToken.decodeAccessToken.mockReturnValue({
+      sub: "user1",
+      deviceId: "dev1",
+    } as any);
+    mockedToken.saveTokens.mockResolvedValue(undefined);
+  });
+
+  it("affiche les deux onglets TOTP et backup code", () => {
+    const { getByText } = render(<TwoFactorVerifyLoginScreen />);
+    expect(getByText("twoFactor.tabTotp")).toBeTruthy();
+    expect(getByText("twoFactor.tabBackupCode")).toBeTruthy();
+  });
+
+  it("appelle loginAfter2FA avec le bon code TOTP et navigue vers ConversationsList", async () => {
+    mockedAuth.loginAfter2FA.mockResolvedValue({
+      accessToken: "at",
+      refreshToken: "rt",
+    });
+
+    const { getByText, getByPlaceholderText } = render(
+      <TwoFactorVerifyLoginScreen />,
+    );
+
+    await act(async () => {
+      fireEvent.changeText(getByPlaceholderText("000000"), "123456");
+    });
+
+    await act(async () => {
+      fireEvent.press(getByText("auth.continue"));
+    });
+
+    await waitFor(() => {
+      expect(mockedAuth.loginAfter2FA).toHaveBeenCalledWith(
+        ROUTE_PARAMS.verificationId,
+        "123456",
+        ROUTE_PARAMS.deviceInfo,
+        ROUTE_PARAMS.signalKeyBundle,
+      );
+      expect(mockReset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: "ConversationsList" }],
+      });
+    });
+  });
+
+  it("appelle useBackupCode depuis l'onglet backup code et navigue", async () => {
+    mockedTwoFactor.useBackupCode.mockResolvedValue({
+      accessToken: "at2",
+      refreshToken: "rt2",
+    });
+
+    const { getByText, getByPlaceholderText } = render(
+      <TwoFactorVerifyLoginScreen />,
+    );
+
+    // Switcher sur l'onglet backup
+    await act(async () => {
+      fireEvent.press(getByText("twoFactor.tabBackupCode"));
+    });
+
+    await act(async () => {
+      fireEvent.changeText(
+        getByPlaceholderText("XXXX-XXXX-XXXX-XXXX"),
+        "ABCD-1234-EFGH",
+      );
+    });
+
+    await act(async () => {
+      fireEvent.press(getByText("auth.continue"));
+    });
+
+    await waitFor(() => {
+      expect(mockedTwoFactor.useBackupCode).toHaveBeenCalledWith(
+        "ABCD-1234-EFGH",
+        ROUTE_PARAMS.verificationId,
+      );
+      expect(mockReset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: "ConversationsList" }],
+      });
+    });
+  });
+
+  it("affiche une erreur toast quand loginAfter2FA retourne 401", async () => {
+    const err = Object.assign(new Error("unauthorized"), { status: 401 });
+    mockedAuth.loginAfter2FA.mockRejectedValue(err);
+
+    const { getByText, getByPlaceholderText, findByTestId } = render(
+      <TwoFactorVerifyLoginScreen />,
+    );
+
+    await act(async () => {
+      fireEvent.changeText(getByPlaceholderText("000000"), "000000");
+    });
+    await act(async () => {
+      fireEvent.press(getByText("auth.continue"));
+    });
+
+    const toast = await findByTestId("toast");
+    expect(toast).toBeTruthy();
+    expect(mockReset).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -142,7 +142,7 @@ export const AuthService = {
   async login(verificationId: string): Promise<TokenPair> {
     const [deviceInfo, signalKeyBundle] = await Promise.all([
       DeviceService.getDeviceInfo(),
-      SignalKeyService.generateKeyBundle(),
+      SignalKeyService.generateKeyBundle("login"),
     ]);
 
     const tokens = await apiFetch<TokenPair>("/login", {
@@ -384,10 +384,40 @@ export const AuthService = {
     });
   },
 
+  // Appelé depuis TwoFactorVerifyLoginScreen après validation TOTP ou backup code.
+  // verificationId + signalKeyBundle + deviceInfo sont préparés dans OtpScreen
+  // et transmis via les paramètres de navigation pour éviter de les recalculer.
+  async loginAfter2FA(
+    verificationId: string,
+    twoFactorToken: string,
+    deviceInfo: import("../types/auth").DeviceInfo,
+    signalKeyBundle: import("../types/auth").SignalKeyBundleDto,
+  ): Promise<TokenPair> {
+    const tokens = await apiFetch<TokenPair>("/login/2fa", {
+      method: "POST",
+      body: JSON.stringify({
+        verificationId,
+        twoFactorToken,
+        ...deviceInfo,
+        signalKeyBundle,
+      }),
+    });
+
+    await TokenService.saveTokens(tokens);
+    resetSessionState();
+    const userId = TokenService.decodeAccessToken(tokens.accessToken)?.sub;
+    if (userId) {
+      notificationService()
+        .initPushRegistration(userId)
+        .catch(() => {});
+    }
+    return tokens;
+  },
+
   async redeemRecoveryCode(code: string): Promise<TokenPair> {
     const [deviceInfo, signalKeyBundle] = await Promise.all([
       DeviceService.getDeviceInfo(),
-      SignalKeyService.generateKeyBundle(),
+      SignalKeyService.generateKeyBundle("recovery"),
     ]);
 
     const tokens = await apiFetch<TokenPair>("/recovery-codes/redeem", {

--- a/src/services/SignalKeyService.ts
+++ b/src/services/SignalKeyService.ts
@@ -1,5 +1,5 @@
 import nacl from "tweetnacl";
-import { encodeBase64 } from "tweetnacl-util";
+import { encodeBase64, decodeBase64 } from "tweetnacl-util";
 import { getRandomBytes } from "expo-crypto";
 import { TokenService } from "./TokenService";
 import { generateClientRandom } from "../utils/crypto";
@@ -38,28 +38,60 @@ function toBase64(bytes: Uint8Array): string {
   return encodeBase64(bytes);
 }
 
+export type KeyBundleContext = "register" | "login" | "recovery";
+
+function deriveIdentityPublicKey(secretKey: Uint8Array): Uint8Array {
+  // La clé secrète NaCl box est 64 octets ; les 32 premiers sont la seed
+  // Curve25519, les 32 suivants sont la clé publique dérivée.
+  // On peut reconstruire la paire via fromSecretKey si l'implémentation
+  // le supporte, sinon on dérive manuellement via keyPair.fromSeed n'existe
+  // pas pour box. tweetnacl expose publicKey dans secretKey[32..64].
+  return secretKey.slice(32, 64);
+}
+
 export const SignalKeyService = {
-  async generateKeyBundle(): Promise<SignalKeyBundleDto> {
-    // Identity key pair (Curve25519)
-    const identityKeyPair = nacl.box.keyPair();
+  async generateKeyBundle(
+    context: KeyBundleContext = "register",
+  ): Promise<SignalKeyBundleDto> {
+    let identitySecretKey: Uint8Array;
+    let identityPublicKey: Uint8Array;
+
+    if (context === "login") {
+      // En contexte login : réutiliser la clé d'identité existante pour ne
+      // pas casser les sessions E2EE en cours. La clé est générée une seule
+      // fois à l'inscription et persistée dans le vault sécurisé.
+      const existingKey = await TokenService.getIdentityPrivateKey();
+      if (existingKey) {
+        identitySecretKey = decodeBase64(existingKey);
+        identityPublicKey = deriveIdentityPublicKey(identitySecretKey);
+      } else {
+        // Pas de clé stockée (premier login sur cet appareil) : générer et persister.
+        const kp = nacl.box.keyPair();
+        identitySecretKey = kp.secretKey;
+        identityPublicKey = kp.publicKey;
+        await TokenService.saveIdentityPrivateKey(toBase64(identitySecretKey));
+      }
+    } else {
+      // register ou recovery : générer une nouvelle paire et écraser.
+      // recovery est un placeholder pour le flow complet du ticket suivant.
+      const kp = nacl.box.keyPair();
+      identitySecretKey = kp.secretKey;
+      identityPublicKey = kp.publicKey;
+      await TokenService.saveIdentityPrivateKey(toBase64(identitySecretKey));
+    }
 
     // Signed pre-key pair (Curve25519)
     const signedPreKeyPair = nacl.box.keyPair();
 
-    // Sign the signed pre-key public key with the identity key (Ed25519)
-    // We use the identity key secret to derive a signing key via nacl.sign.keyPair.fromSeed
-    // The identity key secret is 32 bytes — valid seed for Ed25519
+    // Signer la clé publique du signed pre-key avec la clé d'identité (Ed25519)
     const signingKeyPair = nacl.sign.keyPair.fromSeed(
-      identityKeyPair.secretKey.slice(0, 32),
+      identitySecretKey.slice(0, 32),
     );
     const signature = nacl.sign.detached(
       signedPreKeyPair.publicKey,
       signingKeyPair.secretKey,
     );
 
-    // Use timestamp-based ids to avoid collisions with previously
-    // uploaded keys on the same device (backend has a unique
-    // (deviceId, keyId) constraint).
     const signedPrekeyId = generateSignedPrekeyId();
     const prekeyBase = generatePrekeyIdBase(signedPrekeyId);
 
@@ -72,13 +104,8 @@ export const SignalKeyService = {
       };
     });
 
-    // Persist identity private key securely for future sessions
-    await TokenService.saveIdentityPrivateKey(
-      toBase64(identityKeyPair.secretKey),
-    );
-
     return {
-      identityKey: toBase64(identityKeyPair.publicKey),
+      identityKey: toBase64(identityPublicKey),
       signedPreKey: {
         keyId: signedPrekeyId,
         publicKey: toBase64(signedPreKeyPair.publicKey),

--- a/src/services/TwoFactorService.ts
+++ b/src/services/TwoFactorService.ts
@@ -105,6 +105,23 @@ export const TwoFactorService = {
       "/2fa/backup-codes/remaining",
     );
   },
+
+  // Utilisé depuis TwoFactorVerifyLoginScreen pour finaliser le login
+  // quand l'user ne peut pas saisir son TOTP (téléphone perdu, etc.).
+  // Retourne les tokens directement : le backend valide le code de secours
+  // et émet les JWT en une seule étape.
+  async useBackupCode(
+    code: string,
+    verificationId: string,
+  ): Promise<import("../types/auth").TokenPair> {
+    return apiFetch<import("../types/auth").TokenPair>(
+      "/2fa/backup-codes/use",
+      {
+        method: "POST",
+        body: JSON.stringify({ verificationId, recoveryCode: code }),
+      },
+    );
+  },
 };
 
 export default TwoFactorService;

--- a/src/services/__tests__/SignalKeyService.test.ts
+++ b/src/services/__tests__/SignalKeyService.test.ts
@@ -40,6 +40,7 @@ jest.mock("tweetnacl", () => {
 
 jest.mock("tweetnacl-util", () => ({
   encodeBase64: jest.fn((bytes: Uint8Array) => `b64(${bytes.length})`),
+  decodeBase64: jest.fn((s: string) => new Uint8Array(64).fill(0xab)),
 }));
 
 import { SignalKeyService } from "../SignalKeyService";
@@ -155,5 +156,63 @@ describe("SignalKeyService.generateKeyBundle", () => {
     expoCrypto.getRandomBytes.mockImplementation(
       (n: number) => new Uint8Array(n),
     );
+  });
+});
+
+
+describe("SignalKeyService.generateKeyBundle context-aware", () => {
+  const mockGetIdentityPrivateKey = jest.fn();
+
+  beforeEach(() => {
+    mockGetIdentityPrivateKey.mockReset();
+    // Injecter getIdentityPrivateKey dans le mock TokenService existant
+    const TokenService = jest.requireMock("../TokenService").TokenService;
+    TokenService.getIdentityPrivateKey = mockGetIdentityPrivateKey;
+  });
+
+  it("register context : génère et persiste une nouvelle paire quelle que soit la clé existante", async () => {
+    mockGetIdentityPrivateKey.mockResolvedValue("existing-key-base64");
+
+    await SignalKeyService.generateKeyBundle("register");
+
+    // generateKeyBundle doit TOUJOURS écraser en register
+    expect(mockSaveIdentityPrivateKey).toHaveBeenCalledTimes(1);
+    // nacl.box.keyPair appelé pour identity + signedPreKey + 100 one-time
+    expect(mockedNacl.box.keyPair).toHaveBeenCalledTimes(102);
+  });
+
+  it("login context : réutilise la clé existante sans écraser le storage", async () => {
+    // decodeBase64 retournera un Uint8Array valide de 64 octets
+    const { decodeBase64 } = jest.requireMock("tweetnacl-util");
+    decodeBase64.mockReturnValue(new Uint8Array(64).fill(0xab));
+    mockGetIdentityPrivateKey.mockResolvedValue("existing-b64-key");
+
+    await SignalKeyService.generateKeyBundle("login");
+
+    // clé existante présente → pas d'overwrite
+    expect(mockSaveIdentityPrivateKey).not.toHaveBeenCalled();
+    // nacl.box.keyPair appelé seulement pour signedPreKey + 100 one-time (pas identity)
+    expect(mockedNacl.box.keyPair).toHaveBeenCalledTimes(101);
+  });
+
+  it("login context sans clé stockée : génère et persiste une nouvelle clé", async () => {
+    const { decodeBase64 } = jest.requireMock("tweetnacl-util");
+    decodeBase64.mockReturnValue(new Uint8Array(64).fill(0xab));
+    mockGetIdentityPrivateKey.mockResolvedValue(null);
+
+    await SignalKeyService.generateKeyBundle("login");
+
+    expect(mockSaveIdentityPrivateKey).toHaveBeenCalledTimes(1);
+    // identity + signedPreKey + 100 one-time
+    expect(mockedNacl.box.keyPair).toHaveBeenCalledTimes(102);
+  });
+
+  it("recovery context : génère et persiste une nouvelle paire", async () => {
+    mockGetIdentityPrivateKey.mockResolvedValue("old-key");
+
+    await SignalKeyService.generateKeyBundle("recovery");
+
+    expect(mockSaveIdentityPrivateKey).toHaveBeenCalledTimes(1);
+    expect(mockedNacl.box.keyPair).toHaveBeenCalledTimes(102);
   });
 });

--- a/src/services/__tests__/TwoFactorService.test.ts
+++ b/src/services/__tests__/TwoFactorService.test.ts
@@ -168,3 +168,33 @@ describe("TwoFactorService response handling", () => {
     expect(init.headers.Authorization).toBeUndefined();
   });
 });
+
+
+describe("TwoFactorService.useBackupCode", () => {
+  it("POST /2fa/backup-codes/use avec verificationId et recoveryCode", async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ body: { accessToken: "at", refreshToken: "rt" } }),
+    );
+
+    const result = await TwoFactorService.useBackupCode("ABCD-EFGH", "vid123");
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://api.test/auth/v1/2fa/backup-codes/use");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toEqual({
+      verificationId: "vid123",
+      recoveryCode: "ABCD-EFGH",
+    });
+    expect(result).toEqual({ accessToken: "at", refreshToken: "rt" });
+  });
+
+  it("lève une erreur 400 si le code est invalide", async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ status: 400, body: { message: "invalid backup code" } }),
+    );
+
+    await expect(
+      TwoFactorService.useBackupCode("INVALID", "vid"),
+    ).rejects.toMatchObject({ status: 400, message: "invalid backup code" });
+  });
+});


### PR DESCRIPTION
## Summary
- fix(auth): OtpScreen branche vers TwoFactorVerifyLogin si backend retourne \`requires2FA: true\` - empêche le bypass complet de la 2FA
- feat(auth): TwoFactorVerifyLoginScreen avec onglets TOTP / backup code + \`TwoFactorService.useBackupCode()\` + \`AuthService.loginAfter2FA()\`
- fix(signal): SignalKeyService.generateKeyBundle accepte un \`context\` (register/login/recovery) - réutilise la clé d'identité existante en contexte login pour ne pas casser les sessions E2EE

## Test plan
- [x] 38 tests Jest verts (SignalKeyService, TwoFactorService, OtpScreen, TwoFactorVerifyLoginScreen)
- [x] TypeScript noEmit clean
- [x] Pas de console.log
- [x] Commits granulaires (1 par bug + 1 tests)
- [ ] Tested on iOS simulator
- [ ] Tested on Android emulator

Closes WHISPR-fix-2fa-bypass / WHISPR-fix-backup-code / WHISPR-fix-identity-key