### PR TITLE
feat(offline): network monitor, inbox cache, queue TTL, retry UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@livekit/react-native": "^2.10.1",
         "@livekit/react-native-webrtc": "^144.0.0",
         "@react-native-async-storage/async-storage": "^2.2.0",
+        "@react-native-community/netinfo": "^12.0.1",
         "@react-native-masked-view/masked-view": "^0.3.2",
         "@react-navigation/native": "^7.1.17",
         "@react-navigation/stack": "^7.4.8",
@@ -3246,6 +3247,16 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
+    "node_modules/@react-native-community/netinfo": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-12.0.1.tgz",
+      "integrity": "sha512-P/3caXIvfYSJG8AWJVefukg+ZGRPs+M4Lp3pNJtgcTYoJxCjWrKQGNnCkj/Cz//zWa/avGed0i/wzm0T8vV2IQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": ">=0.59"
       }
     },
     "node_modules/@react-native-masked-view/masked-view": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@livekit/react-native": "^2.10.1",
     "@livekit/react-native-webrtc": "^144.0.0",
     "@react-native-async-storage/async-storage": "^2.2.0",
+    "@react-native-community/netinfo": "^12.0.1",
     "@react-native-masked-view/masked-view": "^0.3.2",
     "@react-navigation/native": "^7.1.17",
     "@react-navigation/stack": "^7.4.8",

--- a/src/components/Chat/MessageBubble.tsx
+++ b/src/components/Chat/MessageBubble.tsx
@@ -221,6 +221,10 @@ interface MessageBubbleProps {
   };
   /** Called when the user taps "Contester" on a locally blocked image */
   onContest?: (message: MessageWithRelations) => void;
+  /** Called when the user taps "Réessayer" on a failed (non-moderation) message */
+  onRetry?: (message: MessageWithRelations) => void;
+  /** Called when the user taps "Annuler" on a failed message */
+  onCancel?: (message: MessageWithRelations) => void;
   /** When true, renders a textual delivery status under the bubble (only the
    * latest message sent by the current user should set this). */
   isLastSentByMe?: boolean;
@@ -250,6 +254,8 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
   searchQuery,
   pendingAppeal,
   onContest,
+  onRetry,
+  onCancel,
   isLastSentByMe = false,
   isGroupConversation = false,
   otherMembersCount = 0,
@@ -545,7 +551,24 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                   </View>
                 ) : null}
               </View>
-            ) : null}
+            ) : (
+              <View style={styles.failedActionRow}>
+                <TouchableOpacity
+                  style={styles.failedRetryBtn}
+                  onPress={() => onRetry?.(message)}
+                  activeOpacity={0.7}
+                >
+                  <Text style={styles.failedRetryText}>Réessayer</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={styles.failedCancelBtn}
+                  onPress={() => onCancel?.(message)}
+                  activeOpacity={0.7}
+                >
+                  <Text style={styles.failedCancelText}>Annuler</Text>
+                </TouchableOpacity>
+              </View>
+            )}
           </MaskedBubbleSurface>
         </View>
       );
@@ -994,6 +1017,37 @@ const styles = StyleSheet.create({
     fontSize: 11,
     fontWeight: "700",
     color: "#FFFFFF",
+  },
+  failedActionRow: {
+    flexDirection: "row",
+    gap: 8,
+    paddingHorizontal: 4,
+    paddingTop: 8,
+    paddingBottom: 2,
+  },
+  failedRetryBtn: {
+    flex: 1,
+    paddingVertical: 6,
+    borderRadius: 6,
+    backgroundColor: "rgba(255,255,255,0.15)",
+    alignItems: "center",
+  },
+  failedRetryText: {
+    fontSize: 12,
+    fontWeight: "600",
+    color: "#FFFFFF",
+  },
+  failedCancelBtn: {
+    flex: 1,
+    paddingVertical: 6,
+    borderRadius: 6,
+    backgroundColor: "rgba(240,72,72,0.18)",
+    alignItems: "center",
+  },
+  failedCancelText: {
+    fontSize: 12,
+    fontWeight: "600",
+    color: "#F04848",
   },
 });
 

--- a/src/hooks/__tests__/useNetworkMonitor.test.ts
+++ b/src/hooks/__tests__/useNetworkMonitor.test.ts
@@ -1,0 +1,111 @@
+import { renderHook } from "@testing-library/react-native";
+import { act } from "@testing-library/react-native";
+import { useNetworkMonitor } from "../useNetworkMonitor";
+
+let netInfoCallback: ((state: object) => void) | null = null;
+const mockUnsubscribe = jest.fn();
+const mockNudge = jest.fn();
+
+jest.mock("@react-native-community/netinfo", () => ({
+  __esModule: true,
+  default: {
+    addEventListener: jest.fn((cb: (state: object) => void) => {
+      netInfoCallback = cb;
+      return mockUnsubscribe;
+    }),
+  },
+}));
+
+jest.mock("../../services/messaging/websocket", () => ({
+  getSharedSocket: jest.fn(() => ({ nudge: mockNudge })),
+}));
+
+jest.mock("../../utils/logger", () => ({
+  logger: { info: jest.fn(), error: jest.fn() },
+}));
+
+const fire = (
+  isConnected: boolean,
+  isInternetReachable: boolean | null = true,
+) => {
+  act(() => {
+    netInfoCallback?.({ isConnected, isInternetReachable });
+  });
+};
+
+beforeEach(() => {
+  netInfoCallback = null;
+  mockUnsubscribe.mockClear();
+  mockNudge.mockClear();
+});
+
+describe("useNetworkMonitor", () => {
+  it("calls NetInfo.addEventListener on mount and unsubscribes on unmount", () => {
+    const NetInfo = require("@react-native-community/netinfo").default;
+    const { unmount } = renderHook(() => useNetworkMonitor());
+
+    expect(NetInfo.addEventListener).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("nudges the socket on offline → online transition", () => {
+    renderHook(() => useNetworkMonitor());
+
+    fire(false); // go offline
+    fire(true); // come back online
+
+    expect(mockNudge).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT nudge when already online on the first event", () => {
+    renderHook(() => useNetworkMonitor());
+
+    fire(true); // first event while wasReachable is null
+
+    expect(mockNudge).not.toHaveBeenCalled();
+  });
+
+  it("does NOT nudge on consecutive online events (no transition)", () => {
+    renderHook(() => useNetworkMonitor());
+
+    fire(false);
+    fire(true); // nudge here (offline → online)
+    fire(true); // no nudge (online → online)
+
+    expect(mockNudge).toHaveBeenCalledTimes(1);
+  });
+
+  it("nudges again on a second offline → online cycle", () => {
+    renderHook(() => useNetworkMonitor());
+
+    fire(false);
+    fire(true); // first nudge
+    fire(false);
+    fire(true); // second nudge
+
+    expect(mockNudge).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats isInternetReachable=false as offline", () => {
+    renderHook(() => useNetworkMonitor());
+
+    fire(true, false); // connected but no internet — treat as offline
+    fire(true, true); // truly online now → nudge
+
+    expect(mockNudge).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw when getSharedSocket throws (socket not yet initialised)", () => {
+    const { getSharedSocket } = require("../../services/messaging/websocket");
+    (getSharedSocket as jest.Mock).mockImplementationOnce(() => {
+      throw new Error("socket not ready");
+    });
+    renderHook(() => useNetworkMonitor());
+
+    expect(() => {
+      fire(false);
+      fire(true);
+    }).not.toThrow();
+  });
+});

--- a/src/hooks/useNetworkMonitor.ts
+++ b/src/hooks/useNetworkMonitor.ts
@@ -1,0 +1,49 @@
+/**
+ * useNetworkMonitor — WHISPR-offline
+ *
+ * Listens to OS-level network reachability via NetInfo and nudges the
+ * WebSocket to reconnect immediately when connectivity is restored,
+ * instead of waiting for the exponential backoff timer to fire.
+ *
+ * This is the difference between "reconnects in up to 30 seconds" and
+ * "reconnects in ~500ms after the network comes back."
+ */
+
+import { useEffect, useRef } from "react";
+import NetInfo from "@react-native-community/netinfo";
+import { getSharedSocket } from "../services/messaging/websocket";
+import { logger } from "../utils/logger";
+
+export function useNetworkMonitor(): void {
+  // Track the previous reachability state so we only nudge on the
+  // transition from offline → online (not on every poll event).
+  const wasReachable = useRef<boolean | null>(null);
+
+  useEffect(() => {
+    const unsubscribe = NetInfo.addEventListener((state) => {
+      const isOnline =
+        state.isConnected === true && state.isInternetReachable !== false;
+
+      if (!isOnline) {
+        wasReachable.current = false;
+        return;
+      }
+
+      if (wasReachable.current === false) {
+        // Transition: offline → online. Kick the WebSocket immediately.
+        logger.info("NetworkMonitor", "Network restored — nudging WebSocket");
+        try {
+          getSharedSocket().nudge();
+        } catch {
+          // Socket not initialised yet (unauthenticated state) — ignore.
+        }
+      }
+
+      wasReachable.current = true;
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+}

--- a/src/hooks/useOfflineQueueDrainer.ts
+++ b/src/hooks/useOfflineQueueDrainer.ts
@@ -31,7 +31,7 @@ export function useOfflineQueueDrainer(): void {
       if (inFlight.current) return;
       inFlight.current = true;
       try {
-        const { sent, failed, skipped } = await offlineQueue.drainAll(
+        const { sent, failed, skipped, expired } = await offlineQueue.drainAll(
           async (queued) => {
             await messagingAPI.sendMessage(queued.conversation_id, {
               content: queued.content,
@@ -44,10 +44,13 @@ export function useOfflineQueueDrainer(): void {
             });
           },
         );
-        if (!skipped && (sent > 0 || failed > 0)) {
+        if (
+          !skipped &&
+          (sent > 0 || failed > 0 || (expired?.length ?? 0) > 0)
+        ) {
           logger.info(
             "offlineQueueDrainer",
-            `Drained offline queue: ${sent} sent, ${failed} still pending`,
+            `Drained offline queue: ${sent} sent, ${failed} pending, ${expired?.length ?? 0} expired`,
           );
         }
       } catch (err) {

--- a/src/navigation/AuthNavigator.tsx
+++ b/src/navigation/AuthNavigator.tsx
@@ -56,6 +56,7 @@ import { AppState } from "react-native";
 import * as LocalAuthentication from "expo-local-authentication";
 import { useAuth } from "../context/AuthContext";
 import { useOfflineQueueDrainer } from "../hooks/useOfflineQueueDrainer";
+import { useNetworkMonitor } from "../hooks/useNetworkMonitor";
 import { useModerationStore } from "../store/moderationStore";
 import { useConversationsStore } from "../store/conversationsStore";
 import { profileSetupFlag } from "../services/profileSetupFlag";
@@ -200,6 +201,7 @@ export const AuthNavigator: React.FC = () => {
   // a no-op when the queue is empty, so calling it unconditionally is
   // cheap.
   useOfflineQueueDrainer();
+  useNetworkMonitor();
 
   useEffect(() => {
     const t = setTimeout(() => setSplashMinElapsed(true), SPLASH_MIN_MS);

--- a/src/navigation/__tests__/AuthNavigator.test.tsx
+++ b/src/navigation/__tests__/AuthNavigator.test.tsx
@@ -49,6 +49,21 @@ jest.mock("../../hooks/useOfflineQueueDrainer", () => ({
   useOfflineQueueDrainer: jest.fn(),
 }));
 
+jest.mock("../../hooks/useNetworkMonitor", () => ({
+  useNetworkMonitor: jest.fn(),
+}));
+
+jest.mock("@react-native-community/netinfo", () => ({
+  __esModule: true,
+  default: {
+    addEventListener: jest.fn(() => jest.fn()),
+    fetch: jest.fn().mockResolvedValue({
+      isConnected: true,
+      isInternetReachable: true,
+    }),
+  },
+}));
+
 const mockFetchMyRole = jest.fn();
 jest.mock("../../store/moderationStore", () => ({
   useModerationStore: (selector: any) =>

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -3007,6 +3007,26 @@ export const ChatScreen: React.FC = () => {
               messageTempId: m.id,
             });
           }}
+          onRetry={async (m) => {
+            const queued: QueuedMessage = {
+              id: m.id,
+              conversation_id: m.conversation_id,
+              content: m.content,
+              message_type: m.message_type as "text" | "media" | "system",
+              client_random: (m.client_random as number) ?? Date.now(),
+              reply_to_id: m.reply_to_id ?? undefined,
+              queued_at: new Date().toISOString(),
+            };
+            await offlineQueue.enqueue(queued);
+            setMessages((prev) =>
+              prev.map((msg) =>
+                msg.id === m.id ? { ...msg, status: "queued" as const } : msg,
+              ),
+            );
+          }}
+          onCancel={(m) => {
+            setMessages((prev) => prev.filter((msg) => msg.id !== m.id));
+          }}
         />
       );
     },

--- a/src/services/__tests__/offlineQueue.test.ts
+++ b/src/services/__tests__/offlineQueue.test.ts
@@ -46,7 +46,7 @@ const makeMessage = (
   content: "hello",
   message_type: "text",
   client_random: overrides.client_random ?? 1,
-  queued_at: "2026-04-22T00:00:00.000Z",
+  queued_at: new Date().toISOString(),
   ...overrides,
 });
 
@@ -68,7 +68,7 @@ describe("offlineQueue.drainAll (WHISPR-1060)", () => {
 
     const result = await offlineQueue.drainAll(sendFn);
 
-    expect(result).toEqual({ sent: 0, failed: 0 });
+    expect(result).toEqual({ sent: 0, failed: 0, expired: [] });
     expect(sendFn).not.toHaveBeenCalled();
   });
 
@@ -81,7 +81,7 @@ describe("offlineQueue.drainAll (WHISPR-1060)", () => {
     const result = await offlineQueue.drainAll(sendFn);
 
     expect(sendFn).toHaveBeenCalledTimes(3);
-    expect(result).toEqual({ sent: 3, failed: 0 });
+    expect(result).toEqual({ sent: 3, failed: 0, expired: [] });
     expect(await offlineQueue.getAll()).toEqual([]);
   });
 
@@ -101,7 +101,7 @@ describe("offlineQueue.drainAll (WHISPR-1060)", () => {
 
     const result = await offlineQueue.drainAll(sendFn);
 
-    expect(result).toEqual({ sent: 2, failed: 1 });
+    expect(result).toEqual({ sent: 2, failed: 1, expired: [] });
     const remaining = await offlineQueue.getAll();
     expect(remaining.map((m) => m.client_random)).toEqual([22]);
   });
@@ -133,6 +133,25 @@ describe("offlineQueue.drainAll (WHISPR-1060)", () => {
   });
 });
 
+describe("offlineQueue.drainAll TTL eviction", () => {
+  it("drops messages older than 24 h and reports them as expired", async () => {
+    const staleAt = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+    await offlineQueue.enqueue(
+      makeMessage({ client_random: 501, queued_at: staleAt }),
+    );
+    await offlineQueue.enqueue(makeMessage({ client_random: 502 }));
+    const sendFn = jest.fn().mockResolvedValue(undefined);
+
+    const result = await offlineQueue.drainAll(sendFn);
+
+    expect(result.expired).toEqual([501]);
+    expect(result.sent).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(sendFn).toHaveBeenCalledTimes(1);
+    expect(await offlineQueue.getAll()).toEqual([]);
+  });
+});
+
 describe("offlineQueue.drainAll concurrency lock (WHISPR-1219)", () => {
   it("rejects a concurrent invocation with skipped=true and only sends each message once", async () => {
     await offlineQueue.enqueue(makeMessage({ client_random: 51 }));
@@ -154,7 +173,7 @@ describe("offlineQueue.drainAll concurrency lock (WHISPR-1219)", () => {
 
     // Second drain fires while the first is in flight. It must short-circuit.
     const second = await offlineQueue.drainAll(sendFn);
-    expect(second).toEqual({ sent: 0, failed: 0, skipped: true });
+    expect(second).toEqual({ sent: 0, failed: 0, expired: [], skipped: true });
 
     // Now let the first drain finish.
     resolveFirst();
@@ -162,7 +181,7 @@ describe("offlineQueue.drainAll concurrency lock (WHISPR-1219)", () => {
     sendFn.mockImplementation(() => Promise.resolve());
     const firstResult = await first;
 
-    expect(firstResult).toEqual({ sent: 2, failed: 0 });
+    expect(firstResult).toEqual({ sent: 2, failed: 0, expired: [] });
     // sendFn was called for each of the 2 messages — never doubled by the
     // concurrent call.
     expect(sendFn).toHaveBeenCalledTimes(2);
@@ -173,7 +192,7 @@ describe("offlineQueue.drainAll concurrency lock (WHISPR-1219)", () => {
     const sendFn = jest.fn().mockResolvedValue(undefined);
 
     const first = await offlineQueue.drainAll(sendFn);
-    expect(first).toEqual({ sent: 1, failed: 0 });
+    expect(first).toEqual({ sent: 1, failed: 0, expired: [] });
 
     // Re-enqueue and drain again — second call must NOT report skipped.
     await offlineQueue.enqueue(makeMessage({ client_random: 62 }));

--- a/src/services/messaging/cache.ts
+++ b/src/services/messaging/cache.ts
@@ -4,8 +4,11 @@
 
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Conversation, MessageWithRelations } from "../../types/messaging";
+import type { InboxItem } from "../../types/inbox";
 
 const CACHE_KEY = "whispr.conversations.cache";
+const INBOX_CACHE_KEY = "whispr.inbox.cache";
+const INBOX_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 const CACHE_TIMESTAMP_KEY = "whispr.conversations.cache.timestamp";
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
@@ -155,6 +158,38 @@ export const cacheService = {
       await AsyncStorage.multiRemove(targets);
     } catch (error) {
       console.error("Error clearing all messages cache:", error);
+    }
+  },
+
+  async saveInbox(items: InboxItem[], unreadCount: number): Promise<void> {
+    try {
+      await AsyncStorage.setItem(
+        INBOX_CACHE_KEY,
+        JSON.stringify({
+          items,
+          unread_count: unreadCount,
+          cachedAt: Date.now(),
+        }),
+      );
+    } catch {}
+  },
+
+  async getInbox(): Promise<{
+    items: InboxItem[];
+    unread_count: number;
+  } | null> {
+    try {
+      const raw = await AsyncStorage.getItem(INBOX_CACHE_KEY);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw) as {
+        items: InboxItem[];
+        unread_count: number;
+        cachedAt: number;
+      };
+      if (Date.now() - parsed.cachedAt > INBOX_CACHE_TTL) return null;
+      return { items: parsed.items, unread_count: parsed.unread_count };
+    } catch {
+      return null;
     }
   },
 };

--- a/src/services/messaging/websocket.ts
+++ b/src/services/messaging/websocket.ts
@@ -449,6 +449,29 @@ export class SocketConnection {
     }, delay);
   }
 
+  /**
+   * Nudge the socket to reconnect immediately, bypassing the backoff timer.
+   * Called by useNetworkMonitor when the OS reports network reachability
+   * has been restored. Resets the attempt counter so the next connect
+   * attempt starts from the base delay rather than an inflated one.
+   * No-op if already connected or if there are no saved credentials.
+   */
+  nudge(): void {
+    if (
+      this._connectionState === "connected" ||
+      this.connecting ||
+      !this.shouldReconnect ||
+      !this.lastUserId
+    )
+      return;
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.reconnectAttempt = 0;
+    this.scheduleReconnect();
+  }
+
   disconnect(): void {
     this.shouldReconnect = false;
     if (this.reconnectTimer) {

--- a/src/services/offlineQueue.ts
+++ b/src/services/offlineQueue.ts
@@ -94,7 +94,11 @@ function generateUUID(): string {
 // the same message twice. Second invocation now short-circuits and
 // returns `skipped: true` so callers can tell apart "drained nothing"
 // from "another drain is already in flight".
-let drainPromise: Promise<{ sent: number; failed: number }> | null = null;
+let drainPromise: Promise<{
+  sent: number;
+  failed: number;
+  expired: number[];
+}> | null = null;
 
 export interface DrainResult {
   sent: number;

--- a/src/services/offlineQueue.ts
+++ b/src/services/offlineQueue.ts
@@ -9,6 +9,7 @@ import * as ExpoCrypto from "expo-crypto";
 import { storage } from "./storage";
 
 const QUEUE_KEY = "whispr.offline.message.queue";
+const QUEUE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours — messages older than this are dropped on drain
 
 // WHISPR-1359 — migration douce AsyncStorage → SecureStore. Sur Android
 // rooté ou backup ADB non chiffré, lire les messages texte en clair depuis
@@ -98,6 +99,8 @@ let drainPromise: Promise<{ sent: number; failed: number }> | null = null;
 export interface DrainResult {
   sent: number;
   failed: number;
+  /** client_random values of messages dropped because they exceeded QUEUE_TTL_MS. */
+  expired: number[];
   /** True iff another drainAll() was already in flight when this one started. */
   skipped?: boolean;
 }
@@ -177,13 +180,20 @@ export const offlineQueue = {
     sendFn: (message: QueuedMessage) => Promise<unknown>,
   ): Promise<DrainResult> {
     if (drainPromise) {
-      return { sent: 0, failed: 0, skipped: true };
+      return { sent: 0, failed: 0, expired: [], skipped: true };
     }
     drainPromise = (async () => {
       const pending = await this.getAll();
       let sent = 0;
       let failed = 0;
+      const expired: number[] = [];
+      const now = Date.now();
       for (const queued of pending) {
+        if (now - new Date(queued.queued_at).getTime() > QUEUE_TTL_MS) {
+          await this.remove(queued.client_random);
+          expired.push(queued.client_random);
+          continue;
+        }
         try {
           await sendFn(queued);
           await this.remove(queued.client_random);
@@ -192,7 +202,7 @@ export const offlineQueue = {
           failed += 1;
         }
       }
-      return { sent, failed };
+      return { sent, failed, expired };
     })();
     try {
       return await drainPromise;
@@ -201,3 +211,5 @@ export const offlineQueue = {
     }
   },
 };
+
+export const OFFLINE_QUEUE_TTL_MS = QUEUE_TTL_MS;

--- a/src/store/inboxStore.ts
+++ b/src/store/inboxStore.ts
@@ -6,6 +6,7 @@
 
 import { create } from "zustand";
 import { inboxApi } from "../services/inboxApi";
+import { cacheService } from "../services/messaging/cache";
 import type { InboxItem } from "../types/inbox";
 
 const INBOX_PAGE_SIZE = 20;
@@ -33,6 +34,10 @@ export const useInboxStore = create<InboxState>((set, get) => ({
 
   async hydrate() {
     if (get().loading) return;
+    const cached = await cacheService.getInbox();
+    if (cached && get().items.length === 0) {
+      set({ items: cached.items, unread_count: cached.unread_count });
+    }
     set({ loading: true });
     try {
       const data = await inboxApi.fetchInbox({ limit: INBOX_PAGE_SIZE });
@@ -43,6 +48,7 @@ export const useInboxStore = create<InboxState>((set, get) => ({
         next_cursor: data.next_cursor,
         loading: false,
       });
+      cacheService.saveInbox(data.items, data.unread_count).catch(() => {});
     } catch {
       set({ loading: false });
     }


### PR DESCRIPTION
## Summary

- **NetInfo hook** (`useNetworkMonitor`): listens to OS-level reachability and calls `socket.nudge()` on offline→online transition — cuts reconnect from up to 30 s down to ~500 ms
- **WebSocket `nudge()`**: new public method that cancels the backoff timer and immediately calls `scheduleReconnect()`, resetting the attempt counter
- **Inbox cache** (`cacheService.saveInbox` / `getInbox`): cache-then-fetch pattern in `inboxStore` — inbox renders stale data immediately on mount, fresh data loads in background (same pattern already used in `conversationsStore`, TTL = 5 min)
- **Queue TTL** (24 h): messages older than 24 h are silently evicted from the offline queue during drain and reported as `expired[]` in `DrainResult` — prevents zombie retries
- **Retry / Cancel UI**: failed message bubbles (non-moderation) now show Retry and Cancel buttons — Retry re-enqueues the message for the next drain pass; Cancel removes it from local state

## Test plan

- [x] Unit tests green (46 tests across offlineQueue, inboxStore, useNetworkMonitor, MessageBubble)
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [x] Lint clean (`eslint --fix` + `prettier`)
- [ ] Tested on iOS simulator
- [ ] Tested on Android emulator

Closes WHISPR-offline