### PR TITLE
feat(auth): wire recovery codes flow - unmock + DEV settings cleanup

### DIFF
--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -1434,32 +1434,36 @@ export const SettingsScreen: React.FC = () => {
                 />
               }
             />
-            <SettingItem
-              label="[DEV] Recovery Codes Screen"
-              subtitle="Preview écran codes de backup (données mockées)"
-              onPress={() => navigation.navigate("RecoveryCodes")}
-              icon="shield-checkmark-outline"
-              rightComponent={
-                <Ionicons
-                  name="chevron-forward"
-                  size={20}
-                  color={themeColors.text.tertiary}
+            {__DEV__ && (
+              <>
+                <SettingItem
+                  label="[DEV] Recovery Codes Screen"
+                  subtitle="Preview écran codes de backup (données mockées)"
+                  onPress={() => navigation.navigate("RecoveryCodes")}
+                  icon="shield-checkmark-outline"
+                  rightComponent={
+                    <Ionicons
+                      name="chevron-forward"
+                      size={20}
+                      color={themeColors.text.tertiary}
+                    />
+                  }
                 />
-              }
-            />
-            <SettingItem
-              label="[DEV] Recovery Code Entry"
-              subtitle="Preview saisie code de récupération"
-              onPress={() => navigation.navigate("RecoveryCodeEntry")}
-              icon="key-outline"
-              rightComponent={
-                <Ionicons
-                  name="chevron-forward"
-                  size={20}
-                  color={themeColors.text.tertiary}
+                <SettingItem
+                  label="[DEV] Recovery Code Entry"
+                  subtitle="Preview saisie code de récupération"
+                  onPress={() => navigation.navigate("RecoveryCodeEntry")}
+                  icon="key-outline"
+                  rightComponent={
+                    <Ionicons
+                      name="chevron-forward"
+                      size={20}
+                      color={themeColors.text.tertiary}
+                    />
+                  }
                 />
-              }
-            />
+              </>
+            )}
           </SettingSection>
         )}
       </ScrollView>

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -354,34 +354,38 @@ export const AuthService = {
   },
 
   async fetchRecoveryCodes(): Promise<string[]> {
-    if (__DEV__) {
-      return new Promise((res) =>
-        setTimeout(
-          () =>
-            res([
-              "A1B2-C3D4-E5F6",
-              "G7H8-I9J0-K1L2",
-              "M3N4-O5P6-Q7R8",
-              "S9T0-U1V2-W3X4",
-              "Y5Z6-A7B8-C9D0",
-              "E1F2-G3H4-I5J6",
-              "K7L8-M9N0-O1P2",
-              "Q3R4-S5T6-U7V8",
-            ]),
-          800,
-        ),
-      );
-    }
     const token = await TokenService.getAccessToken();
     if (!token) {
       const err = new Error("NO_ACCESS_TOKEN") as Error & { status: number };
       err.status = 401;
       throw err;
     }
-    return apiFetch<string[]>("/recovery-codes", {
-      method: "GET",
-      token,
-    });
+
+    try {
+      return await apiFetch<string[]>("/recovery-codes", {
+        method: "GET",
+        token,
+      });
+    } catch (err: unknown) {
+      const status = (err as { status?: number })?.status;
+      // En dev : fallback mock si l'endpoint n'existe pas encore (404)
+      // ou si le backend est injoignable (undefined = network error).
+      // En prod : on laisse l'erreur remonter pour que l'UI affiche
+      // un message "Service indisponible".
+      if (__DEV__ && (status === 404 || status === undefined)) {
+        return [
+          "A1B2-C3D4-E5F6",
+          "G7H8-I9J0-K1L2",
+          "M3N4-O5P6-Q7R8",
+          "S9T0-U1V2-W3X4",
+          "Y5Z6-A7B8-C9D0",
+          "E1F2-G3H4-I5J6",
+          "K7L8-M9N0-O1P2",
+          "Q3R4-S5T6-U7V8",
+        ];
+      }
+      throw err;
+    }
   },
 
   // Appelé depuis TwoFactorVerifyLoginScreen après validation TOTP ou backup code.

--- a/src/services/__tests__/AuthService.test.ts
+++ b/src/services/__tests__/AuthService.test.ts
@@ -501,3 +501,44 @@ describe("AuthService.getWsToken (WHISPR-1214)", () => {
     });
   });
 });
+
+describe("AuthService.fetchRecoveryCodes", () => {
+  beforeEach(() => {
+    mockFetch = installFetchMock();
+  });
+
+  it("throws 401 when no access token is stored", async () => {
+    mockedToken.getAccessToken.mockResolvedValueOnce(null);
+
+    await expect(AuthService.fetchRecoveryCodes()).rejects.toMatchObject({
+      message: "NO_ACCESS_TOKEN",
+      status: 401,
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("calls GET /recovery-codes with Bearer token and returns codes", async () => {
+    const codes = ["A1B2-XXXX", "C3D4-YYYY"];
+    mockedToken.getAccessToken.mockResolvedValueOnce("access-tok");
+    mockFetch.mockResolvedValueOnce(mockResponse({ body: codes }));
+
+    const result = await AuthService.fetchRecoveryCodes();
+
+    expect(result).toEqual(codes);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://api.test/auth/v1/recovery-codes");
+    expect(init.method).toBe("GET");
+    expect(init.headers.Authorization).toBe("Bearer access-tok");
+  });
+
+  it("propagates non-404 errors without fallback", async () => {
+    mockedToken.getAccessToken.mockResolvedValueOnce("access-tok");
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ status: 500, body: { message: "server error" } }),
+    );
+
+    await expect(AuthService.fetchRecoveryCodes()).rejects.toMatchObject({
+      status: 500,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `AuthService.fetchRecoveryCodes()` appelle maintenant `GET /auth/v1/recovery-codes` en premier. Fallback sur les codes mockés uniquement en `__DEV__` si l'endpoint retourne 404 ou est injoignable (backend pas encore déployé). En prod l'erreur remonte pour que l'UI affiche "Service indisponible".
- Les entrées `[DEV] Recovery Codes Screen` et `[DEV] Recovery Code Entry` dans Settings > Debug ne s'affichent plus en build preprod - uniquement en dev local (`__DEV__`). Les flows sont maintenant accessibles via le vrai parcours register/login.
- Ajout de 3 tests `AuthService.fetchRecoveryCodes` : no token → 401, appel réel avec Bearer, erreur non-404 remonte.

## Flows en place (pas de changement, déjà câblés par xAPT)

- Register: `OtpScreen` → `RecoveryCodes` (checkbox + continue) → `ProfileSetup`
- Login: `PhoneInputScreen` → lien "J'ai perdu l'accès" → `RecoveryCodeEntry` → `ConversationsList`
- Gestion 400 (code invalide) et 429 (rate limit) dans `RecoveryCodeEntryScreen`

## Test plan

- [x] `npm test -- --watchAll=false --testPathPattern="AuthService|RecoveryCode"` : 53 tests verts
- [x] Lint : 0 erreurs
- [x] TypeScript : 0 erreurs sur les fichiers modifiés
- [x] Diff relu - pas de console.log, pas de TODO, pas de code mort
- [ ] Audit visuel PWA preprod : register flow → RecoveryCodes screen, login → lien recovery