### PR TITLE
feat(mobile-web): URL waitlist sans .html ni #pricing

### DIFF
--- a/docker/prod/nginx.conf
+++ b/docker/prod/nginx.conf
@@ -9,6 +9,16 @@ server {
     gzip on;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml image/svg+xml;
 
+    # Page waitlist sans extension .html
+    location = /waitlist {
+        try_files /waitlist.html =404;
+    }
+
+    # Redirect ancienne URL → nouvelle URL propre
+    location = /waitlist.html {
+        return 301 /waitlist;
+    }
+
     # SPA fallback
     location / {
         try_files $uri $uri/ /index.html;

--- a/public/legal/privacy.html
+++ b/public/legal/privacy.html
@@ -761,7 +761,7 @@
   <div class="nav-right">
     <a href="privacy.html" class="nav-pill active">Confidentialité</a>
     <a href="terms.html" class="nav-pill">CGU</a>
-    <a href="../waitlist.html" class="nav-pill" style="color:var(--coral);border-color:rgba(254,122,92,.25);background:var(--coral-glow)">Accès anticipé</a>
+    <a href="../waitlist" class="nav-pill" style="color:var(--coral);border-color:rgba(254,122,92,.25);background:var(--coral-glow)">Accès anticipé</a>
   </div>
 </nav>
 

--- a/public/legal/terms.html
+++ b/public/legal/terms.html
@@ -859,7 +859,7 @@
   <div class="nav-right">
     <a href="privacy.html" class="nav-pill">Confidentialité</a>
     <a href="terms.html" class="nav-pill active">CGU</a>
-    <a href="../waitlist.html" class="nav-pill" style="color:var(--coral);border-color:rgba(254,122,92,.25);background:var(--coral-glow)">Accès anticipé</a>
+    <a href="../waitlist" class="nav-pill" style="color:var(--coral);border-color:rgba(254,122,92,.25);background:var(--coral-glow)">Accès anticipé</a>
   </div>
 </nav>
 

--- a/public/waitlist.html
+++ b/public/waitlist.html
@@ -791,7 +791,7 @@
     <a href="legal/privacy.html" class="nav-pill">Confidentialité</a>
     <a href="legal/terms.html" class="nav-pill">CGU</a>
     <a href="#pricing" class="nav-pill">Offres</a>
-    <a href="waitlist.html" class="nav-pill active">Accès anticipé</a>
+    <a href="/waitlist" class="nav-pill active">Accès anticipé</a>
   </div>
 </nav>
 
@@ -1001,7 +1001,7 @@
       </div>
       <div class="plan-divider"></div>
       <div class="plan-price coral">Gratuit</div>
-      <a href="waitlist.html" class="plan-cta coral">Rejoindre la waitlist</a>
+      <a href="/waitlist" class="plan-cta coral">Rejoindre la waitlist</a>
     </div>
 
     <!-- Premium -->
@@ -1014,7 +1014,7 @@
       </div>
       <div class="plan-divider"></div>
       <div class="plan-price violet">5,99 € / mois</div>
-      <a href="waitlist.html" class="plan-cta violet">Rejoindre la waitlist</a>
+      <a href="/waitlist" class="plan-cta violet">Rejoindre la waitlist</a>
     </div>
 
     <!-- B2B -->

--- a/src/screens/Auth/WelcomeScreen.tsx
+++ b/src/screens/Auth/WelcomeScreen.tsx
@@ -18,7 +18,7 @@ import { colors, spacing, typography } from "../../theme";
 import type { AuthStackParamList } from "../../navigation/AuthNavigator";
 import { AuthLanguageSwitcher } from "./AuthLanguageSwitcher";
 
-const WAITLIST_URL = "https://whispr-preprod.roadmvn.com/waitlist.html#pricing";
+const WAITLIST_URL = "https://whispr-preprod.roadmvn.com/waitlist";
 
 type NavigationProp = StackNavigationProp<AuthStackParamList, "Welcome">;
 


### PR DESCRIPTION
## Summary
- nginx: `location = /waitlist` sert `waitlist.html`, redirect 301 depuis `/waitlist.html`
- `WelcomeScreen`: `WAITLIST_URL` -> `/waitlist` (suppression `.html` et `#pricing`)
- `privacy.html`, `terms.html`, `waitlist.html`: liens internes mis a jour

## Test plan
- [ ] `curl -I https://whispr-preprod.roadmvn.com/waitlist` -> 200
- [ ] `curl -I https://whispr-preprod.roadmvn.com/waitlist.html` -> 301 vers `/waitlist`
- [ ] PWA root `/` toujours 200
- [ ] Tests Jest WelcomeScreen verts