### PR TITLE
feat(auth): recovery codes resume flow au login si non-acknowledged

### DIFF
--- a/src/navigation/AuthNavigator.tsx
+++ b/src/navigation/AuthNavigator.tsx
@@ -114,7 +114,7 @@ export type AuthStackParamList = {
     deviceInfo: import("../types/auth").DeviceInfo;
     signalKeyBundle: import("../types/auth").SignalKeyBundleDto;
   };
-  RecoveryCodes: undefined;
+  RecoveryCodes: { mode?: "resume" } | undefined;
   RecoveryCodeEntry: undefined;
   ConversationsList: undefined;
   ArchivedConversations: undefined;

--- a/src/screens/Auth/OtpScreen.tsx
+++ b/src/screens/Auth/OtpScreen.tsx
@@ -218,12 +218,23 @@ export const OtpScreen: React.FC = () => {
         generateAndUploadSignalKeys();
 
         if (purpose === "register") {
+          // Flow register : toujours passer par RecoveryCodes (mode normal)
           navigation.reset({ index: 0, routes: [{ name: "RecoveryCodes" }] });
         } else {
-          navigation.reset({
-            index: 0,
-            routes: [{ name: "ConversationsList" }],
-          });
+          // Login : si l'user n'a jamais validé ses codes → résume flow
+          // Champ absent (vieux backend) = défaut true pour compat
+          const acknowledged = tokens.recovery_codes_acknowledged ?? true;
+          if (!acknowledged) {
+            navigation.reset({
+              index: 0,
+              routes: [{ name: "RecoveryCodes", params: { mode: "resume" } }],
+            });
+          } else {
+            navigation.reset({
+              index: 0,
+              routes: [{ name: "ConversationsList" }],
+            });
+          }
         }
       } catch (err: unknown) {
         console.error("[OtpScreen] Registration/login failed:", err);

--- a/src/screens/Auth/RecoveryCodesScreen.tsx
+++ b/src/screens/Auth/RecoveryCodesScreen.tsx
@@ -11,7 +11,8 @@ import {
 import { LinearGradient } from "expo-linear-gradient";
 import { Ionicons } from "@expo/vector-icons";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { useNavigation } from "@react-navigation/native";
+import { useNavigation, useRoute } from "@react-navigation/native";
+import type { RouteProp } from "@react-navigation/native";
 import type { StackNavigationProp } from "@react-navigation/stack";
 import { Button } from "../../components";
 import { useTheme } from "../../context/ThemeContext";
@@ -21,9 +22,13 @@ import { colors, spacing, typography } from "../../theme";
 import type { AuthStackParamList } from "../../navigation/AuthNavigator";
 
 type NavigationProp = StackNavigationProp<AuthStackParamList, "RecoveryCodes">;
+type RecoveryCodesRouteProp = RouteProp<AuthStackParamList, "RecoveryCodes">;
 
 export const RecoveryCodesScreen: React.FC = () => {
   const navigation = useNavigation<NavigationProp>();
+  const route = useRoute<RecoveryCodesRouteProp>();
+  // mode "resume" = user connecté qui n'a pas encore validé ses codes
+  const isResumeMode = route.params?.mode === "resume";
   const insets = useSafeAreaInsets();
   const { getThemeColors, getFontSize, getLocalizedText } = useTheme();
   const themeColors = getThemeColors();
@@ -67,8 +72,15 @@ export const RecoveryCodesScreen: React.FC = () => {
 
   const handleContinue = async () => {
     setProceeding(true);
-    await profileSetupFlag.markPending();
-    navigation.reset({ index: 0, routes: [{ name: "ProfileSetup" }] });
+    if (isResumeMode) {
+      // Notifie le backend que l'user a bien sauvegardé ses codes.
+      // Erreur non-bloquante : on navigue quand même vers l'app.
+      await AuthService.acknowledgeRecoveryCodes().catch(() => {});
+      navigation.reset({ index: 0, routes: [{ name: "ConversationsList" }] });
+    } else {
+      await profileSetupFlag.markPending();
+      navigation.reset({ index: 0, routes: [{ name: "ProfileSetup" }] });
+    }
   };
 
   return (
@@ -105,6 +117,20 @@ export const RecoveryCodesScreen: React.FC = () => {
           <Text style={[styles.title, { fontSize: getFontSize("xxl") }]}>
             {getLocalizedText("auth.yourRecoveryCodes")}
           </Text>
+
+          {isResumeMode && (
+            <View style={styles.resumeBanner}>
+              <Ionicons
+                name="alert-circle"
+                size={20}
+                color="#ef4444"
+                style={styles.warningIcon}
+              />
+              <Text style={[styles.resumeBannerText, { fontSize: getFontSize("sm") }]}>
+                {"Tu n'as pas encore sauvegardé tes codes de récupération.\nNe perds pas cette clé secrète : elle permet de recouvrer l'accès à ton compte si tu changes de téléphone ou perds ton appareil."}
+              </Text>
+            </View>
+          )}
 
           <View style={styles.warningCard}>
             <Ionicons
@@ -230,6 +256,23 @@ const styles = StyleSheet.create({
     color: colors.text.light,
     textAlign: "center",
     marginBottom: spacing.lg,
+  },
+  resumeBanner: {
+    flexDirection: "row",
+    backgroundColor: "rgba(239, 68, 68, 0.15)",
+    borderRadius: 12,
+    borderWidth: 1.5,
+    borderColor: "rgba(239, 68, 68, 0.5)",
+    padding: spacing.md,
+    marginBottom: spacing.md,
+    gap: spacing.sm,
+    width: "100%",
+  },
+  resumeBannerText: {
+    color: "#fca5a5",
+    flex: 1,
+    lineHeight: 20,
+    fontWeight: "600",
   },
   warningCard: {
     flexDirection: "row",

--- a/src/screens/Auth/__tests__/OtpScreen.test.tsx
+++ b/src/screens/Auth/__tests__/OtpScreen.test.tsx
@@ -236,4 +236,91 @@ describe("OtpScreen", () => {
     );
     expect(mockNavigate).not.toHaveBeenCalledWith("TwoFactorVerifyLogin", expect.anything());
   }, 10000);
+
+  it("redirige vers RecoveryCodes mode resume si recovery_codes_acknowledged est false", async () => {
+    mockedAuthService.confirmVerification.mockResolvedValue({ verified: true });
+    mockedAuthService.login.mockResolvedValue({
+      accessToken: "tok",
+      refreshToken: "ref",
+      recovery_codes_acknowledged: false,
+    } as any);
+    mockedTokenService.decodeAccessToken.mockReturnValue({
+      sub: "user1",
+      deviceId: "dev1",
+    } as any);
+
+    const { getAllByDisplayValue } = render(<OtpScreen />);
+
+    await act(async () => {
+      fireEvent.changeText(getAllByDisplayValue("")[0], "123456");
+    });
+
+    await waitFor(
+      () => {
+        expect(mockReset).toHaveBeenCalledWith({
+          index: 0,
+          routes: [{ name: "RecoveryCodes", params: { mode: "resume" } }],
+        });
+      },
+      { timeout: 8000 },
+    );
+  }, 10000);
+
+  it("flow normal si recovery_codes_acknowledged est true", async () => {
+    mockedAuthService.confirmVerification.mockResolvedValue({ verified: true });
+    mockedAuthService.login.mockResolvedValue({
+      accessToken: "tok",
+      refreshToken: "ref",
+      recovery_codes_acknowledged: true,
+    } as any);
+    mockedTokenService.decodeAccessToken.mockReturnValue({
+      sub: "user1",
+      deviceId: "dev1",
+    } as any);
+
+    const { getAllByDisplayValue } = render(<OtpScreen />);
+
+    await act(async () => {
+      fireEvent.changeText(getAllByDisplayValue("")[0], "123456");
+    });
+
+    await waitFor(
+      () => {
+        expect(mockReset).toHaveBeenCalledWith({
+          index: 0,
+          routes: [{ name: "ConversationsList" }],
+        });
+      },
+      { timeout: 8000 },
+    );
+  }, 10000);
+
+  it("compat: champ absent dans la response → flow normal (default true)", async () => {
+    mockedAuthService.confirmVerification.mockResolvedValue({ verified: true });
+    // Pas de recovery_codes_acknowledged dans la response
+    mockedAuthService.login.mockResolvedValue({
+      accessToken: "tok",
+      refreshToken: "ref",
+    });
+    mockedTokenService.decodeAccessToken.mockReturnValue({
+      sub: "user1",
+      deviceId: "dev1",
+    } as any);
+
+    const { getAllByDisplayValue } = render(<OtpScreen />);
+
+    await act(async () => {
+      fireEvent.changeText(getAllByDisplayValue("")[0], "123456");
+    });
+
+    await waitFor(
+      () => {
+        expect(mockReset).toHaveBeenCalledWith({
+          index: 0,
+          routes: [{ name: "ConversationsList" }],
+        });
+      },
+      { timeout: 8000 },
+    );
+  }, 10000);
 });

--- a/src/screens/Auth/__tests__/RecoveryCodesScreen.test.tsx
+++ b/src/screens/Auth/__tests__/RecoveryCodesScreen.test.tsx
@@ -4,9 +4,11 @@ import { RecoveryCodesScreen } from "../RecoveryCodesScreen";
 import { AuthService } from "../../../services/AuthService";
 
 const mockReset = jest.fn();
+let mockRouteParams: { mode?: string } = {};
 
 jest.mock("@react-navigation/native", () => ({
   useNavigation: () => ({ reset: mockReset }),
+  useRoute: () => ({ params: mockRouteParams }),
 }));
 jest.mock("expo-linear-gradient", () => ({
   LinearGradient: ({ children }: any) => children,
@@ -40,6 +42,7 @@ jest.mock("../../../components", () => ({
 jest.mock("../../../services/AuthService", () => ({
   AuthService: {
     fetchRecoveryCodes: jest.fn(),
+    acknowledgeRecoveryCodes: jest.fn().mockResolvedValue(undefined),
   },
 }));
 jest.mock("../../../services/profileSetupFlag", () => ({
@@ -74,7 +77,10 @@ const CODES = [
 ];
 
 describe("RecoveryCodesScreen", () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRouteParams = {};
+  });
 
   it("shows skeletons while loading", () => {
     mockedAuthService.fetchRecoveryCodes.mockReturnValue(new Promise(() => {}));
@@ -162,6 +168,83 @@ describe("RecoveryCodesScreen", () => {
     const { getByText } = render(<RecoveryCodesScreen />);
     await waitFor(() => {
       expect(getByText("auth.yourRecoveryCodes")).toBeTruthy();
+    });
+  });
+});
+
+describe("RecoveryCodesScreen — mode resume", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRouteParams = { mode: "resume" };
+    mockedAuthService.fetchRecoveryCodes.mockResolvedValue(CODES);
+  });
+
+  it("affiche le banner d'avertissement fort en mode resume", async () => {
+    const { getByText } = render(<RecoveryCodesScreen />);
+    await waitFor(() => {
+      expect(
+        getByText(/Tu n'as pas encore sauvegardé tes codes/),
+      ).toBeTruthy();
+    });
+  });
+
+  it("n'affiche PAS le banner resume en mode normal", async () => {
+    mockRouteParams = {};
+    const { queryByText, getByText: getByTextLocal } = render(<RecoveryCodesScreen />);
+    await waitFor(() => getByTextLocal("auth.yourRecoveryCodes"));
+    expect(
+      queryByText(/Tu n'as pas encore sauvegardé tes codes/),
+    ).toBeNull();
+  });
+
+  it("navigue vers ConversationsList en mode resume après confirmation", async () => {
+    const { getByText } = render(<RecoveryCodesScreen />);
+    await waitFor(() => getByText("auth.iSavedMyCodes"));
+    await act(async () => {
+      fireEvent.press(getByText("auth.iSavedMyCodes"));
+    });
+    await act(async () => {
+      fireEvent.press(getByText("auth.continueToApp"));
+    });
+    await waitFor(() => {
+      expect(mockReset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: "ConversationsList" }],
+      });
+    });
+  });
+
+  it("appelle acknowledgeRecoveryCodes en mode resume", async () => {
+    const { getByText } = render(<RecoveryCodesScreen />);
+    await waitFor(() => getByText("auth.iSavedMyCodes"));
+    await act(async () => {
+      fireEvent.press(getByText("auth.iSavedMyCodes"));
+    });
+    await act(async () => {
+      fireEvent.press(getByText("auth.continueToApp"));
+    });
+    await waitFor(() => {
+      expect(mockedAuthService.acknowledgeRecoveryCodes).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("navigue quand même si acknowledgeRecoveryCodes échoue (erreur non-bloquante)", async () => {
+    mockedAuthService.acknowledgeRecoveryCodes.mockRejectedValueOnce(
+      new Error("network"),
+    );
+    const { getByText } = render(<RecoveryCodesScreen />);
+    await waitFor(() => getByText("auth.iSavedMyCodes"));
+    await act(async () => {
+      fireEvent.press(getByText("auth.iSavedMyCodes"));
+    });
+    await act(async () => {
+      fireEvent.press(getByText("auth.continueToApp"));
+    });
+    await waitFor(() => {
+      expect(mockReset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: "ConversationsList" }],
+      });
     });
   });
 });

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -418,6 +418,24 @@ export const AuthService = {
     return tokens;
   },
 
+  // POST /auth/v1/recovery-codes/acknowledge — marque que l'user a sauvegardé ses codes.
+  // Tolère un 404 (backend pas encore déployé) : swallow silencieux.
+  async acknowledgeRecoveryCodes(): Promise<void> {
+    const token = await TokenService.getAccessToken();
+    if (!token) return;
+    try {
+      await apiFetch<void>("/recovery-codes/acknowledge", {
+        method: "POST",
+        token,
+      });
+    } catch (err: unknown) {
+      const status = (err as { status?: number })?.status;
+      // 404 = endpoint pas encore déployé côté backend, on ignore.
+      if (status === 404) return;
+      throw err;
+    }
+  },
+
   async redeemRecoveryCode(code: string): Promise<TokenPair> {
     const [deviceInfo, signalKeyBundle] = await Promise.all([
       DeviceService.getDeviceInfo(),

--- a/src/services/__tests__/AuthService.test.ts
+++ b/src/services/__tests__/AuthService.test.ts
@@ -542,3 +542,44 @@ describe("AuthService.fetchRecoveryCodes", () => {
     });
   });
 });
+
+describe("AuthService.acknowledgeRecoveryCodes", () => {
+  it("POSTs /recovery-codes/acknowledge avec le Bearer token et retourne void sur 204", async () => {
+    mockedToken.getAccessToken.mockResolvedValueOnce("access-tok");
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 204 }));
+
+    await expect(AuthService.acknowledgeRecoveryCodes()).resolves.toBeUndefined();
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://api.test/auth/v1/recovery-codes/acknowledge");
+    expect(init.method).toBe("POST");
+    expect(init.headers.Authorization).toBe("Bearer access-tok");
+  });
+
+  it("swallow 404 silencieusement (backend pas encore deployé)", async () => {
+    mockedToken.getAccessToken.mockResolvedValueOnce("access-tok");
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ status: 404, body: { message: "Not Found" } }),
+    );
+
+    await expect(AuthService.acknowledgeRecoveryCodes()).resolves.toBeUndefined();
+  });
+
+  it("retourne void sans appel réseau si pas de token", async () => {
+    mockedToken.getAccessToken.mockResolvedValueOnce(null);
+
+    await expect(AuthService.acknowledgeRecoveryCodes()).resolves.toBeUndefined();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("propage les erreurs non-404 (ex: 500)", async () => {
+    mockedToken.getAccessToken.mockResolvedValueOnce("access-tok");
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ status: 500, body: { message: "server error" } }),
+    );
+
+    await expect(AuthService.acknowledgeRecoveryCodes()).rejects.toMatchObject({
+      status: 500,
+    });
+  });
+});

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -13,6 +13,8 @@ export interface VerificationConfirmResponse {
 export interface TokenPair {
   accessToken: string;
   refreshToken: string;
+  /** false si l'user n'a jamais validé "J'ai sauvegardé mes codes". Absent = compat old backend → traité comme true. */
+  recovery_codes_acknowledged?: boolean;
 }
 
 export interface JwtPayload {


### PR DESCRIPTION
## Summary
- Ajout du champ optionnel `recovery_codes_acknowledged` dans `TokenPair` (compat : absent = `true`)
- `OtpScreen` : après login, si `recovery_codes_acknowledged === false` → reset vers `RecoveryCodesScreen` avec `params: { mode: 'resume' }`
- `RecoveryCodesScreen` : mode `resume` affiche un banner rouge d'avertissement fort au-dessus des codes, appelle `acknowledgeRecoveryCodes()` on continue, navigue vers `ConversationsList` (au lieu de `ProfileSetup`)
- `AuthService.acknowledgeRecoveryCodes()` : POST `/recovery-codes/acknowledge`, 404 swallowed pour compat backend non-encore-deployé
- Flow register inchangé (RecoveryCodes mode normal → ProfileSetup)

## Test plan
- [x] AuthService.acknowledgeRecoveryCodes — 4 scenarios (204, 404-swallow, no-token, 500-propagate)
- [x] RecoveryCodesScreen mode resume — 5 scenarios (banner visible, banner absent en mode normal, nav ConversationsList, ack appelé, ack fail non-bloquant)
- [x] OtpScreen — 4 scenarios (acknowledged=false → resume, true → normal, absent → normal, register unchanged)
- [x] Suite complète : 1493 tests verts, 0 régression

Closes WHISPR-recovery-codes-resume-login