### PR TITLE
fix(auth): preserve identity key on login OTP flow

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -20,6 +20,7 @@ import {
 } from "@expo-google-fonts/inter";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { AuthNavigator } from "./src/navigation/AuthNavigator";
+import { ErrorBoundary } from "./src/components/ErrorBoundary";
 import { linkingConfig } from "./src/navigation/linkingConfig";
 import { navigationRef } from "./src/navigation/navigationRef";
 import { ThemeProvider, useTheme } from "./src/context/ThemeContext";
@@ -170,7 +171,9 @@ export default function App() {
       <SafeAreaProvider>
         <QueryClientProvider client={getAppQueryClient()}>
           <ThemeProvider>
-            <AppShell />
+            <ErrorBoundary>
+              <AppShell />
+            </ErrorBoundary>
           </ThemeProvider>
         </QueryClientProvider>
       </SafeAreaProvider>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  SafeAreaView,
+} from "react-native";
+
+interface Props {
+  children: React.ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends React.Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error("[ErrorBoundary]", error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <SafeAreaView style={styles.container}>
+          <Text style={styles.title}>Une erreur est survenue</Text>
+          <Text style={styles.subtitle}>Veuillez relancer l'application.</Text>
+          <TouchableOpacity
+            style={styles.button}
+            onPress={() => this.setState({ hasError: false })}
+          >
+            <Text style={styles.buttonText}>Réessayer</Text>
+          </TouchableOpacity>
+        </SafeAreaView>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#050816",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+  },
+  title: {
+    color: "#FFFFFF",
+    fontSize: 20,
+    fontWeight: "600",
+    marginBottom: 8,
+    textAlign: "center",
+  },
+  subtitle: {
+    color: "rgba(255,255,255,0.6)",
+    fontSize: 15,
+    marginBottom: 32,
+    textAlign: "center",
+  },
+  button: {
+    backgroundColor: "#6C63FF",
+    paddingHorizontal: 32,
+    paddingVertical: 14,
+    borderRadius: 12,
+  },
+  buttonText: {
+    color: "#FFFFFF",
+    fontSize: 16,
+    fontWeight: "600",
+  },
+});

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -36,6 +36,7 @@ export interface ReactionRealtimePayload {
 
 interface UseWebSocketOptions {
   userId: string;
+  deviceId?: string;
   token: string;
   onNewMessage?: (message: Message) => void;
   onMessageUpdated?: (message: Message) => void;
@@ -79,7 +80,7 @@ export const useWebSocket = (options: UseWebSocketOptions) => {
     setConnectionState(socket.connectionState);
 
     // connect() is a no-op if already connected
-    socket.connect(options.userId, options.token);
+    socket.connect(options.userId, options.token, options.deviceId);
 
     // channel() is idempotent — returns existing entry if already created.
     // join() adds to pendingTopics if socket isn't open yet; the onopen

--- a/src/navigation/AuthNavigator.tsx
+++ b/src/navigation/AuthNavigator.tsx
@@ -251,13 +251,6 @@ export const AuthNavigator: React.FC = () => {
   }, [isAuthenticated]);
 
   useEffect(() => {
-    // TODO: remove before ship — forces onboarding on every launch in dev
-    if (__DEV__) {
-      AsyncStorage.removeItem(ONBOARDING_KEY)
-        .then(() => setOnboardingDone(false))
-        .catch(() => setOnboardingDone(false));
-      return;
-    }
     AsyncStorage.getItem(ONBOARDING_KEY)
       .then((v) => setOnboardingDone(v === "1"))
       .catch(() => setOnboardingDone(false));

--- a/src/screens/Auth/OtpScreen.tsx
+++ b/src/screens/Auth/OtpScreen.tsx
@@ -117,7 +117,9 @@ export const OtpScreen: React.FC = () => {
    */
   const generateAndUploadSignalKeys = async (): Promise<void> => {
     try {
-      const bundle = await SignalKeyService.generateKeyBundle();
+      const bundle = await SignalKeyService.generateKeyBundle(
+        purpose === "register" ? "register" : "login",
+      );
 
       // Upload signed prekey (map camelCase DTO → snake_case API)
       await SignalKeysService.uploadSignedPrekey({

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -498,13 +498,18 @@ export const ChatScreen: React.FC = () => {
   const { userId: rawUserId } = useAuth();
   const userId = rawUserId ?? "";
   const [token, setToken] = useState<string>("");
+  const [deviceId, setDeviceId] = useState<string | undefined>(undefined);
 
   useEffect(() => {
     if (!userId) {
       setToken("");
+      setDeviceId(undefined);
       return;
     }
-    TokenService.getAccessToken().then((t) => setToken(t ?? ""));
+    TokenService.getAccessToken().then((t) => {
+      setToken(t ?? "");
+      if (t) setDeviceId(TokenService.decodeAccessToken(t)?.deviceId);
+    });
   }, [userId]);
 
   // WebSocket connection
@@ -516,6 +521,7 @@ export const ChatScreen: React.FC = () => {
     sendTyping,
   } = useWebSocket({
     userId,
+    deviceId,
     token,
     onPresenceUpdate: (presenceUserId: string, isOnline: boolean) => {
       setOnlineUsers((prev) => {
@@ -900,8 +906,6 @@ export const ChatScreen: React.FC = () => {
         for (const queued of pending) {
           try {
             let outgoingContent = queued.content;
-            let signature: string | undefined;
-            let sender_public_key: string | undefined;
             if (
               e2eeEnabledRef.current &&
               queued.message_type === "text" &&
@@ -923,8 +927,6 @@ export const ChatScreen: React.FC = () => {
                   recipientUserId: otherUserId,
                 });
                 outgoingContent = enc.content;
-                signature = enc.signature;
-                sender_public_key = enc.sender_public_key;
               }
             }
             const sent = await messagingAPI.sendMessage(conversationId, {
@@ -933,8 +935,6 @@ export const ChatScreen: React.FC = () => {
               client_random: queued.client_random,
               metadata: {},
               reply_to_id: queued.reply_to_id,
-              signature,
-              sender_public_key,
             });
             // Replace queued message with sent one
             setMessages((prev) =>
@@ -1629,8 +1629,6 @@ export const ChatScreen: React.FC = () => {
 
         try {
           let outgoingContent = content;
-          let signature: string | undefined;
-          let sender_public_key: string | undefined;
 
           // Blind the server: always use E2EE for direct chats if possible,
           // or if explicitly enabled via metadata (for groups).
@@ -1655,8 +1653,6 @@ export const ChatScreen: React.FC = () => {
                   recipientUserIds: otherUserIds,
                 });
                 outgoingContent = enc.content;
-                signature = enc.signature;
-                sender_public_key = enc.sender_public_key;
               } catch (encErr: any) {
                 logger.warn(
                   "ChatScreen",
@@ -1679,8 +1675,6 @@ export const ChatScreen: React.FC = () => {
                 // Otherwise (auto-e2ee for 1v1), we fallback to cleartext
                 // if the recipient is not E2EE-ready yet.
                 outgoingContent = content;
-                signature = undefined;
-                sender_public_key = undefined;
               }
             }
           }
@@ -1691,8 +1685,6 @@ export const ChatScreen: React.FC = () => {
             client_random: tempMessage.client_random as number,
             metadata: {},
             reply_to_id: replyToId,
-            signature,
-            sender_public_key,
           });
 
           setMessages((prev) => {
@@ -1718,8 +1710,11 @@ export const ChatScreen: React.FC = () => {
             .applyNewMessage({ ...(sent as any), content } as any, userId)
             .catch(() => {});
           useConversationsStore.getState().resetUnreadCount(conversationId);
-        } catch (error) {
+        } catch (error: any) {
           logger.error("ChatScreen", "Error sending message", error);
+          if (error?.body) {
+            logger.error("ChatScreen", "Send 422 body", error.body);
+          }
           setMessages((prev) => {
             return prev.map((m) => {
               if (m.id === tempMessage.id) {
@@ -2107,8 +2102,6 @@ export const ChatScreen: React.FC = () => {
 
         // 3. Send message via messaging-service with remote media URLs
         let finalContent = messageContent;
-        let signature: string | undefined;
-        let sender_public_key: string | undefined;
 
         if (e2eeMediaMeta) {
           const memberIdsForEnc =
@@ -2131,8 +2124,6 @@ export const ChatScreen: React.FC = () => {
                 recipientUserIds: otherUserIds,
               });
               finalContent = enc.content;
-              signature = enc.signature;
-              sender_public_key = enc.sender_public_key;
             } catch (encErr) {
               logger.warn(
                 "ChatScreen",
@@ -2153,8 +2144,6 @@ export const ChatScreen: React.FC = () => {
             e2ee: !!e2eeMediaMeta,
           },
           reply_to_id: replyToId,
-          signature,
-          sender_public_key,
         });
 
         // 4. Attach media record to the message (non-blocking — message already has metadata)

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -1459,15 +1459,19 @@ export const ChatScreen: React.FC = () => {
           });
           setHasMore(messagesWithRelations.length === MESSAGES_PAGE_SIZE);
         } else {
-          // Initial load — merge with any messages already received via WS
+          // Initial load — merge with any messages already received via WS.
+          // API versions take priority over cache so decrypted content
+          // replaces any encrypted placeholders loaded from cache.
           setMessages((prev) => {
-            const existingIds = new Set(prev.map((m) => m.id));
-            const newcomers = messagesWithRelations.filter(
-              (m) => !existingIds.has(m.id),
+            const apiById = new Map(
+              messagesWithRelations.map((m) => [m.id, m]),
             );
-            const withReplies = resolveReplies(newcomers, prev);
-            const merged = [...prev, ...withReplies];
-            return merged.sort(
+            const wsOnly = prev.filter((m) => !apiById.has(m.id));
+            const withReplies = resolveReplies(
+              [...messagesWithRelations, ...wsOnly],
+              [...messagesWithRelations, ...wsOnly],
+            );
+            return withReplies.sort(
               (a, b) =>
                 new Date(b.sent_at).getTime() - new Date(a.sent_at).getTime(),
             );

--- a/src/screens/Chat/__tests__/ChatScreen.test.tsx
+++ b/src/screens/Chat/__tests__/ChatScreen.test.tsx
@@ -72,7 +72,12 @@ jest.mock("../../../hooks/useWebSocket", () => ({
   }),
 }));
 jest.mock("../../../services/TokenService", () => ({
-  TokenService: { getAccessToken: jest.fn().mockResolvedValue("tok") },
+  TokenService: {
+    getAccessToken: jest.fn().mockResolvedValue("tok"),
+    decodeAccessToken: jest
+      .fn()
+      .mockReturnValue({ sub: "user-1", deviceId: "device-1" }),
+  },
 }));
 jest.mock("../../../services/messaging/api", () => ({
   messagingAPI: {

--- a/src/services/E2EEService.ts
+++ b/src/services/E2EEService.ts
@@ -309,30 +309,31 @@ export const E2EEService = {
         (d) => d !== deviceId,
       );
 
-      const myOtherBundles = await Promise.all(
-        myOtherDeviceIds.map(async (d) => {
-          try {
-            const cached = getCachedBundle(userId, d);
-            if (cached) {
-              return { user_id: userId, device_id: d, identity_key: cached };
-            }
-            const bundle = await SignalKeysService.getKeyBundle(userId, d);
-            setCachedBundle(userId, d, bundle.identity_key);
-            return {
+      for (const d of myOtherDeviceIds) {
+        try {
+          const cached = getCachedBundle(userId, d);
+          if (cached) {
+            myOtherRecipients.push({
               user_id: userId,
               device_id: d,
-              identity_key: bundle.identity_key,
-            };
-          } catch (err) {
-            console.warn(
-              `[E2EEService] Could not fetch bundle for own device ${d}:`,
-              err,
-            );
-            return null;
+              identity_key: cached,
+            });
+            continue;
           }
-        }),
-      );
-      myOtherRecipients = myOtherBundles.filter((b): b is any => b !== null);
+          const bundle = await SignalKeysService.getKeyBundle(userId, d);
+          setCachedBundle(userId, d, bundle.identity_key);
+          myOtherRecipients.push({
+            user_id: userId,
+            device_id: d,
+            identity_key: bundle.identity_key,
+          });
+        } catch (err) {
+          console.warn(
+            `[E2EEService] Could not fetch bundle for own device ${d}:`,
+            err,
+          );
+        }
+      }
     } catch (err) {
       console.warn("[E2EEService] Could not fetch keys for own devices:", err);
     }

--- a/src/services/E2EEService.ts
+++ b/src/services/E2EEService.ts
@@ -141,10 +141,40 @@ function isEnvelopeV1(value: unknown): value is E2EEEnvelopeV1 {
 let cachedIdentitySecretKey: Uint8Array | null = null;
 let cachedIdentityPublicKey: Uint8Array | null = null;
 
+// Key bundle cache — avoids hammering the backend rate limiter on every send.
+// TTL: 5 min (bundles change only when a device rotates prekeys, which is rare).
+const KEY_BUNDLE_CACHE_TTL_MS = 5 * 60 * 1000;
+const keyBundleCache = new Map<
+  string,
+  { identity_key: string; fetchedAt: number }
+>();
+
+function getCachedBundle(userId: string, deviceId: string): string | null {
+  const entry = keyBundleCache.get(`${userId}:${deviceId}`);
+  if (!entry) return null;
+  if (Date.now() - entry.fetchedAt > KEY_BUNDLE_CACHE_TTL_MS) {
+    keyBundleCache.delete(`${userId}:${deviceId}`);
+    return null;
+  }
+  return entry.identity_key;
+}
+
+function setCachedBundle(
+  userId: string,
+  deviceId: string,
+  identityKey: string,
+): void {
+  keyBundleCache.set(`${userId}:${deviceId}`, {
+    identity_key: identityKey,
+    fetchedAt: Date.now(),
+  });
+}
+
 export const __testing = {
   resetCache(): void {
     cachedIdentitySecretKey = null;
     cachedIdentityPublicKey = null;
+    keyBundleCache.clear();
   },
 };
 
@@ -237,7 +267,12 @@ export const E2EEService = {
           const bundles = await Promise.all(
             deviceIds.map(async (d) => {
               try {
+                const cached = getCachedBundle(uid, d);
+                if (cached) {
+                  return { user_id: uid, device_id: d, identity_key: cached };
+                }
                 const bundle = await SignalKeysService.getKeyBundle(uid, d);
+                setCachedBundle(uid, d, bundle.identity_key);
                 return {
                   user_id: uid,
                   device_id: d,
@@ -277,7 +312,12 @@ export const E2EEService = {
       const myOtherBundles = await Promise.all(
         myOtherDeviceIds.map(async (d) => {
           try {
+            const cached = getCachedBundle(userId, d);
+            if (cached) {
+              return { user_id: userId, device_id: d, identity_key: cached };
+            }
             const bundle = await SignalKeysService.getKeyBundle(userId, d);
+            setCachedBundle(userId, d, bundle.identity_key);
             return {
               user_id: userId,
               device_id: d,

--- a/src/services/messaging/api.ts
+++ b/src/services/messaging/api.ts
@@ -519,7 +519,7 @@ export const messagingAPI = {
     );
 
     if (!response.ok) {
-      throw httpError("Failed to send message", response);
+      throw await richHttpError("Failed to send message", response);
     }
 
     return unwrap(response);

--- a/src/services/messaging/websocket.ts
+++ b/src/services/messaging/websocket.ts
@@ -143,6 +143,7 @@ export class SocketConnection {
   private maxReconnectAttempts = 20;
   private shouldReconnect = false;
   private lastUserId: string | null = null;
+  private lastDeviceId: string | null = null;
   // Long-lived access token captured at connect()-time, used as a fallback
   // for the WS handshake if the dedicated /tokens/ws-token endpoint is
   // unreachable (network error or backend not yet rolled out). WHISPR-1214.
@@ -174,7 +175,11 @@ export class SocketConnection {
     return !!this.socket && this.socket.readyState === WebSocket.OPEN;
   }
 
-  async connect(userId: string, token: string): Promise<void> {
+  async connect(
+    userId: string,
+    token: string,
+    deviceId?: string,
+  ): Promise<void> {
     if (
       this.socket &&
       (this.socket.readyState === WebSocket.OPEN ||
@@ -187,6 +192,7 @@ export class SocketConnection {
 
     this.lastUserId = userId;
     this.lastToken = token;
+    this.lastDeviceId = deviceId ?? null;
     this.lastCloseCode = 0;
     this.shouldReconnect = true;
 
@@ -206,9 +212,12 @@ export class SocketConnection {
     }
 
     // Explicitly request v2 serializer so both sides agree on array format
+    const deviceParam = deviceId
+      ? `&device_id=${encodeURIComponent(deviceId)}`
+      : "";
     const url = `${getWsBaseUrl()}/messaging/socket/websocket?user_id=${encodeURIComponent(
       userId,
-    )}&token=${encodeURIComponent(wsToken)}&vsn=2.0.0`;
+    )}&token=${encodeURIComponent(wsToken)}${deviceParam}&vsn=2.0.0`;
 
     this.socket = new WebSocket(url);
     this.connecting = false;
@@ -439,7 +448,11 @@ export class SocketConnection {
 
         this.lastToken = token;
         this.socket = null;
-        this.connect(this.lastUserId!, this.lastToken);
+        this.connect(
+          this.lastUserId!,
+          this.lastToken,
+          this.lastDeviceId ?? undefined,
+        );
       } catch (err) {
         logger.warn("WS", "Token refresh failed during reconnect", err);
         this.shouldReconnect = false;

--- a/src/store/conversationsStore.ts
+++ b/src/store/conversationsStore.ts
@@ -339,7 +339,10 @@ export const useConversationsStore = create<
         data.map(async (conv) => ({
           ...conv,
           last_message: conv.last_message
-            ? await tryDecryptMessage(conv.last_message)
+            ? await tryDecryptMessage({
+                ...conv.last_message,
+                conversation_id: conv.last_message.conversation_id || conv.id,
+              })
             : conv.last_message,
         })),
       );
@@ -369,7 +372,10 @@ export const useConversationsStore = create<
         data.map(async (conv) => ({
           ...conv,
           last_message: conv.last_message
-            ? await tryDecryptMessage(conv.last_message)
+            ? await tryDecryptMessage({
+                ...conv.last_message,
+                conversation_id: conv.last_message.conversation_id || conv.id,
+              })
             : conv.last_message,
         })),
       );

--- a/src/store/conversationsStore.ts
+++ b/src/store/conversationsStore.ts
@@ -335,10 +335,18 @@ export const useConversationsStore = create<
       }
 
       const data = await messagingAPI.getConversations();
+      const decryptedPreviews = await Promise.all(
+        data.map(async (conv) => ({
+          ...conv,
+          last_message: conv.last_message
+            ? await tryDecryptMessage(conv.last_message)
+            : conv.last_message,
+        })),
+      );
       const userId = await getCurrentUserId();
       const enriched = userId
-        ? await enrichWithDisplayNames(data, userId)
-        : data;
+        ? await enrichWithDisplayNames(decryptedPreviews, userId)
+        : decryptedPreviews;
       await cacheService.saveConversations(enriched);
       _setConversations(enriched);
     } catch (err) {
@@ -357,10 +365,18 @@ export const useConversationsStore = create<
     const { _setConversations } = get();
     try {
       const data = await messagingAPI.getConversations();
+      const decryptedPreviews = await Promise.all(
+        data.map(async (conv) => ({
+          ...conv,
+          last_message: conv.last_message
+            ? await tryDecryptMessage(conv.last_message)
+            : conv.last_message,
+        })),
+      );
       const userId = await getCurrentUserId();
       const enriched = userId
-        ? await enrichWithDisplayNames(data, userId)
-        : data;
+        ? await enrichWithDisplayNames(decryptedPreviews, userId)
+        : decryptedPreviews;
       await cacheService.saveConversations(enriched);
       _setConversations(enriched, true);
     } catch (err) {


### PR DESCRIPTION
## Summary
- `generateAndUploadSignalKeys()` appelait `generateKeyBundle()` sans contexte, ce qui defaultait sur `"register"` → régénération d'une nouvelle identity key à chaque login
- Résultat : tous les messages reçus pendant la session précédente devenaient illisibles ([Message chiffré])
- Fix : passer `"login"` comme contexte sur le flow OTP normal (la 2FA path le faisait déjà correctement ligne 185)

## Root cause
```ts
// Avant (bug) — génère une NOUVELLE clé à chaque login
const bundle = await SignalKeyService.generateKeyBundle();

// Après (fix) — réutilise la clé existante
const bundle = await SignalKeyService.generateKeyBundle(
  purpose === "register" ? "register" : "login",
);
```

## Test plan
- [ ] Unit tests green
- [ ] Login → messages précédents déchiffrables
- [ ] Register → nouvelle clé générée correctement