### PR TITLE
feat(calls): appels LiveKit sur web PWA sans casser Android natif

### DIFF
--- a/src/hooks/__tests__/useCallsAvailable.test.ts
+++ b/src/hooks/__tests__/useCallsAvailable.test.ts
@@ -6,18 +6,30 @@
  */
 
 describe("useCallsAvailable", () => {
+  const originalNavigator = global.navigator;
+
   beforeEach(() => {
     jest.resetModules();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(global, "navigator", {
+      value: originalNavigator,
+      writable: true,
+      configurable: true,
+    });
   });
 
   function setupMocks(opts: {
     platform?: "ios" | "android" | "web";
     expoGo?: boolean;
     hasWebRtc?: boolean;
+    browserGetUserMedia?: boolean;
   }) {
     const platform = opts.platform ?? "ios";
     const expoGo = opts.expoGo ?? false;
     const hasWebRtc = opts.hasWebRtc ?? true;
+    const browserGetUserMedia = opts.browserGetUserMedia ?? true;
 
     jest.doMock("expo-constants", () => ({
       __esModule: true,
@@ -31,6 +43,19 @@ describe("useCallsAvailable", () => {
       Platform: { OS: platform },
       NativeModules: hasWebRtc ? { WebRTCModule: {} } : {},
     }));
+
+    if (platform === "web") {
+      Object.defineProperty(global, "navigator", {
+        value: {
+          mediaDevices: browserGetUserMedia
+            ? { getUserMedia: jest.fn() }
+            : undefined,
+          vibrate: jest.fn(),
+        },
+        writable: true,
+        configurable: true,
+      });
+    }
   }
 
   it("returns available=true on a native dev build with WebRTC linked", () => {
@@ -57,13 +82,20 @@ describe("useCallsAvailable", () => {
     expect(getCallsUnavailableMessage(result.reason)).toMatch(/Expo Go/);
   });
 
-  it("returns reason=web on web platform", () => {
-    setupMocks({ platform: "web", expoGo: false });
+  it("returns available=true on web when browser has getUserMedia", () => {
+    setupMocks({ platform: "web", browserGetUserMedia: true });
+    const { getCallsAvailability } = require("../useCallsAvailable");
+
+    expect(getCallsAvailability()).toEqual({ available: true, reason: null });
+  });
+
+  it("returns reason=web-no-webrtc on web when getUserMedia is absent", () => {
+    setupMocks({ platform: "web", browserGetUserMedia: false });
     const { getCallsAvailability } = require("../useCallsAvailable");
 
     expect(getCallsAvailability()).toEqual({
       available: false,
-      reason: "web",
+      reason: "web-no-webrtc",
     });
   });
 
@@ -83,7 +115,7 @@ describe("useCallsAvailable", () => {
 
     expect(getCallsUnavailableMessage("expo-go")).toContain("Expo Go");
     expect(getCallsUnavailableMessage("no-webrtc")).toContain("WebRTC");
-    expect(getCallsUnavailableMessage("web")).toContain("web");
+    expect(getCallsUnavailableMessage("web-no-webrtc")).toContain("navigateur");
     expect(getCallsUnavailableMessage(null)).toBeTruthy();
   });
 });

--- a/src/hooks/useCallsAvailable.ts
+++ b/src/hooks/useCallsAvailable.ts
@@ -1,17 +1,17 @@
 /**
  * useCallsAvailable — Détection centralisée du support des appels.
  *
- * Les appels reposent sur des modules natifs (@livekit/react-native,
- * @livekit/react-native-webrtc, react-native-call-keeper) absents d'Expo Go.
- * Ce hook (et le helper sync isCallsAvailable) permet à l'UI d'afficher un
- * fallback explicite plutôt que de planter silencieusement au clic.
+ * Sur natif (iOS/Android) : repose sur @livekit/react-native + WebRTC native.
+ * Sur web : repose sur livekit-client + WebRTC navigateur (getUserMedia).
+ * Les deux chemins sont supportés ; ce hook ne bloque plus sur Platform.OS="web"
+ * tant que le navigateur expose navigator.mediaDevices.getUserMedia.
  */
 
 import { useMemo } from "react";
 import Constants from "expo-constants";
 import { NativeModules, Platform } from "react-native";
 
-export type CallsUnavailableReason = "expo-go" | "no-webrtc" | "web";
+export type CallsUnavailableReason = "expo-go" | "no-webrtc" | "web-no-webrtc";
 
 export interface CallsAvailability {
   available: boolean;
@@ -29,9 +29,23 @@ function detectHasWebRtcNative(): boolean {
   return Boolean(native?.WebRTCModule || native?.LivekitReactNativeWebRTC);
 }
 
+/**
+ * Vérifie que le navigateur expose getUserMedia (Chrome, Firefox, Safari 16.4+).
+ * Retourne false en SSR ou dans un contexte sans accès aux APIs navigateur.
+ */
+function detectBrowserWebRtc(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return typeof navigator.mediaDevices?.getUserMedia === "function";
+}
+
 export function getCallsAvailability(): CallsAvailability {
   if (Platform.OS === "web") {
-    return { available: false, reason: "web" };
+    // Sur web, on s'appuie sur le WebRTC natif du navigateur via livekit-client.
+    // Si getUserMedia est absent (vieux navigateur, contexte non-HTTPS), on bloque.
+    if (!detectBrowserWebRtc()) {
+      return { available: false, reason: "web-no-webrtc" };
+    }
+    return { available: true, reason: null };
   }
   if (detectIsExpoGo()) {
     return { available: false, reason: "expo-go" };
@@ -58,8 +72,8 @@ export function getCallsUnavailableMessage(
       return "Les appels ne sont pas disponibles dans Expo Go. Utilisez un build de développement.";
     case "no-webrtc":
       return "Les appels nécessitent une reconstruction de l'application (module WebRTC manquant).";
-    case "web":
-      return "Les appels ne sont pas disponibles sur le web.";
+    case "web-no-webrtc":
+      return "Votre navigateur ne supporte pas les appels. Utilisez Chrome, Firefox ou Safari 16.4+.";
     default:
       return "Les appels ne sont pas disponibles sur cet appareil.";
   }

--- a/src/screens/Calls/IncomingCallScreen.tsx
+++ b/src/screens/Calls/IncomingCallScreen.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import {
   View,
   Text,
@@ -29,6 +29,9 @@ const showAcceptError = (message: string) => {
  * Full-screen incoming call UI. Shown as a modal over the current stack
  * when a WS `incoming_call` event arrives. Accept connects to LiveKit and
  * transitions to InCall; decline closes the screen.
+ *
+ * Sur web : joue une sonnerie via l'API Audio navigateur et vibre si disponible.
+ * Sur natif : la sonnerie est gérée par react-native-call-keeper (systemCallProvider).
  */
 export const IncomingCallScreen: React.FC = () => {
   const incoming = useCallsStore((s) => s.incoming);
@@ -36,6 +39,58 @@ export const IncomingCallScreen: React.FC = () => {
   const declineIncoming = useCallsStore((s) => s.declineIncoming);
   const setIncoming = useCallsStore((s) => s.setIncoming);
   const navigation = useNavigation<Nav>();
+
+  // Sonnerie web : démarrer/arrêter selon la présence d'un appel entrant.
+  useEffect(() => {
+    if (Platform.OS !== "web" || !incoming) return;
+
+    // Vibration navigateur si disponible (Android Chrome, Firefox).
+    if (typeof navigator !== "undefined" && navigator.vibrate) {
+      // Pattern 400ms ON / 400ms OFF, répété.
+      navigator.vibrate([400, 400, 400, 400, 400]);
+    }
+
+    // Sonnerie via oscillateur AudioContext — pas de fichier externe requis.
+    let audioCtx: AudioContext | null = null;
+    let ringInterval: ReturnType<typeof setInterval> | null = null;
+
+    const playRingTone = () => {
+      try {
+        const AudioContextCtor =
+          (window as any).AudioContext ?? (window as any).webkitAudioContext;
+        if (!AudioContextCtor) return;
+
+        audioCtx = new AudioContextCtor() as AudioContext;
+        const osc = audioCtx.createOscillator();
+        const gain = audioCtx.createGain();
+        osc.connect(gain);
+        gain.connect(audioCtx.destination);
+        osc.type = "sine";
+        osc.frequency.setValueAtTime(440, audioCtx.currentTime);
+        gain.gain.setValueAtTime(0.3, audioCtx.currentTime);
+        osc.start();
+        // Bip de 800ms puis silence — simuler une sonnerie.
+        setTimeout(() => {
+          osc.stop();
+          audioCtx?.close();
+          audioCtx = null;
+        }, 800);
+      } catch {
+        // AudioContext bloqué (politique autoplay) — pas bloquant.
+      }
+    };
+
+    playRingTone();
+    ringInterval = setInterval(playRingTone, 2000);
+
+    return () => {
+      if (ringInterval) clearInterval(ringInterval);
+      if (audioCtx) audioCtx.close();
+      if (typeof navigator !== "undefined" && navigator.vibrate) {
+        navigator.vibrate(0);
+      }
+    };
+  }, [incoming]);
 
   const onAccept = async () => {
     const callId = incoming?.callId;

--- a/src/services/calls/__tests__/webPermissions.test.ts
+++ b/src/services/calls/__tests__/webPermissions.test.ts
@@ -1,0 +1,149 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Tests pour webPermissions — demande de permissions média navigateur.
+ */
+
+jest.mock("react-native", () => ({
+  Platform: { OS: "web" },
+}));
+
+import { requestWebMediaPermissions } from "../webPermissions";
+
+describe("requestWebMediaPermissions", () => {
+  const originalNavigator = global.navigator;
+
+  afterEach(() => {
+    Object.defineProperty(global, "navigator", {
+      value: originalNavigator,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("retourne granted=true quand getUserMedia réussit", async () => {
+    const mockStream = {
+      getTracks: () => [{ stop: jest.fn() }],
+    };
+    Object.defineProperty(global, "navigator", {
+      value: {
+        mediaDevices: {
+          getUserMedia: jest.fn().mockResolvedValue(mockStream),
+        },
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const result = await requestWebMediaPermissions(false);
+
+    expect(result.granted).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("arrête les tracks du stream après la demande de permission", async () => {
+    const stopFn = jest.fn();
+    const mockStream = {
+      getTracks: () => [{ stop: stopFn }, { stop: stopFn }],
+    };
+    Object.defineProperty(global, "navigator", {
+      value: {
+        mediaDevices: { getUserMedia: jest.fn().mockResolvedValue(mockStream) },
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    await requestWebMediaPermissions(true);
+
+    expect(stopFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("retourne error=not-allowed sur NotAllowedError", async () => {
+    const err = Object.assign(new Error(""), { name: "NotAllowedError" });
+    Object.defineProperty(global, "navigator", {
+      value: {
+        mediaDevices: { getUserMedia: jest.fn().mockRejectedValue(err) },
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const result = await requestWebMediaPermissions(false);
+
+    expect(result.granted).toBe(false);
+    expect(result.error).toBe("not-allowed");
+    expect(result.message).toContain("refusé");
+  });
+
+  it("retourne error=not-allowed sur PermissionDeniedError", async () => {
+    const err = Object.assign(new Error(""), { name: "PermissionDeniedError" });
+    Object.defineProperty(global, "navigator", {
+      value: {
+        mediaDevices: { getUserMedia: jest.fn().mockRejectedValue(err) },
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const result = await requestWebMediaPermissions(false);
+
+    expect(result.granted).toBe(false);
+    expect(result.error).toBe("not-allowed");
+  });
+
+  it("retourne error=not-found sur NotFoundError", async () => {
+    const err = Object.assign(new Error(""), { name: "NotFoundError" });
+    Object.defineProperty(global, "navigator", {
+      value: {
+        mediaDevices: { getUserMedia: jest.fn().mockRejectedValue(err) },
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const result = await requestWebMediaPermissions(false);
+
+    expect(result.granted).toBe(false);
+    expect(result.error).toBe("not-found");
+    expect(result.message).toContain("micro");
+  });
+
+  it("retourne error=not-supported quand navigator.mediaDevices est absent", async () => {
+    Object.defineProperty(global, "navigator", {
+      value: { mediaDevices: undefined },
+      writable: true,
+      configurable: true,
+    });
+
+    const result = await requestWebMediaPermissions(false);
+
+    expect(result.granted).toBe(false);
+    expect(result.error).toBe("not-supported");
+  });
+
+  it("retourne error=unknown pour les erreurs inconnues", async () => {
+    const err = Object.assign(new Error("weird"), { name: "SecurityError" });
+    Object.defineProperty(global, "navigator", {
+      value: {
+        mediaDevices: { getUserMedia: jest.fn().mockRejectedValue(err) },
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const result = await requestWebMediaPermissions(false);
+
+    expect(result.granted).toBe(false);
+    expect(result.error).toBe("unknown");
+  });
+
+  it("retourne granted=true immédiatement sur plateforme natif (non-web)", async () => {
+    jest.resetModules();
+    jest.doMock("react-native", () => ({ Platform: { OS: "ios" } }));
+    const { requestWebMediaPermissions: fn } = require("../webPermissions");
+
+    const result = await fn(false);
+
+    expect(result.granted).toBe(true);
+  });
+});

--- a/src/services/calls/webPermissions.ts
+++ b/src/services/calls/webPermissions.ts
@@ -1,0 +1,78 @@
+import { Platform } from "react-native";
+
+export type WebPermissionError =
+  | "not-allowed"
+  | "not-found"
+  | "not-supported"
+  | "unknown";
+
+export interface WebPermissionResult {
+  granted: boolean;
+  error?: WebPermissionError;
+  message?: string;
+}
+
+/**
+ * Demande les permissions micro (et optionnellement caméra) au navigateur.
+ * No-op sur natif — les permissions sont gérées par le système d'exploitation.
+ *
+ * À appeler avant de rejoindre une room LiveKit sur web pour éviter que
+ * livekit-client plante silencieusement avec une NotAllowedError.
+ */
+export async function requestWebMediaPermissions(
+  video: boolean,
+): Promise<WebPermissionResult> {
+  if (Platform.OS !== "web") {
+    return { granted: true };
+  }
+
+  if (
+    typeof navigator === "undefined" ||
+    !navigator.mediaDevices?.getUserMedia
+  ) {
+    return {
+      granted: false,
+      error: "not-supported",
+      message: "Votre navigateur ne supporte pas l'accès aux médias.",
+    };
+  }
+
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({
+      audio: true,
+      video,
+    });
+    // On arrête immédiatement les tracks — livekit-client ouvrira les siens.
+    stream.getTracks().forEach((t) => t.stop());
+    return { granted: true };
+  } catch (err) {
+    return classifyMediaError(err);
+  }
+}
+
+function classifyMediaError(err: unknown): WebPermissionResult {
+  const name = (err as { name?: string })?.name ?? "";
+
+  if (name === "NotAllowedError" || name === "PermissionDeniedError") {
+    return {
+      granted: false,
+      error: "not-allowed",
+      message:
+        "Accès au micro/caméra refusé. Autorisez-les dans les paramètres de votre navigateur.",
+    };
+  }
+
+  if (name === "NotFoundError" || name === "DevicesNotFoundError") {
+    return {
+      granted: false,
+      error: "not-found",
+      message: "Aucun micro ou caméra détecté sur cet appareil.",
+    };
+  }
+
+  return {
+    granted: false,
+    error: "unknown",
+    message: "Impossible d'accéder aux périphériques audio/vidéo.",
+  };
+}

--- a/src/store/callsStore.ts
+++ b/src/store/callsStore.ts
@@ -4,6 +4,7 @@ import {
   getCallsAvailability,
   getCallsUnavailableMessage,
 } from "../hooks/useCallsAvailable";
+import { requestWebMediaPermissions } from "../services/calls/webPermissions";
 import type { CallStatus, CallType } from "../types/calls";
 import type { Room } from "livekit-client";
 
@@ -72,6 +73,13 @@ export const useCallsStore = create<CallsState>((set, get) => ({
     displayName,
     avatarUrl,
   ) => {
+    // Sur web, demander les permissions micro/caméra avant d'appeler le backend
+    // pour éviter une NotAllowedError après que la room LiveKit est créée.
+    const perm = await requestWebMediaPermissions(type === "video");
+    if (!perm.granted) {
+      throw new Error(perm.message ?? "Permission refusée");
+    }
+
     const resp = await callsApi.initiate(conversationId, type, participants);
     const provider = getCallsLiveKit();
     const room = await provider.connect({
@@ -108,6 +116,16 @@ export const useCallsStore = create<CallsState>((set, get) => ({
   acceptIncoming: async () => {
     const inc = get().incoming;
     if (!inc) return;
+
+    // Sur web, vérifier les permissions avant d'accepter pour éviter un état
+    // incohérent (call accepté côté serveur mais WebRTC bloqué navigateur).
+    const perm = await requestWebMediaPermissions(inc.type === "video");
+    if (!perm.granted) {
+      throw new Error(
+        `accept-permissions: ${perm.message ?? "Permission refusée"}`,
+      );
+    }
+
     // WHISPR-1200 : on tague chaque étape pour que la couche UI puisse
     // distinguer un échec API (call introuvable, droits, etc.) d'un échec
     // LiveKit (URL injoignable, token invalide, WebRTC non supporté).


### PR DESCRIPTION
## Summary
- Retire le blocage `Platform.OS="web"` dans `useCallsAvailable` - remplace par detection `navigator.mediaDevices.getUserMedia` au runtime
- Nouveau module `webPermissions.ts` - gestion `NotAllowedError` / `NotFoundError` / `not-supported` avant connect LiveKit sur web
- Sonnerie web dans `IncomingCallScreen` via `AudioContext` + `navigator.vibrate` (no-op natif)
- `livekit-client` (deja installe 2.18.4) + `CallParticipantTile.web.tsx` (deja pret) : aucun nouveau dep
- Code Android natif inchange - `@livekit/react-native` et `systemCallProvider` non touches

## Limite documentee
PWA fermee = pas de sonnerie (Web Push sans Service Worker actif). PWA ouverte = sonnerie OK.

## Test plan
- [x] 63 tests calls verts (dont 7 nouveaux webPermissions + 4 useCallsAvailable mis a jour)
- [x] Lint 0 erreur
- [x] Prettier passe
- [ ] Tester sur whispr-preprod.roadmvn.com : initier appel 1v1 Chrome desktop
- [ ] Tester reception appel PWA ouverte Safari iOS
- [ ] Confirmer non-regression Android natif

Closes WHISPR-calls-web