### PR TITLE
fix(tour): prevent autostart race condition on app relaunch

### DIFF
--- a/src/context/TourContext.tsx
+++ b/src/context/TourContext.tsx
@@ -24,17 +24,17 @@ const TourContext = createContext<TourContextType>({
 export const TourProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const [isTourActive, setIsTourActive] = useState(true);
+  const [isTourActive, setIsTourActive] = useState(false);
 
-  // charger la valeur persistée au montage
   useEffect(() => {
     AsyncStorage.getItem(TOUR_STORAGE_KEY)
       .then((stored) => {
-        if (stored !== null) {
-          setIsTourActive(stored === "true");
-        }
+        // null = premier lancement → activer ; sinon respecter la valeur persistée
+        setIsTourActive(stored === null || stored === "true");
       })
-      .catch(() => {});
+      .catch(() => {
+        setIsTourActive(true);
+      });
   }, []);
 
   const skipTour = useCallback(() => {


### PR DESCRIPTION
## Summary
- `useState(true)` dans `TourProvider` causait un démarrage immédiat du tour avant que `AsyncStorage.getItem` ait répondu
- `TourAutoStart` a un délai de 700ms, mais AsyncStorage peut être plus lent → le tour se relançait à chaque ouverture même après désactivation
- Fix : initialiser à `false`, activer uniquement si `stored === null` (premier lancement) ou `stored === "true"`

## Test plan
- [x] Unit tests green (5/5 sur TourContext)
- [x] TypeScript check clean
- [x] Désactiver le tour dans Settings → relancer l'app → tour ne se relance plus