### PR TITLE
fix(groups): resolve user-service group UUID from conversation externalGroupId

### DIFF
--- a/src/services/groups/__tests__/api.test.ts
+++ b/src/services/groups/__tests__/api.test.ts
@@ -379,7 +379,14 @@ describe("groupsAPI.getGroupLogs", () => {
 // ---------------- getGroupSettings ----------------
 
 describe("groupsAPI.getGroupSettings", () => {
-  it("GETs /user/v1/groups/:groupId/settings and returns parsed settings", async () => {
+  it("resolves externalGroupId from conversation and GETs settings with it", async () => {
+    // 1st call: fetch conversation → externalGroupId = "real-uuid"
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        body: { data: { id: "conv-1", externalGroupId: "real-uuid" } },
+      }),
+    );
+    // 2nd call: GET settings using the resolved UUID
     mockFetch.mockResolvedValueOnce(
       mockResponse({
         body: {
@@ -394,16 +401,41 @@ describe("groupsAPI.getGroupSettings", () => {
       }),
     );
 
-    const settings = await groupsAPI.getGroupSettings("grp-1");
+    const settings = await groupsAPI.getGroupSettings("conv-1", {
+      conversationId: "conv-1",
+    });
 
-    expect(mockFetch.mock.calls[0][0]).toBe(
-      `${USER_BASE}/groups/grp-1/settings`,
+    expect(mockFetch.mock.calls[0][0]).toBe(`${MSG_BASE}/conversations/conv-1`);
+    expect(mockFetch.mock.calls[1][0]).toBe(
+      `${USER_BASE}/groups/real-uuid/settings`,
     );
     expect(settings.message_permission).toBe("moderators_plus");
     expect(settings.moderation_level).toBe("strict");
   });
 
-  it("returns defaults when the backend returns a non-OK status", async () => {
+  it("falls back to groupId when conversation has no externalGroupId", async () => {
+    // 1st call: conversation with no externalGroupId
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ body: { data: { id: "grp-1" } } }),
+    );
+    // 2nd call: settings
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ body: { message_permission: "all_members" } }),
+    );
+
+    await groupsAPI.getGroupSettings("grp-1");
+
+    expect(mockFetch.mock.calls[1][0]).toBe(
+      `${USER_BASE}/groups/grp-1/settings`,
+    );
+  });
+
+  it("returns defaults when the settings endpoint returns a non-OK status", async () => {
+    // conversation fetch
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ body: { data: { id: "grp-1" } } }),
+    );
+    // settings 404
     mockFetch.mockResolvedValueOnce(mockResponse({ status: 404 }));
 
     const settings = await groupsAPI.getGroupSettings("grp-1");
@@ -417,24 +449,17 @@ describe("groupsAPI.getGroupSettings", () => {
       join_approval_required: false,
     });
   });
-
-  it("ignores the conversationId param (no longer used)", async () => {
-    mockFetch.mockResolvedValueOnce(
-      mockResponse({ body: { message_permission: "all_members" } }),
-    );
-
-    await groupsAPI.getGroupSettings("grp-1", { conversationId: "conv-X" });
-
-    expect(mockFetch.mock.calls[0][0]).toBe(
-      `${USER_BASE}/groups/grp-1/settings`,
-    );
-  });
 });
 
 // ---------------- updateGroupSettings ----------------
 
 describe("groupsAPI.updateGroupSettings", () => {
-  it("PATCHes /user/v1/groups/:groupId/settings and returns updated settings", async () => {
+  it("resolves externalGroupId then PATCHes settings with it", async () => {
+    // 1st call: conversation → externalGroupId
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ body: { data: { externalGroupId: "real-uuid" } } }),
+    );
+    // 2nd call: PATCH settings
     mockFetch.mockResolvedValueOnce(
       mockResponse({
         body: {
@@ -449,43 +474,53 @@ describe("groupsAPI.updateGroupSettings", () => {
       }),
     );
 
-    const result = await groupsAPI.updateGroupSettings("grp-1", {
-      message_permission: "admins_only",
-    });
+    const result = await groupsAPI.updateGroupSettings(
+      "conv-1",
+      { message_permission: "admins_only" },
+      { conversationId: "conv-1" },
+    );
 
-    const call = mockFetch.mock.calls[0];
-    expect(call[0]).toBe(`${USER_BASE}/groups/grp-1/settings`);
-    expect(call[1].method).toBe("PATCH");
-    expect(JSON.parse(call[1].body)).toEqual({
+    const patchCall = mockFetch.mock.calls[1];
+    expect(patchCall[0]).toBe(`${USER_BASE}/groups/real-uuid/settings`);
+    expect(patchCall[1].method).toBe("PATCH");
+    expect(JSON.parse(patchCall[1].body)).toEqual({
       message_permission: "admins_only",
     });
     expect(result.message_permission).toBe("admins_only");
   });
 
+  it("falls back to groupId when conversation has no externalGroupId", async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ body: { data: { id: "grp-1" } } }),
+    );
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ body: { message_permission: "all_members" } }),
+    );
+
+    await groupsAPI.updateGroupSettings("grp-1", {});
+
+    expect(mockFetch.mock.calls[1][0]).toBe(
+      `${USER_BASE}/groups/grp-1/settings`,
+    );
+  });
+
   it("throws when the PATCH fails", async () => {
+    // conversation fetch
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ body: { data: { externalGroupId: "real-uuid" } } }),
+    );
+    // PATCH 403
     mockFetch.mockResolvedValueOnce(
       mockResponse({ status: 403, textBody: "forbidden" }),
     );
 
     await expect(
-      groupsAPI.updateGroupSettings("grp-1", { moderation_level: "strict" }),
+      groupsAPI.updateGroupSettings(
+        "conv-1",
+        { moderation_level: "strict" },
+        { conversationId: "conv-1" },
+      ),
     ).rejects.toThrow(/Impossible de mettre a jour les parametres \(403\)/);
-  });
-
-  it("ignores the conversationId param (no longer used)", async () => {
-    mockFetch.mockResolvedValueOnce(
-      mockResponse({ body: { message_permission: "all_members" } }),
-    );
-
-    await groupsAPI.updateGroupSettings(
-      "grp-1",
-      {},
-      { conversationId: "conv-X" },
-    );
-
-    expect(mockFetch.mock.calls[0][0]).toBe(
-      `${USER_BASE}/groups/grp-1/settings`,
-    );
   });
 });
 

--- a/src/services/groups/api.ts
+++ b/src/services/groups/api.ts
@@ -823,11 +823,15 @@ export const groupsAPI = {
 
   async getGroupSettings(
     groupId: string,
-    _params?: { conversationId?: string },
+    params?: { conversationId?: string },
   ): Promise<GroupSettings> {
     const headers = await getAuthHeaders();
+    const convId = params?.conversationId || groupId;
+    const conv = await fetchMessagingConversationPayload(convId, headers);
+    const userServiceGroupId =
+      conv?.externalGroupId || conv?.external_group_id || groupId;
     const res = await fetch(
-      `${API_BASE_URL}/groups/${encodeURIComponent(groupId)}/settings`,
+      `${API_BASE_URL}/groups/${encodeURIComponent(userServiceGroupId)}/settings`,
       { headers },
     );
     if (!res.ok) {
@@ -839,11 +843,15 @@ export const groupsAPI = {
   async updateGroupSettings(
     groupId: string,
     updates: Partial<GroupSettings>,
-    _params?: { conversationId?: string },
+    params?: { conversationId?: string },
   ): Promise<GroupSettings> {
     const headers = await getAuthHeaders();
+    const convId = params?.conversationId || groupId;
+    const conv = await fetchMessagingConversationPayload(convId, headers);
+    const userServiceGroupId =
+      conv?.externalGroupId || conv?.external_group_id || groupId;
     const res = await fetch(
-      `${API_BASE_URL}/groups/${encodeURIComponent(groupId)}/settings`,
+      `${API_BASE_URL}/groups/${encodeURIComponent(userServiceGroupId)}/settings`,
       {
         method: "PATCH",
         headers: { "Content-Type": "application/json", ...headers },


### PR DESCRIPTION
## Summary
- `getGroupSettings` and `updateGroupSettings` now fetch the messaging conversation first and use `externalGroupId` (or `external_group_id`) as the actual user-service group UUID
- Falls back to the original `groupId` when the field is absent
- Fixes the \"Group not found\" 404 that appeared when saving group settings from the simulator

## Root cause
`ChatScreen` passes the messaging conversation ID as `groupId` when navigating to `GroupDetailsScreen`. The user-service `PATCH /groups/:id/settings` expects the user-service group UUID, not the messaging conversation ID, so every save failed with 404.

## Test plan
- [x] Unit tests updated and green (47 tests pass)
- [x] Lint clean
- [ ] Tested on iOS simulator — group settings save without error

Closes WHISPR-961