### PR TITLE
chore(android): renommer le package vers com.roadmvn.whispr.preprod

### DIFF
--- a/app.json
+++ b/app.json
@@ -18,7 +18,7 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.anonymous.Whispr-Frontend",
+      "bundleIdentifier": "com.roadmvn.whispr.preprod",
       "infoPlist": {
         "NSAppTransportSecurity": {
           "NSAllowsLocalNetworking": true
@@ -35,7 +35,7 @@
         "backgroundColor": "#ffffff"
       },
       "edgeToEdgeEnabled": true,
-      "package": "whispr.test1702",
+      "package": "com.roadmvn.whispr.preprod",
       "googleServicesFile": "./google-services.json",
       "permissions": [
         "RECORD_AUDIO",


### PR DESCRIPTION
## Résumé
- `android.package` : `whispr.test1702` → `com.roadmvn.whispr.preprod`
- `ios.bundleIdentifier` : `com.anonymous.Whispr-Frontend` → `com.roadmvn.whispr.preprod`

Prérequis avant de lancer le build EAS (voir WHISPR-1536).

## Test plan
- [ ] `eas build --platform android --profile preprod` produit un APK sans erreur de package conflict
- [ ] Identifiants cohérents Android / iOS

Closes WHISPR-1536