### PR TITLE
Revert PR #296 rename package android

### DIFF
--- a/app.json
+++ b/app.json
@@ -18,7 +18,7 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.roadmvn.whispr.preprod",
+      "bundleIdentifier": "com.anonymous.Whispr-Frontend",
       "infoPlist": {
         "NSAppTransportSecurity": {
           "NSAllowsLocalNetworking": true
@@ -35,7 +35,7 @@
         "backgroundColor": "#ffffff"
       },
       "edgeToEdgeEnabled": true,
-      "package": "com.roadmvn.whispr.preprod",
+      "package": "whispr.test1702",
       "googleServicesFile": "./google-services.json",
       "permissions": [
         "RECORD_AUDIO",


### PR DESCRIPTION
Revert du rename app.json. Tudy ne voulait pas changer le package native, on garde whispr.test1702. Closes WHISPR-1536-revert