### PR TITLE
fix(safety-number): parcourir tous les appareils pour trouver un bundle valide

### DIFF
--- a/src/components/Chat/SafetyNumberModal.tsx
+++ b/src/components/Chat/SafetyNumberModal.tsx
@@ -59,14 +59,21 @@ export const SafetyNumberModal: React.FC<SafetyNumberModalProps> = ({
       .catch(() => {
         throw new Error("NO_DEVICE");
       })
-      .then((r) => {
-        const firstDevice = r.deviceIds[0];
-        if (!firstDevice) throw new Error("NO_DEVICE");
-        return SignalKeysService.getKeyBundle(contactUserId, firstDevice).catch(
-          () => {
-            throw new Error("NO_THEIR_KEYS");
-          },
-        );
+      .then(async (r) => {
+        if (!r.deviceIds.length) throw new Error("NO_DEVICE");
+        // Certains appareils enregistrés ont une identityKey vide ("") —
+        // on parcourt la liste jusqu'au premier appareil avec un bundle valide.
+        for (const deviceId of r.deviceIds) {
+          try {
+            return await SignalKeysService.getKeyBundle(
+              contactUserId,
+              deviceId,
+            );
+          } catch {
+            // bundle invalide ou absent pour cet appareil, on essaie le suivant
+          }
+        }
+        throw new Error("NO_THEIR_KEYS");
       });
 
     Promise.all([

--- a/src/components/Chat/__tests__/SafetyNumberModal.test.tsx
+++ b/src/components/Chat/__tests__/SafetyNumberModal.test.tsx
@@ -122,6 +122,21 @@ describe("SafetyNumberModal", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it("falls back to next device when first device has invalid bundle", async () => {
+    mockListDevices.mockResolvedValue({
+      userId: "user-b",
+      deviceIds: ["device-b-bad", "device-b-good"],
+    });
+    mockGetKeyBundle.mockImplementation((userId: string, deviceId: string) => {
+      if (userId === "user-a") return Promise.resolve(MY_BUNDLE);
+      if (deviceId === "device-b-bad")
+        return Promise.reject(new Error("INVALID_SIGNAL_BUNDLE"));
+      return Promise.resolve(THEIR_BUNDLE);
+    });
+    const { findByText } = render(<SafetyNumberModal {...defaultProps} />);
+    expect(await findByText("12345")).toBeTruthy();
+  });
+
   it("marks contact as verified and calls onVerified", async () => {
     const onVerified = jest.fn();
     const onClose = jest.fn();

--- a/src/services/SignalKeyService.ts
+++ b/src/services/SignalKeyService.ts
@@ -41,7 +41,7 @@ function toBase64(bytes: Uint8Array): string {
 
 export type KeyBundleContext = "register" | "login" | "recovery";
 
-function deriveIdentityPublicKey(secretKey: Uint8Array): Uint8Array {
+export function deriveIdentityPublicKey(secretKey: Uint8Array): Uint8Array {
   // nacl.box.keyPair() retourne une secretKey de 32 bytes.
   // slice(32, 64) sur 32 bytes = tableau vide → publicKey vide → identityKey ""
   // On utilise fromSecretKey pour reconstruire la paire correctement.

--- a/src/services/__tests__/deriveIdentityPublicKey.test.ts
+++ b/src/services/__tests__/deriveIdentityPublicKey.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests sans mock nacl pour garantir que deriveIdentityPublicKey
+ * produit bien une cle publique valide de 32 bytes non nulle.
+ *
+ * Regression guard contre le bug identityKey="" (WHISPR-safety-number-empty-key) :
+ * si fromSecretKey est remplace par .secretKey.slice(32,64) la cle devient vide.
+ */
+
+// Ces tests utilisent le vrai nacl — pas de mock global ici.
+// Le préfixe "mock" est requis pour que jest.mock() puisse accéder à cette variable
+// (babel-jest autorise uniquement les variables prefixées "mock" dans les factory functions).
+let mockCallCount = 0;
+jest.mock("expo-crypto", () => ({
+  getRandomBytes: jest.fn((n: number) => {
+    mockCallCount++;
+    const buf = new Uint8Array(n);
+    // Chaque appel produit une séquence différente grâce au compteur,
+    // ce qui garantit que nacl.box.keyPair() génère des paires distinctes.
+    for (let i = 0; i < n; i++)
+      buf[i] = ((mockCallCount * 97 + i + 1) * 37) & 0xff;
+    return buf;
+  }),
+}));
+
+jest.mock("../TokenService", () => ({
+  TokenService: {
+    saveIdentityPrivateKey: jest.fn().mockResolvedValue(undefined),
+    getIdentityPrivateKey: jest.fn().mockResolvedValue(null),
+  },
+}));
+
+jest.mock("../E2EEService", () => ({
+  E2EEService: {
+    resetIdentityCache: jest.fn(),
+  },
+}));
+
+import nacl from "tweetnacl";
+import { deriveIdentityPublicKey } from "../SignalKeyService";
+
+describe("deriveIdentityPublicKey (real nacl)", () => {
+  it("retourne une Uint8Array de 32 bytes", () => {
+    const secretKey = nacl.box.keyPair().secretKey;
+    const pubKey = deriveIdentityPublicKey(secretKey);
+    expect(pubKey).toBeInstanceOf(Uint8Array);
+    expect(pubKey.length).toBe(32);
+  });
+
+  it("la cle publique n'est pas tout zeros", () => {
+    const secretKey = nacl.box.keyPair().secretKey;
+    const pubKey = deriveIdentityPublicKey(secretKey);
+    expect(pubKey.some((b) => b !== 0)).toBe(true);
+  });
+
+  it("est deterministe : meme secretKey -> meme publicKey", () => {
+    const secretKey = nacl.box.keyPair().secretKey;
+    const pubKey1 = deriveIdentityPublicKey(secretKey);
+    const pubKey2 = deriveIdentityPublicKey(secretKey);
+    expect(pubKey1).toEqual(pubKey2);
+  });
+
+  it("deux secretKeys differentes produisent des publicKeys differentes", () => {
+    const sk1 = nacl.box.keyPair().secretKey;
+    const sk2 = nacl.box.keyPair().secretKey;
+    const pk1 = deriveIdentityPublicKey(sk1);
+    const pk2 = deriveIdentityPublicKey(sk2);
+    // Probabilite de collision negligeable avec nacl CSPRNG
+    expect(pk1).not.toEqual(pk2);
+  });
+
+  it("leve une erreur sur une secretKey vide (protection contre slice vide)", () => {
+    expect(() => deriveIdentityPublicKey(new Uint8Array(0))).toThrow();
+  });
+
+  it("leve une erreur sur une secretKey de mauvaise taille (< 32 bytes)", () => {
+    expect(() => deriveIdentityPublicKey(new Uint8Array(16))).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Le premier appareil d'un contact peut avoir une `identityKey` vide (\`""\`) - le backend renvoie une chaine vide au lieu d'une erreur 404.
- `getKeyBundle` validait correctement (throw `INVALID_SIGNAL_BUNDLE`) mais `SafetyNumberModal` bloquait sur `deviceIds[0]` sans fallback.
- On itere maintenant tous les `deviceIds` jusqu'au premier bundle valide.

## Root cause (live verification)
- `GET /auth/v1/signal/keys/6ac33551.../devices/ec75eeaf...` retourne `{ identityKey: "" }` (200 OK, bundle invalide)
- `deviceIds[0]` = `ec75eeaf` - toujours le premier appareil retourné, toujours invalide
- `deviceIds[1]` = `c2b3accb` - `identityKey` non vide, bundle valide

## Test plan
- [x] 7 tests unitaires verts (dont 1 nouveau cas de regression)
- [x] Lint clean (prettier)
- [ ] Tester live safety number modal avec imane (long press sur la conv)

Closes WHISPR-safety-number-empty-key