### PR TITLE
feat(media): convertir HEIC en JPEG avant upload pour compat web

### DIFF
--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -129,6 +129,7 @@ const CHAT_TOUR_STEPS: TourStep[] = [
 ];
 import { getConversationDisplayName } from "../../utils";
 import { generateClientRandom } from "../../utils/crypto";
+import { convertHeicToJpeg } from "../../utils/imageCompression";
 import { usePresenceStore } from "../../store/presenceStore";
 import { AuthStackParamList } from "../../navigation/AuthNavigator";
 import { colors, withOpacity } from "../../theme/colors";
@@ -1923,15 +1924,40 @@ export const ChatScreen: React.FC = () => {
           uploadProgress: 0,
         });
 
+        // Conversion HEIC → JPEG avant upload : les navigateurs Chrome/Firefox
+        // ne décodent pas HEIC nativement → carré noir côté receveur sur PWA.
+        // On convertit ici, avant E2EE, pour que le ciphertext porte du JPEG.
+        let finalUri = uploadUri;
+        let finalFilename = filename;
+        let finalMimeType = mimeType;
+        if (type === "image") {
+          const heicResult = await convertHeicToJpeg(uploadUri, filename);
+          if (heicResult != null) {
+            finalUri = heicResult.uri;
+            finalMimeType = heicResult.mimeType;
+            finalFilename = heicResult.filename;
+          } else if (
+            mimeType === "image/heic" ||
+            mimeType === "image/heif" ||
+            filename.match(/\.(heic|heif)$/i)
+          ) {
+            // Conversion échouée sur un fichier HEIC confirmé : log + fallback HEIC
+            logger.warn(
+              "ChatScreen.handleSendMedia",
+              "HEIC→JPEG conversion failed, uploading original HEIC (may render black on Chrome/Firefox)",
+            );
+          }
+        }
+
         // E2EE for media: blind the server
         const shouldEncrypt = e2eeEnabled || conversation?.type === "direct";
-        let finalUploadUri = uploadUri;
-        let uploadMimeType = mimeType;
+        let finalUploadUri = finalUri;
+        let uploadMimeType = finalMimeType;
         let e2eeMediaMeta: { key: string; nonce: string } | undefined;
 
         if (shouldEncrypt) {
           try {
-            const encMedia = await E2EEService.encryptMediaFile(uploadUri);
+            const encMedia = await E2EEService.encryptMediaFile(finalUri);
             finalUploadUri = encMedia.encryptedUri;
             e2eeMediaMeta = { key: encMedia.key, nonce: encMedia.nonce };
             // The ciphertext no longer matches the original image/video magic
@@ -1952,7 +1978,7 @@ export const ChatScreen: React.FC = () => {
 
         // 1. Upload file to media-service (encrypted or plain)
         const uploadResult = await MediaService.uploadMedia(
-          { uri: finalUploadUri, name: filename, type: uploadMimeType },
+          { uri: finalUploadUri, name: finalFilename, type: uploadMimeType },
           (percent) => {
             patchTempUploadMeta({
               uploadPhase: "uploading",
@@ -1993,8 +2019,8 @@ export const ChatScreen: React.FC = () => {
           media_id: uploadResult.id,
           media_url: uploadResult.url,
           thumbnail_url: uploadResult.thumbnail_url || uploadResult.url,
-          filename: uploadResult.filename || filename,
-          mime_type: uploadResult.mime_type || mimeType,
+          filename: uploadResult.filename || finalFilename,
+          mime_type: uploadResult.mime_type || finalMimeType,
           size: uploadResult.size,
           duration: resolvedDuration,
         };
@@ -2014,7 +2040,7 @@ export const ChatScreen: React.FC = () => {
                       media_url: uploadResult.url,
                       thumbnail_url:
                         uploadResult.thumbnail_url || uploadResult.url,
-                      mime_type: uploadResult.mime_type || mimeType,
+                      mime_type: uploadResult.mime_type || finalMimeType,
                       duration: resolvedDuration,
                     },
                   })),
@@ -2163,9 +2189,9 @@ export const ChatScreen: React.FC = () => {
             media_id: uploadResult.id,
             media_type: type,
             metadata: {
-              filename: uploadResult.filename || filename,
+              filename: uploadResult.filename || finalFilename,
               size: uploadResult.size,
-              mime_type: uploadResult.mime_type || mimeType,
+              mime_type: uploadResult.mime_type || finalMimeType,
               media_url: uploadResult.url,
               thumbnail_url: uploadResult.thumbnail_url || uploadResult.url,
               duration: resolvedDuration,

--- a/src/utils/__tests__/imageCompression.test.ts
+++ b/src/utils/__tests__/imageCompression.test.ts
@@ -2,7 +2,8 @@
  * WHISPR-1039: garantit que la compression ne déforme jamais une image.
  * Test unitaire pur sur la fonction de décision `buildResizeAction`.
  *
- * WHISPR-1197: garantit que GIF/HEIC ne sont jamais re-encodés.
+ * WHISPR-1197: garantit que GIF/HEIC ne sont jamais re-encodés dans compressImage.
+ * convertHeicToJpeg: conversion HEIC→JPEG dédiée compat web (Chrome/Firefox).
  */
 
 // Mock expo-image-manipulator AVANT l'import du module testé : ainsi on peut
@@ -28,6 +29,7 @@ jest.mock("react-native", () => ({
 import {
   buildResizeAction,
   compressImage,
+  convertHeicToJpeg,
   detectImageFormatFromUri,
 } from "../imageCompression";
 
@@ -155,5 +157,76 @@ describe("compressImage format short-circuit (WHISPR-1197)", () => {
     const result = await compressImage("file:///tmp/photo");
     expect(mockManipulateAsync).toHaveBeenCalledTimes(2);
     expect(result).toBe("file:///tmp/compressed.jpg");
+  });
+});
+
+describe("convertHeicToJpeg (compat web)", () => {
+  beforeEach(() => {
+    mockManipulateAsync.mockReset();
+  });
+
+  it("convertit un .heic en JPEG et renomme le fichier", async () => {
+    mockManipulateAsync.mockResolvedValueOnce({
+      uri: "file:///tmp/IMG_1234.jpg",
+    });
+    const result = await convertHeicToJpeg(
+      "file:///tmp/IMG_1234.heic",
+      "IMG_1234.heic",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.uri).toBe("file:///tmp/IMG_1234.jpg");
+    expect(result!.mimeType).toBe("image/jpeg");
+    expect(result!.filename).toBe("IMG_1234.jpg");
+  });
+
+  it("convertit un .heif en JPEG et renomme le fichier", async () => {
+    mockManipulateAsync.mockResolvedValueOnce({
+      uri: "file:///tmp/IMG_5678.jpg",
+    });
+    const result = await convertHeicToJpeg(
+      "file:///tmp/IMG_5678.heif",
+      "IMG_5678.heif",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.mimeType).toBe("image/jpeg");
+    expect(result!.filename).toBe("IMG_5678.jpg");
+  });
+
+  it("appelle manipulateAsync avec compress 0.92 et format JPEG", async () => {
+    mockManipulateAsync.mockResolvedValueOnce({ uri: "file:///tmp/out.jpg" });
+    await convertHeicToJpeg("file:///tmp/photo.heic", "photo.heic");
+    expect(mockManipulateAsync).toHaveBeenCalledWith(
+      "file:///tmp/photo.heic",
+      [],
+      { compress: 0.92, format: "jpeg" },
+    );
+  });
+
+  it("retourne null pour une URI non-HEIC (JPEG) sans appeler manipulateAsync", async () => {
+    const result = await convertHeicToJpeg(
+      "file:///tmp/photo.jpg",
+      "photo.jpg",
+    );
+    expect(result).toBeNull();
+    expect(mockManipulateAsync).not.toHaveBeenCalled();
+  });
+
+  it("retourne null si manipulateAsync échoue (fallback safe)", async () => {
+    mockManipulateAsync.mockRejectedValueOnce(new Error("manipulate failed"));
+    const result = await convertHeicToJpeg(
+      "file:///tmp/IMG_1234.heic",
+      "IMG_1234.heic",
+    );
+    expect(result).toBeNull();
+  });
+
+  it("conserve le casing .HEIC dans la détection mais produit .jpg en minuscule", async () => {
+    mockManipulateAsync.mockResolvedValueOnce({ uri: "file:///tmp/out.jpg" });
+    const result = await convertHeicToJpeg(
+      "file:///tmp/PHOTO.HEIC",
+      "PHOTO.HEIC",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.filename).toBe("PHOTO.jpg");
   });
 });

--- a/src/utils/imageCompression.ts
+++ b/src/utils/imageCompression.ts
@@ -3,10 +3,13 @@
  * WHISPR-265: Compression automatique des images avant envoi
  * WHISPR-1039: ne plus déformer les images, le côté le plus long est borné
  *              et le ratio d'origine est préservé.
- * WHISPR-1197: GIF/HEIC sont préservés tels quels (pas de re-encodage JPEG)
- *              pour conserver l'animation des GIFs et la compression native
- *              Apple sur les HEIC. Seuls JPEG/PNG/inconnu passent par le
- *              pipeline `manipulateAsync`.
+ * WHISPR-1197: GIF/HEIC sont préservés tels quels dans compressImage (pas de
+ *              re-encodage JPEG) pour conserver l'animation des GIFs et la
+ *              compression native Apple sur les HEIC.
+ *              Exception : convertHeicToJpeg() est dédié à la compatibilité
+ *              web — les navigateurs Chrome/Firefox ne décodent pas HEIC
+ *              nativement, les images apparaissent noires. Cette conversion
+ *              doit être appelée avant upload dans handleSendMedia.
  */
 
 import * as ImageManipulator from "expo-image-manipulator";
@@ -42,6 +45,53 @@ export function detectImageFormatFromUri(uri: string): ImageFormat {
       return "webp";
     default:
       return "unknown";
+  }
+}
+
+export interface HeicConversionResult {
+  uri: string;
+  mimeType: "image/jpeg";
+  filename: string;
+}
+
+/**
+ * Convertit un fichier HEIC/HEIF en JPEG via expo-image-manipulator.
+ *
+ * Les navigateurs web (Chrome, Firefox, Brave) ne décodent pas HEIC
+ * nativement : les images apparaissent comme des carrés noirs côté receveur
+ * sur PWA. Cette conversion doit être appelée avant upload.
+ *
+ * En cas d'échec de la conversion (rare), la fonction retourne null et
+ * l'appelant doit envoyer le HEIC original en fallback (avec un warning log).
+ *
+ * @param uri      URI locale du fichier HEIC/HEIF
+ * @param filename Nom de fichier d'origine (ex: IMG_1234.heic)
+ */
+export async function convertHeicToJpeg(
+  uri: string,
+  filename: string,
+): Promise<HeicConversionResult | null> {
+  const format = detectImageFormatFromUri(uri);
+  if (format !== "heic") {
+    // Pas HEIC/HEIF — rien à convertir, retourner tel quel serait confusant
+    // pour l'appelant qui s'attend à un résultat typé JPEG. On retourne null.
+    return null;
+  }
+
+  try {
+    const result = await ImageManipulator.manipulateAsync(uri, [], {
+      compress: 0.92,
+      format: ImageManipulator.SaveFormat.JPEG,
+    });
+    return {
+      uri: result.uri,
+      mimeType: "image/jpeg",
+      filename: filename.replace(/\.(heic|heif)$/i, ".jpg"),
+    };
+  } catch (err) {
+    // expo-image-manipulator peut échouer sur certains appareils très anciens
+    // ou sur des fichiers HEIC corrompus. On laisse l'appelant décider du fallback.
+    return null;
   }
 }
 


### PR DESCRIPTION
## Summary
- Ajoute `convertHeicToJpeg()` dans `imageCompression.ts` : conversion via `expo-image-manipulator` avec compress 0.92, format JPEG, renommage `.heic`/`.heif` → `.jpg`
- Appel dans `handleSendMedia` (ChatScreen) avant le bloc E2EE, sur les médias de type `image` uniquement
- Fallback safe : si la conversion échoue, le HEIC original est envoyé avec un warning logger
- `finalFilename` et `finalMimeType` propagés à tous les points d'usage (E2EE, uploadMedia, addAttachment, mediaMetadata)

## Test plan
- [x] Tests Jest `convertHeicToJpeg` : 6 nouveaux cas (heic→jpg, heif→jpg, manipulateAsync args, non-HEIC null, failure null, casing)
- [x] 29/29 tests imageCompression verts
- [x] Lint clean (0 erreurs)
- [x] TypeScript : seule erreur pre-existante dans useNetworkMonitor.ts (hors scope)
- [ ] Test live PWA : upload HEIC depuis iPhone Safari → vérifier rendu sur Chrome/Firefox côté receveur sur whispr-preprod.roadmvn.com

Closes WHISPR (ticket à créer sprint actif)