### PR TITLE
[WHISPR-fix-contacts-pagination] fix(contacts): utiliser limit=100 sur GET /contacts

### DIFF
--- a/src/services/contacts/__tests__/contactsApi.test.ts
+++ b/src/services/contacts/__tests__/contactsApi.test.ts
@@ -61,7 +61,7 @@ describe("contactsAPI.getContacts", () => {
 
     const result = await contactsAPI.getContacts();
 
-    expect(mockFetch.mock.calls[0][0]).toBe(`${BASE}/contacts`);
+    expect(mockFetch.mock.calls[0][0]).toBe(`${BASE}/contacts?limit=100`);
     expect(result.total).toBe(1);
     expect(result.contacts[0]).toMatchObject({
       id: "c-1",

--- a/src/services/contacts/api.ts
+++ b/src/services/contacts/api.ts
@@ -293,7 +293,10 @@ export const contactsAPI = {
       contacts: Contact[];
       total: number;
     }> => {
-      const url = `${API_BASE_URL}/contacts`;
+      // limit=100 : le max autorise par user-service (CursorPaginationDto @Max(100)).
+      // Sans param le service retourne 50 par defaut, ce qui tronque silencieusement
+      // les carnets d adresses > 50 contacts.
+      const url = `${API_BASE_URL}/contacts?limit=100`;
       const response = await fetch(url, {
         headers: {
           Authorization: `Bearer ${token}`,


### PR DESCRIPTION
## Summary
- GET /contacts était appelé sans paramètre, le service retournait 50 entrées par défaut (CursorPaginationDto default=50)
- Les utilisateurs avec > 50 contacts voyaient un carnet d'adresses tronqué silencieusement
- Fix : ajout de ?limit=100 (le max autorisé côté user-service)

## Test plan
- [x] Test unitaire `contactsApi.test.ts` mis à jour et vert (41/41)
- [x] Vérifié que le POST addContact n'est pas affecté

Closes WHISPR-fix-contacts-pagination