### PR TITLE
feat(i18n): extraire les chaînes FR codées en dur (ScheduledMessages, ArchivedConversations, OfflineBanner, NewConversationModal)

### DIFF
--- a/src/components/Chat/NewConversationModal.tsx
+++ b/src/components/Chat/NewConversationModal.tsx
@@ -25,6 +25,7 @@ import { messagingAPI } from "../../services/messaging/api";
 import { Avatar } from "./Avatar";
 import { logger } from "../../utils/logger";
 import { formatUsername } from "../../utils";
+import { useTheme } from "../../context/ThemeContext";
 
 interface NewConversationModalProps {
   visible: boolean;
@@ -56,6 +57,7 @@ export const NewConversationModal: React.FC<NewConversationModalProps> = ({
   const [groupName, setGroupName] = useState("");
   const [groupNameTouched, setGroupNameTouched] = useState(false);
   const insets = useSafeAreaInsets();
+  const { getLocalizedText } = useTheme();
 
   const resetState = useCallback(() => {
     setSearchQuery("");
@@ -75,7 +77,10 @@ export const NewConversationModal: React.FC<NewConversationModalProps> = ({
       } catch (error) {
         logger.error("NewConversationModal", "Error loading contacts", error);
         if (!cancelled) {
-          Alert.alert("Erreur", "Impossible de charger les contacts");
+          Alert.alert(
+            getLocalizedText("notif.error"),
+            getLocalizedText("newConversation.errorLoadContacts"),
+          );
         }
       } finally {
         if (!cancelled) setLoading(false);
@@ -143,7 +148,7 @@ export const NewConversationModal: React.FC<NewConversationModalProps> = ({
         if (next.size >= 49) {
           Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
           Alert.alert(
-            "Limite atteinte",
+            getLocalizedText("newConversation.limitTitle"),
             "Un groupe peut contenir au maximum 50 membres (créateur inclus)",
           );
           return prev;
@@ -174,8 +179,8 @@ export const NewConversationModal: React.FC<NewConversationModalProps> = ({
         const message =
           error instanceof Error
             ? error.message
-            : "Impossible de créer la conversation";
-        Alert.alert("Erreur", message);
+            : getLocalizedText("newConversation.errorCreate");
+        Alert.alert(getLocalizedText("notif.error"), message);
       } finally {
         setCreating(false);
       }
@@ -196,7 +201,10 @@ export const NewConversationModal: React.FC<NewConversationModalProps> = ({
         resetState();
       } catch {
         Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
-        Alert.alert("Erreur", "Impossible de créer le groupe");
+        Alert.alert(
+          getLocalizedText("notif.error"),
+          getLocalizedText("newConversation.errorCreateGroup"),
+        );
       } finally {
         setCreating(false);
       }
@@ -216,7 +224,7 @@ export const NewConversationModal: React.FC<NewConversationModalProps> = ({
     if (trimmed.length < 3) {
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
       Alert.alert(
-        "Nom invalide",
+        getLocalizedText("newConversation.invalidNameTitle"),
         "Le nom du groupe doit contenir au moins 3 caractères",
       );
       return;
@@ -224,7 +232,7 @@ export const NewConversationModal: React.FC<NewConversationModalProps> = ({
     if (trimmed.length > 100) {
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
       Alert.alert(
-        "Nom invalide",
+        getLocalizedText("newConversation.invalidNameTitle"),
         "Le nom du groupe ne peut pas dépasser 100 caractères",
       );
       return;
@@ -285,7 +293,9 @@ export const NewConversationModal: React.FC<NewConversationModalProps> = ({
   );
 
   const primaryButtonLabel =
-    selectedIds.size <= 1 ? "Créer la conversation" : "Créer le groupe";
+    selectedIds.size <= 1
+      ? getLocalizedText("newConversation.createConversation")
+      : getLocalizedText("newConversation.createGroup");
 
   return (
     <Modal
@@ -323,7 +333,9 @@ export const NewConversationModal: React.FC<NewConversationModalProps> = ({
                     // que defaultGroupName ecrase ce que l'user va taper
                     if (!groupNameTouched) setGroupNameTouched(true);
                   }}
-                  placeholder="Nom du groupe"
+                  placeholder={getLocalizedText(
+                    "newConversation.groupNamePlaceholder",
+                  )}
                   placeholderTextColor="rgba(255, 255, 255, 0.5)"
                   maxLength={100}
                   returnKeyType="done"
@@ -337,7 +349,9 @@ export const NewConversationModal: React.FC<NewConversationModalProps> = ({
                 />
               </View>
             ) : (
-              <Text style={styles.headerTitle}>Nouvelle conversation</Text>
+              <Text style={styles.headerTitle}>
+                {getLocalizedText("newConversation.createConversation")}
+              </Text>
             )}
             <View style={styles.headerButton} />
           </View>
@@ -351,7 +365,9 @@ export const NewConversationModal: React.FC<NewConversationModalProps> = ({
             />
             <TextInput
               style={styles.searchInput}
-              placeholder="Rechercher un contact"
+              placeholder={getLocalizedText(
+                "newConversation.searchPlaceholder",
+              )}
               placeholderTextColor="rgba(255, 255, 255, 0.6)"
               value={searchQuery}
               onChangeText={setSearchQuery}
@@ -416,8 +432,8 @@ export const NewConversationModal: React.FC<NewConversationModalProps> = ({
             <View style={styles.centered}>
               <Text style={styles.emptyText}>
                 {searchQuery.trim()
-                  ? "Aucun contact trouvé"
-                  : "Aucun contact disponible"}
+                  ? getLocalizedText("newConversation.noContactsFound")
+                  : getLocalizedText("newConversation.noContactsAvailable")}
               </Text>
             </View>
           ) : (

--- a/src/components/Chat/OfflineBanner.tsx
+++ b/src/components/Chat/OfflineBanner.tsx
@@ -7,6 +7,7 @@ import React, { useEffect, useRef } from "react";
 import { View, Text, StyleSheet, Animated } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { ConnectionState } from "../../services/messaging/websocket";
+import { useTheme } from "../../context/ThemeContext";
 
 interface OfflineBannerProps {
   connectionState: ConnectionState;
@@ -15,6 +16,7 @@ interface OfflineBannerProps {
 export const OfflineBanner: React.FC<OfflineBannerProps> = ({
   connectionState,
 }) => {
+  const { getLocalizedText } = useTheme();
   const opacity = useRef(new Animated.Value(0)).current;
   // Only show offline banner for reconnecting state or after we were previously
   // connected and then disconnected. Don't show during initial connection setup.
@@ -56,8 +58,8 @@ export const OfflineBanner: React.FC<OfflineBannerProps> = ({
       />
       <Text style={styles.text}>
         {isReconnecting
-          ? "Reconnexion en cours"
-          : "Hors ligne — les messages seront envoyés à la reconnexion"}
+          ? getLocalizedText("connection.reconnecting")
+          : getLocalizedText("connection.offline")}
       </Text>
     </Animated.View>
   );

--- a/src/components/Chat/__tests__/NewConversationModal.test.tsx
+++ b/src/components/Chat/__tests__/NewConversationModal.test.tsx
@@ -32,6 +32,33 @@ jest.mock("../Avatar", () => ({
   Avatar: () => null,
 }));
 
+jest.mock("react-native-safe-area-context", () => ({
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+}));
+
+jest.mock("../../../context/ThemeContext", () => {
+  const translations: Record<string, string> = {
+    "notif.error": "Erreur",
+    "newConversation.errorLoadContacts": "Impossible de charger les contacts",
+    "newConversation.limitTitle": "Limite atteinte",
+    "newConversation.errorCreate": "Impossible de créer la conversation",
+    "newConversation.errorCreateGroup": "Impossible de créer le groupe",
+    "newConversation.invalidNameTitle": "Nom invalide",
+    "newConversation.createConversation": "Créer la conversation",
+    "newConversation.createGroup": "Créer le groupe",
+    "newConversation.groupNamePlaceholder": "Nom du groupe",
+    "newConversation.searchPlaceholder": "Rechercher un contact",
+    "newConversation.noContactsFound": "Aucun contact trouvé",
+    "newConversation.noContactsAvailable": "Aucun contact disponible",
+  };
+  return {
+    useTheme: () => ({
+      getLocalizedText: (key: string) => translations[key] ?? key,
+    }),
+  };
+});
+
 const mockGetContacts = jest.fn();
 const mockCreateDirect = jest.fn();
 const mockCreateGroup = jest.fn();
@@ -199,7 +226,7 @@ describe("NewConversationModal — direct conversation", () => {
   it("creates a direct conversation when exactly one contact is selected", async () => {
     mockCreateDirect.mockResolvedValueOnce({ id: "conv-9" });
     const onCreated = jest.fn();
-    const { getByText } = render(
+    const { getByText, getAllByText } = render(
       <NewConversationModal
         visible
         onClose={jest.fn()}
@@ -209,7 +236,9 @@ describe("NewConversationModal — direct conversation", () => {
     await waitFor(() => getByText("Alice Smith"));
 
     fireEvent.press(getByText("Alice Smith"));
-    fireEvent.press(getByText("Créer la conversation"));
+    // Header title and primary button share the same label — press the button (last)
+    const createButtons = getAllByText("Créer la conversation");
+    fireEvent.press(createButtons[createButtons.length - 1]);
     await flushAsync();
 
     expect(mockCreateDirect).toHaveBeenCalledWith("u-1");
@@ -218,7 +247,7 @@ describe("NewConversationModal — direct conversation", () => {
 
   it("alerts when the direct conversation creation fails", async () => {
     mockCreateDirect.mockRejectedValueOnce(new Error("forbidden"));
-    const { getByText } = render(
+    const { getByText, getAllByText } = render(
       <NewConversationModal
         visible
         onClose={jest.fn()}
@@ -228,7 +257,8 @@ describe("NewConversationModal — direct conversation", () => {
     await waitFor(() => getByText("Alice Smith"));
 
     fireEvent.press(getByText("Alice Smith"));
-    fireEvent.press(getByText("Créer la conversation"));
+    const createButtons = getAllByText("Créer la conversation");
+    fireEvent.press(createButtons[createButtons.length - 1]);
     await flushAsync();
 
     expect(alertSpy).toHaveBeenCalledWith("Erreur", "forbidden");

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1069,6 +1069,51 @@ const localizedTexts: Record<Language, Record<string, string>> = {
     "confirm.deleteGroup.description":
       "Tous les messages, médias et l'historique seront perdus. Action irréversible. Tape SUPPRIMER pour confirmer.",
     "confirm.deleteGroup.action": "Supprimer définitivement",
+
+    // Scheduled messages
+    "scheduled.title": "Messages programmés",
+    "scheduled.pendingCount": "en attente",
+    "scheduled.empty": "Aucun message programmé",
+    "scheduled.emptyHint":
+      "Appuyez longuement sur le bouton d'envoi pour programmer un message",
+    "scheduled.cancelButton": "Annuler",
+    "scheduled.cancelAlertTitle": "Annuler le message programmé",
+    "scheduled.cancelAlertMessage":
+      "Voulez-vous annuler l'envoi de ce message ?",
+    "scheduled.cancelAlertConfirm": "Annuler le message",
+    "scheduled.cancelAlertNo": "Non",
+    "scheduled.cancelError": "Impossible d'annuler le message.",
+    "scheduled.statusPending": "En attente",
+    "scheduled.statusSent": "Envoyé",
+    "scheduled.statusFailed": "Échoué",
+    "scheduled.statusCancelled": "Annulé",
+
+    // Archived conversations
+    "archived.title": "Archivées",
+    "archived.unarchived": "Conversation désarchivée",
+    "archived.unarchiveError": "Impossible de désarchiver la conversation",
+    "archived.empty": "Aucune conversation archivée",
+    "archived.emptyHint": "Les conversations que vous archivez apparaîtront ici.",
+    "archived.loadError": "Erreur de chargement",
+    "archived.loadErrorHint": "Vérifiez votre connexion puis réessayez.",
+
+    // Connection status banner
+    "connection.reconnecting": "Reconnexion en cours",
+    "connection.offline":
+      "Hors ligne — les messages seront envoyés à la reconnexion",
+
+    // New conversation modal
+    "newConversation.errorLoadContacts": "Impossible de charger les contacts",
+    "newConversation.limitTitle": "Limite atteinte",
+    "newConversation.errorCreate": "Impossible de créer la conversation",
+    "newConversation.errorCreateGroup": "Impossible de créer le groupe",
+    "newConversation.invalidNameTitle": "Nom invalide",
+    "newConversation.createConversation": "Créer la conversation",
+    "newConversation.createGroup": "Créer le groupe",
+    "newConversation.groupNamePlaceholder": "Nom du groupe",
+    "newConversation.searchPlaceholder": "Rechercher un contact",
+    "newConversation.noContactsFound": "Aucun contact trouvé",
+    "newConversation.noContactsAvailable": "Aucun contact disponible",
   },
   en: {
     // Navigation
@@ -1444,6 +1489,51 @@ const localizedTexts: Record<Language, Record<string, string>> = {
     "confirm.deleteGroup.description":
       "All messages, media and history will be lost. This action cannot be undone. Type DELETE to confirm.",
     "confirm.deleteGroup.action": "Delete permanently",
+
+    // Scheduled messages
+    "scheduled.title": "Scheduled Messages",
+    "scheduled.pendingCount": "pending",
+    "scheduled.empty": "No scheduled messages",
+    "scheduled.emptyHint":
+      "Long-press the send button to schedule a message",
+    "scheduled.cancelButton": "Cancel",
+    "scheduled.cancelAlertTitle": "Cancel scheduled message",
+    "scheduled.cancelAlertMessage":
+      "Do you want to cancel sending this message?",
+    "scheduled.cancelAlertConfirm": "Cancel message",
+    "scheduled.cancelAlertNo": "No",
+    "scheduled.cancelError": "Unable to cancel the message.",
+    "scheduled.statusPending": "Pending",
+    "scheduled.statusSent": "Sent",
+    "scheduled.statusFailed": "Failed",
+    "scheduled.statusCancelled": "Cancelled",
+
+    // Archived conversations
+    "archived.title": "Archived",
+    "archived.unarchived": "Conversation unarchived",
+    "archived.unarchiveError": "Unable to unarchive conversation",
+    "archived.empty": "No archived conversations",
+    "archived.emptyHint": "Conversations you archive will appear here.",
+    "archived.loadError": "Loading error",
+    "archived.loadErrorHint": "Check your connection and try again.",
+
+    // Connection status banner
+    "connection.reconnecting": "Reconnecting…",
+    "connection.offline":
+      "Offline — messages will be sent when reconnected",
+
+    // New conversation modal
+    "newConversation.errorLoadContacts": "Unable to load contacts",
+    "newConversation.limitTitle": "Limit reached",
+    "newConversation.errorCreate": "Unable to create conversation",
+    "newConversation.errorCreateGroup": "Unable to create group",
+    "newConversation.invalidNameTitle": "Invalid name",
+    "newConversation.createConversation": "Create conversation",
+    "newConversation.createGroup": "Create group",
+    "newConversation.groupNamePlaceholder": "Group name",
+    "newConversation.searchPlaceholder": "Search a contact",
+    "newConversation.noContactsFound": "No contact found",
+    "newConversation.noContactsAvailable": "No contacts available",
   },
 };
 

--- a/src/screens/Chat/ArchivedConversationsScreen.tsx
+++ b/src/screens/Chat/ArchivedConversationsScreen.tsx
@@ -114,7 +114,7 @@ const SwipeableArchivedItem: React.FC<SwipeableArchivedItemProps> = ({
 export const ArchivedConversationsScreen: React.FC = () => {
   const navigation = useNavigation<NavigationProp>();
   const insets = useSafeAreaInsets();
-  const { settings } = useTheme();
+  const { settings, getLocalizedText } = useTheme();
   const hasCustomBackground =
     settings.backgroundPreset === "custom" && !!settings.customBackgroundUri;
   const customBackgroundUri = settings.customBackgroundUri ?? null;
@@ -165,18 +165,18 @@ export const ArchivedConversationsScreen: React.FC = () => {
         fetchConversations();
         setToast({
           visible: true,
-          message: "Conversation désarchivée",
+          message: getLocalizedText("archived.unarchived"),
           type: "success",
         });
       } catch {
         setToast({
           visible: true,
-          message: "Impossible de désarchiver la conversation",
+          message: getLocalizedText("archived.unarchiveError"),
           type: "error",
         });
       }
     },
-    [unarchiveConversation, fetchConversations],
+    [unarchiveConversation, fetchConversations, getLocalizedText],
   );
 
   const onRefresh = useCallback(async () => {
@@ -237,15 +237,19 @@ export const ArchivedConversationsScreen: React.FC = () => {
             size={48}
             color="rgba(255, 255, 255, 0.5)"
           />
-          <Text style={styles.emptyTitle}>Erreur de chargement</Text>
+          <Text style={styles.emptyTitle}>
+            {getLocalizedText("archived.loadError")}
+          </Text>
           <Text style={styles.emptySubtitle}>
-            Vérifiez votre connexion puis réessayez.
+            {getLocalizedText("archived.loadErrorHint")}
           </Text>
           <TouchableOpacity
             style={styles.retryButton}
             onPress={() => fetchArchived()}
           >
-            <Text style={styles.retryButtonText}>Réessayer</Text>
+            <Text style={styles.retryButtonText}>
+              {getLocalizedText("common.retry")}
+            </Text>
           </TouchableOpacity>
         </View>
       );
@@ -259,9 +263,11 @@ export const ArchivedConversationsScreen: React.FC = () => {
             size={48}
             color="rgba(255, 255, 255, 0.5)"
           />
-          <Text style={styles.emptyTitle}>Aucune conversation archivée</Text>
+          <Text style={styles.emptyTitle}>
+            {getLocalizedText("archived.empty")}
+          </Text>
           <Text style={styles.emptySubtitle}>
-            Les conversations que vous archivez apparaîtront ici.
+            {getLocalizedText("archived.emptyHint")}
           </Text>
         </View>
       );
@@ -350,7 +356,9 @@ export const ArchivedConversationsScreen: React.FC = () => {
                 color={colors.text.light}
               />
             </TouchableOpacity>
-            <Text style={styles.headerTitle}>Archivées</Text>
+            <Text style={styles.headerTitle}>
+              {getLocalizedText("archived.title")}
+            </Text>
             <View style={styles.headerButton} />
           </View>
 

--- a/src/screens/Chat/ScheduledMessagesScreen.tsx
+++ b/src/screens/Chat/ScheduledMessagesScreen.tsx
@@ -71,27 +71,27 @@ function getStatusColor(status: ScheduledMessage["status"]): string {
   }
 }
 
-function getStatusLabel(status: ScheduledMessage["status"]): string {
-  switch (status) {
-    case "pending":
-      return "En attente";
-    case "sent":
-      return "Envoyé";
-    case "failed":
-      return "Échoué";
-    case "cancelled":
-      return "Annulé";
-    default:
-      return status;
-  }
-}
-
 export const ScheduledMessagesScreen: React.FC = () => {
   const navigation = useNavigation();
   const route = useRoute<ScheduledMessagesRouteProp>();
   const { conversationId } = route.params;
-  const { getThemeColors } = useTheme();
+  const { getThemeColors, getLocalizedText } = useTheme();
   const themeColors = getThemeColors();
+
+  const getStatusLabel = (status: ScheduledMessage["status"]): string => {
+    switch (status) {
+      case "pending":
+        return getLocalizedText("scheduled.statusPending");
+      case "sent":
+        return getLocalizedText("scheduled.statusSent");
+      case "failed":
+        return getLocalizedText("scheduled.statusFailed");
+      case "cancelled":
+        return getLocalizedText("scheduled.statusCancelled");
+      default:
+        return status;
+    }
+  };
 
   const [messages, setMessages] = useState<ScheduledMessage[]>([]);
   const [loading, setLoading] = useState(true);
@@ -130,39 +130,49 @@ export const ScheduledMessagesScreen: React.FC = () => {
     loadMessages();
   }, [loadMessages]);
 
-  const handleCancel = useCallback((message: ScheduledMessage) => {
-    Alert.alert(
-      "Annuler le message programmé",
-      `Voulez-vous annuler l'envoi de ce message ?\n\n"${message.content.substring(0, 80)}${message.content.length > 80 ? "..." : ""}"`,
-      [
-        { text: "Non", style: "cancel" },
-        {
-          text: "Annuler le message",
-          style: "destructive",
-          onPress: async () => {
-            try {
-              Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-              await SchedulingService.cancelScheduledMessage(message.id);
-              setMessages((prev) =>
-                prev.map((m) =>
-                  m.id === message.id
-                    ? { ...m, status: "cancelled" as const }
-                    : m,
-                ),
-              );
-            } catch (error) {
-              logger.error(
-                "ScheduledMessages",
-                "Error cancelling scheduled message",
-                error,
-              );
-              Alert.alert("Erreur", "Impossible d'annuler le message.");
-            }
+  const handleCancel = useCallback(
+    (message: ScheduledMessage) => {
+      const preview = `"${message.content.substring(0, 80)}${message.content.length > 80 ? "..." : ""}"`;
+      Alert.alert(
+        getLocalizedText("scheduled.cancelAlertTitle"),
+        `${getLocalizedText("scheduled.cancelAlertMessage")}\n\n${preview}`,
+        [
+          {
+            text: getLocalizedText("scheduled.cancelAlertNo"),
+            style: "cancel",
           },
-        },
-      ],
-    );
-  }, []);
+          {
+            text: getLocalizedText("scheduled.cancelAlertConfirm"),
+            style: "destructive",
+            onPress: async () => {
+              try {
+                Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+                await SchedulingService.cancelScheduledMessage(message.id);
+                setMessages((prev) =>
+                  prev.map((m) =>
+                    m.id === message.id
+                      ? { ...m, status: "cancelled" as const }
+                      : m,
+                  ),
+                );
+              } catch (error) {
+                logger.error(
+                  "ScheduledMessages",
+                  "Error cancelling scheduled message",
+                  error,
+                );
+                Alert.alert(
+                  getLocalizedText("notif.error"),
+                  getLocalizedText("scheduled.cancelError"),
+                );
+              }
+            },
+          },
+        ],
+      );
+    },
+    [getLocalizedText],
+  );
 
   const renderItem = useCallback(
     ({ item }: { item: ScheduledMessage }) => {
@@ -203,13 +213,15 @@ export const ScheduledMessagesScreen: React.FC = () => {
               activeOpacity={0.7}
             >
               <Ionicons name="close-circle-outline" size={16} color="#F04882" />
-              <Text style={styles.cancelButtonText}>Annuler</Text>
+              <Text style={styles.cancelButtonText}>
+                {getLocalizedText("scheduled.cancelButton")}
+              </Text>
             </TouchableOpacity>
           )}
         </View>
       );
     },
-    [handleCancel],
+    [handleCancel, getLocalizedText, getStatusLabel],
   );
 
   const pendingCount = messages.filter((m) => m.status === "pending").length;
@@ -235,10 +247,12 @@ export const ScheduledMessagesScreen: React.FC = () => {
             />
           </TouchableOpacity>
           <View style={styles.headerInfo}>
-            <Text style={styles.headerTitle}>Messages programmés</Text>
+            <Text style={styles.headerTitle}>
+              {getLocalizedText("scheduled.title")}
+            </Text>
             {pendingCount > 0 && (
               <Text style={styles.headerSubtitle}>
-                {pendingCount} en attente
+                {pendingCount} {getLocalizedText("scheduled.pendingCount")}
               </Text>
             )}
           </View>
@@ -256,10 +270,11 @@ export const ScheduledMessagesScreen: React.FC = () => {
               size={64}
               color={withOpacity(colors.text.light, 0.2)}
             />
-            <Text style={styles.emptyTitle}>Aucun message programmé</Text>
+            <Text style={styles.emptyTitle}>
+              {getLocalizedText("scheduled.empty")}
+            </Text>
             <Text style={styles.emptySubtitle}>
-              Appuyez longuement sur le bouton d'envoi pour programmer un
-              message
+              {getLocalizedText("scheduled.emptyHint")}
             </Text>
           </View>
         ) : (

--- a/src/screens/Chat/__tests__/ArchivedConversationsScreen.test.tsx
+++ b/src/screens/Chat/__tests__/ArchivedConversationsScreen.test.tsx
@@ -70,14 +70,28 @@ jest.mock("@react-navigation/native", () => {
   };
 });
 
-jest.mock("../../../context/ThemeContext", () => ({
-  useTheme: () => ({
-    settings: { backgroundPreset: "default", customBackgroundUri: null },
-    getThemeColors: () => ({
-      text: { primary: "#fff", secondary: "#aaa", tertiary: "#666" },
+jest.mock("../../../context/ThemeContext", () => {
+  const translations: Record<string, string> = {
+    "archived.title": "Archivées",
+    "archived.empty": "Aucune conversation archivée",
+    "archived.emptyHint":
+      "Les conversations que vous archivez apparaîtront ici.",
+    "archived.loadError": "Erreur de chargement",
+    "archived.loadErrorHint": "Vérifiez votre connexion puis réessayez.",
+    "archived.unarchived": "Conversation désarchivée",
+    "archived.unarchiveError": "Impossible de désarchiver la conversation",
+    "common.retry": "Réessayer",
+  };
+  return {
+    useTheme: () => ({
+      settings: { backgroundPreset: "default", customBackgroundUri: null },
+      getThemeColors: () => ({
+        text: { primary: "#fff", secondary: "#aaa", tertiary: "#666" },
+      }),
+      getLocalizedText: (key: string) => translations[key] ?? key,
     }),
-  }),
-}));
+  };
+});
 
 let mockArchived: any = {
   status: "loaded",

--- a/src/screens/Chat/__tests__/ScheduledMessagesScreen.test.tsx
+++ b/src/screens/Chat/__tests__/ScheduledMessagesScreen.test.tsx
@@ -21,13 +21,35 @@ jest.mock("@react-navigation/native", () => ({
   useRoute: () => ({ params: { conversationId: "conv-1" } }),
 }));
 
-jest.mock("../../../context/ThemeContext", () => ({
-  useTheme: () => ({
-    getThemeColors: () => ({
-      text: { primary: "#fff", secondary: "#aaa", tertiary: "#666" },
+jest.mock("../../../context/ThemeContext", () => {
+  const translations: Record<string, string> = {
+    "scheduled.empty": "Aucun message programmé",
+    "scheduled.emptyHint":
+      "Appuyez longuement sur le bouton d'envoi pour programmer un message",
+    "scheduled.pendingCount": "en attente",
+    "scheduled.cancelButton": "Annuler",
+    "scheduled.cancelAlertTitle": "Annuler le message programmé",
+    "scheduled.cancelAlertMessage":
+      "Voulez-vous annuler l'envoi de ce message ?",
+    "scheduled.cancelAlertConfirm": "Annuler le message",
+    "scheduled.cancelAlertNo": "Non",
+    "scheduled.cancelError": "Impossible d'annuler le message.",
+    "scheduled.statusPending": "En attente",
+    "scheduled.statusSent": "Envoyé",
+    "scheduled.statusFailed": "Échoué",
+    "scheduled.statusCancelled": "Annulé",
+    "scheduled.title": "Messages programmés",
+    "notif.error": "Erreur",
+  };
+  return {
+    useTheme: () => ({
+      getThemeColors: () => ({
+        text: { primary: "#fff", secondary: "#aaa", tertiary: "#666" },
+      }),
+      getLocalizedText: (key: string) => translations[key] ?? key,
     }),
-  }),
-}));
+  };
+});
 
 const mockGetScheduled = jest.fn();
 const mockCancelScheduled = jest.fn();


### PR DESCRIPTION
## Summary
- Extrait ~44 chaînes FR codées en dur vers `ThemeContext` (clés `scheduled.*`, `archived.*`, `connection.*`, `newConversation.*`) — paires FR + EN
- `ScheduledMessagesScreen`: statuts, alertes annulation, état vide, compteur en attente
- `ArchivedConversationsScreen`: titre, état vide, erreur de chargement, désarchivage
- `OfflineBanner`: messages reconnexion et hors-ligne
- `NewConversationModal`: toutes les alertes, labels boutons, placeholders, textes vides
- Tests: mocks `useTheme` mis à jour avec `getLocalizedText` + traductions inline pour éviter la rupture des assertions

## Test plan
- [x] Tests unitaires verts (`npm test -- --watchAll=false`) — 1833/1833 (les 2 suites fail sont des régressions pre-existing)
- [x] Lint + Prettier clean
- [x] Clés présentes en FR et EN dans `ThemeContext.tsx`

Closes WHISPR-1549