### PR TITLE
feat(calls): enrichir affichage dates avec jour précis dans lignes appels

### DIFF
--- a/src/screens/Calls/CallHistoryScreen.tsx
+++ b/src/screens/Calls/CallHistoryScreen.tsx
@@ -108,57 +108,94 @@ function formatCallTime(date: string): string {
 }
 
 /**
- * Retourne le libellé de section de date (Aujourd'hui / Hier / Cette semaine / Plus ancien).
+ * Retourne le jour normalisé (minuit) pour comparaison.
+ */
+function dayStart(d: Date): number {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+}
+
+/**
+ * Retourne le libellé de section de date :
+ * - Aujourd'hui
+ * - Hier
+ * - Cette semaine : "Mardi 21 mai" (weekday + jour + mois court)
+ * - Plus ancien : "Avril 2026" (mois long + année)
  */
 function getSectionLabel(date: string): string {
   const target = new Date(date);
   const now = new Date();
-  const targetDay = new Date(
-    target.getFullYear(),
-    target.getMonth(),
-    target.getDate(),
-  ).getTime();
-  const today = new Date(
-    now.getFullYear(),
-    now.getMonth(),
-    now.getDate(),
-  ).getTime();
-  const diffDays = Math.round((today - targetDay) / 86400000);
+  const diffDays = Math.round((dayStart(now) - dayStart(target)) / 86400000);
   if (diffDays === 0) return "Aujourd'hui";
   if (diffDays === 1) return "Hier";
-  if (diffDays < 7) return "Cette semaine";
-  return "Plus ancien";
+  if (diffDays < 7) {
+    // ex: "Mardi 21 mai"
+    const weekday = target.toLocaleDateString("fr-FR", { weekday: "long" });
+    const day = target.getDate();
+    const month = target.toLocaleDateString("fr-FR", { month: "short" }).replace(".", "");
+    return `${weekday.charAt(0).toUpperCase()}${weekday.slice(1)} ${day} ${month}`;
+  }
+  // ex: "Avril 2026"
+  const monthLong = target.toLocaleDateString("fr-FR", { month: "long" });
+  return `${monthLong.charAt(0).toUpperCase()}${monthLong.slice(1)} ${target.getFullYear()}`;
 }
 
 /**
- * Texte secondaire sous le nom : "Manqué · il y a 2j" ou "12s · 14:30".
+ * Retourne la partie "jour" à insérer dans le sous-texte selon le contexte temporel :
+ * - Aujourd'hui : rien (juste l'heure)
+ * - Hier : "hier"
+ * - Cette semaine : weekday court ex "mar."
+ * - Plus ancien : "26 avr."
+ */
+function formatCallDayContext(date: string): string | null {
+  const target = new Date(date);
+  const now = new Date();
+  const diffDays = Math.round((dayStart(now) - dayStart(target)) / 86400000);
+  if (diffDays === 0) return null;
+  if (diffDays === 1) return "hier";
+  if (diffDays < 7) {
+    // ex: "mardi"
+    return target.toLocaleDateString("fr-FR", { weekday: "long" });
+  }
+  // ex: "26 avr."
+  const day = target.getDate();
+  const month = target.toLocaleDateString("fr-FR", { month: "short" });
+  return `${day} ${month}`;
+}
+
+/**
+ * Texte secondaire sous le nom avec le jour contextuel :
+ * - Aujourd'hui : "12s · 14:30" / "Manqué · 14:30"
+ * - Hier : "12s · hier 14:30" / "Manqué · hier 14:30"
+ * - Cette semaine : "12s · mardi 14:30"
+ * - Plus ancien : "12s · 26 avr. 14:30"
  */
 function buildCallSubtext(item: EnrichedCallHistoryItem): string {
   const time = formatCallTime(item.started_at);
+  const dayCtx = formatCallDayContext(item.started_at);
+  const timeWithDay = dayCtx ? `${dayCtx} ${time}` : time;
+
   if (item.status === "missed" || item.status === "declined") {
-    return `Manqué · ${time}`;
+    return `Manqué · ${timeWithDay}`;
   }
   if (item.status === "failed") {
-    return `Échec · ${time}`;
+    return `Échec · ${timeWithDay}`;
   }
   const dur =
     item.duration_seconds != null
       ? formatDuration(item.duration_seconds)
       : null;
-  return dur ? `${dur} · ${time}` : time;
+  return dur ? `${dur} · ${timeWithDay}` : timeWithDay;
 }
 
 function groupByDate(calls: EnrichedCallHistoryItem[]): SectionData[] {
-  const order = ["Aujourd'hui", "Hier", "Cette semaine", "Plus ancien"];
+  // Conserver l'ordre d'insertion (appels déjà triés du plus récent au plus ancien)
   const map = new Map<string, EnrichedCallHistoryItem[]>();
   for (const call of calls) {
     const label = getSectionLabel(call.started_at);
     if (!map.has(label)) map.set(label, []);
     map.get(label)!.push(call);
   }
-  return order
-    .filter((label) => map.has(label))
-    .map((label) => ({ title: label, data: map.get(label)! }));
+  return Array.from(map.entries()).map(([title, data]) => ({ title, data }));
 }
 
 function isMissed(status: CallStatus): boolean {

--- a/src/screens/Calls/__tests__/CallHistoryScreen.test.tsx
+++ b/src/screens/Calls/__tests__/CallHistoryScreen.test.tsx
@@ -171,3 +171,201 @@ describe("CallHistoryScreen sur web", () => {
     expect(() => render(<CallHistoryScreen />)).not.toThrow();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Tests unitaires des helpers d'affichage des dates
+// ---------------------------------------------------------------------------
+
+// On importe les helpers via un re-export temporaire pour les tester en isolation.
+// On les teste indirectement via le rendu de l'écran avec des dates contrôlées.
+
+describe("affichage des sous-textes de dates dans les lignes d'appel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetConversation.mockResolvedValue(null);
+    mockGetConversationMembers.mockResolvedValue([]);
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("affiche juste l'heure pour un appel d'aujourd'hui", async () => {
+    const now = new Date();
+    now.setHours(14, 30, 0, 0);
+    mockListCalls.mockResolvedValue({
+      data: [
+        {
+          id: "c1",
+          conversation_id: "conv-1",
+          status: "ended",
+          type: "audio",
+          initiator_id: "me",
+          started_at: now.toISOString(),
+          duration_seconds: 12,
+        },
+      ],
+    });
+    const { findByText } = render(<CallHistoryScreen />);
+    // sous-texte "12s · HH:MM" sans mention du jour
+    const subtext = await findByText(/^12s · \d{2}:\d{2}$/);
+    expect(subtext).toBeTruthy();
+    expect(subtext.props.children).not.toMatch(/hier|lundi|mardi|mercredi|jeudi|vendredi|samedi|dimanche/i);
+  });
+
+  it("préfixe 'hier' pour un appel d'hier", async () => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    yesterday.setHours(10, 0, 0, 0);
+    mockListCalls.mockResolvedValue({
+      data: [
+        {
+          id: "c2",
+          conversation_id: "conv-2",
+          status: "ended",
+          type: "audio",
+          initiator_id: "me",
+          started_at: yesterday.toISOString(),
+          duration_seconds: 60,
+        },
+      ],
+    });
+    const { findByText } = render(<CallHistoryScreen />);
+    const subtext = await findByText(/hier \d{2}:\d{2}/);
+    expect(subtext).toBeTruthy();
+  });
+
+  it("préfixe le jour de la semaine pour un appel de cette semaine", async () => {
+    const daysAgo3 = new Date();
+    daysAgo3.setDate(daysAgo3.getDate() - 3);
+    daysAgo3.setHours(9, 15, 0, 0);
+    const expectedWeekday = daysAgo3.toLocaleDateString("fr-FR", { weekday: "long" });
+    mockListCalls.mockResolvedValue({
+      data: [
+        {
+          id: "c3",
+          conversation_id: "conv-3",
+          status: "missed",
+          type: "audio",
+          initiator_id: "other",
+          started_at: daysAgo3.toISOString(),
+        },
+      ],
+    });
+    const { findByText } = render(<CallHistoryScreen />);
+    const subtext = await findByText(new RegExp(`Manqué · ${expectedWeekday} \\d{2}:\\d{2}`));
+    expect(subtext).toBeTruthy();
+  });
+
+  it("préfixe 'j mois.' pour un appel plus ancien", async () => {
+    const old = new Date();
+    old.setMonth(old.getMonth() - 1);
+    old.setHours(8, 0, 0, 0);
+    const expectedDay = old.getDate();
+    const expectedMonth = old.toLocaleDateString("fr-FR", { month: "short" });
+    mockListCalls.mockResolvedValue({
+      data: [
+        {
+          id: "c4",
+          conversation_id: "conv-4",
+          status: "ended",
+          type: "video",
+          initiator_id: "me",
+          started_at: old.toISOString(),
+          duration_seconds: 300,
+        },
+      ],
+    });
+    const { findByText } = render(<CallHistoryScreen />);
+    const subtext = await findByText(new RegExp(`5min \\d{2}s · ${expectedDay} ${expectedMonth} \\d{2}:\\d{2}`));
+    expect(subtext).toBeTruthy();
+  });
+});
+
+describe("section headers groupés par date", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetConversation.mockResolvedValue(null);
+    mockGetConversationMembers.mockResolvedValue([]);
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("affiche 'Aujourd\\'hui' comme section header pour un appel du jour", async () => {
+    mockListCalls.mockResolvedValue({
+      data: [
+        {
+          id: "c1",
+          conversation_id: "conv-1",
+          status: "ended",
+          type: "audio",
+          initiator_id: "me",
+          started_at: new Date().toISOString(),
+        },
+      ],
+    });
+    const { findByText } = render(<CallHistoryScreen />);
+    expect(await findByText("Aujourd'hui")).toBeTruthy();
+  });
+
+  it("affiche 'Hier' comme section header pour un appel d'hier", async () => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    mockListCalls.mockResolvedValue({
+      data: [
+        {
+          id: "c2",
+          conversation_id: "conv-2",
+          status: "ended",
+          type: "audio",
+          initiator_id: "me",
+          started_at: yesterday.toISOString(),
+        },
+      ],
+    });
+    const { findByText } = render(<CallHistoryScreen />);
+    expect(await findByText("Hier")).toBeTruthy();
+  });
+
+  it("affiche le jour précis (ex: 'Mardi 21 mai') pour un appel de cette semaine", async () => {
+    const daysAgo2 = new Date();
+    daysAgo2.setDate(daysAgo2.getDate() - 2);
+    const weekday = daysAgo2.toLocaleDateString("fr-FR", { weekday: "long" });
+    const capitalizedWeekday = weekday.charAt(0).toUpperCase() + weekday.slice(1);
+    const day = daysAgo2.getDate();
+    const month = daysAgo2.toLocaleDateString("fr-FR", { month: "short" }).replace(".", "");
+    const expectedHeader = `${capitalizedWeekday} ${day} ${month}`;
+    mockListCalls.mockResolvedValue({
+      data: [
+        {
+          id: "c3",
+          conversation_id: "conv-3",
+          status: "ended",
+          type: "audio",
+          initiator_id: "me",
+          started_at: daysAgo2.toISOString(),
+        },
+      ],
+    });
+    const { findByText } = render(<CallHistoryScreen />);
+    expect(await findByText(expectedHeader)).toBeTruthy();
+  });
+
+  it("affiche le mois + année pour un appel plus ancien", async () => {
+    const old = new Date();
+    old.setMonth(old.getMonth() - 1);
+    const monthLong = old.toLocaleDateString("fr-FR", { month: "long" });
+    const capitalized = monthLong.charAt(0).toUpperCase() + monthLong.slice(1);
+    const expectedHeader = `${capitalized} ${old.getFullYear()}`;
+    mockListCalls.mockResolvedValue({
+      data: [
+        {
+          id: "c4",
+          conversation_id: "conv-4",
+          status: "ended",
+          type: "audio",
+          initiator_id: "me",
+          started_at: old.toISOString(),
+        },
+      ],
+    });
+    const { findByText } = render(<CallHistoryScreen />);
+    expect(await findByText(expectedHeader)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Section headers : "Mardi 21 mai" pour cette semaine, "Avril 2026" pour plus ancien
- Sous-texte des lignes enrichi : "hier 14:30", "mardi 14:30", "26 avr. 14:30" selon ancienneté
- Groupage "Plus ancien" par mois au lieu d'une seule section plate

## Test plan
- [x] 16 tests Jest verts (8 nouveaux cas)
- [x] Lint clean (0 erreurs)
- [ ] Visuel iOS Safari PWA à vérifier

Closes WHISPR-1553