### PR TITLE
fix(security): rapatrier le fix decodeHtmlEntities depuis main

### DIFF
--- a/src/services/linkPreview.ts
+++ b/src/services/linkPreview.ts
@@ -53,8 +53,9 @@ export function extractFirstUrl(text?: string | null): string | null {
 }
 
 function decodeHtmlEntities(value: string): string {
+  // decoder &amp; en dernier evite le double-unescape:
+  // sinon "&amp;lt;" deviendrait "<" au lieu de "&lt;"
   return value
-    .replace(/&amp;/gi, "&")
     .replace(/&quot;/gi, '"')
     .replace(/&#39;/gi, "'")
     .replace(/&apos;/gi, "'")
@@ -65,7 +66,8 @@ function decodeHtmlEntities(value: string): string {
     )
     .replace(/&#x([0-9a-f]+);/gi, (_, code: string) =>
       String.fromCharCode(parseInt(code, 16)),
-    );
+    )
+    .replace(/&amp;/gi, "&");
 }
 
 function compactWhitespace(


### PR DESCRIPTION
## Summary

Cherry-pick du commit `a8318ac` depuis `main` vers `deploy/preprod`. Ce fix de sécurité a été appliqué directement sur `main` (PR #213) sans jamais redescendre sur `deploy/preprod` lors des syncs précédentes.

## Context

Après le merge de la sync `preprod → main` (#304), un diff de contenu entre les deux branches a révélé que `src/services/linkPreview.ts` divergeait : `main` avait le fix `decode &amp; en dernier dans decodeHtmlEntities` mais pas `preprod`. Ce fix corrige une vulnérabilité de **double-unescape** signalée par CodeQL :

- Avant : `decodeHtmlEntities("&amp;lt;")` renvoyait `<` (au lieu de `&lt;`)
- Après : le `&amp;` est décodé **en dernier**, donc `&amp;lt;` reste `&lt;`

## Autres deltas main vs preprod (non rapatriés)

| Fichier | Raison |
|---|---|
| `.github/workflows/docker.yml` | Mapping main → `whispr-api.roadmvn.com` intentionnellement main-only (CD prod) |
| `src/components/Chat/Avatar.tsx` | preprod a *supprimé* un `triedAuthResolveRef` (fix Sonar S1854), pas main → preprod en avance |
| `src/screens/Auth/__tests__/ProfileSetupScreen.test.tsx` | preprod a *supprimé* un test → preprod en avance |

## Test plan

- [x] `npm test -- --watchAll=false --testPathPattern=linkPreview` — 8/8 verts
- [x] `npm test -- --watchAll=false` — 188 suites / 1857 tests verts
- [ ] CI verte sur la PR