### PR TITLE
fix(chat): parse E2EE media metadata on API message load

### DIFF
--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -1350,6 +1350,7 @@ export const ChatScreen: React.FC = () => {
             ) // Include all message types
             .map(async (msg) => {
               let displayContent = msg.content;
+              let e2eeMetadata: Record<string, unknown> = {};
               if (
                 typeof msg.content === "string" &&
                 E2EEService.isEncryptedPayload(msg.content)
@@ -1358,8 +1359,27 @@ export const ChatScreen: React.FC = () => {
                   conversationId,
                   content: msg.content,
                 });
-                displayContent =
-                  decrypted === null ? "Message chiffré" : decrypted;
+                if (decrypted === null) {
+                  displayContent = "Message chiffré";
+                } else if (msg.message_type === "media") {
+                  try {
+                    const parsed = JSON.parse(decrypted);
+                    if (parsed.media_key && parsed.media_nonce) {
+                      displayContent = parsed.caption || "";
+                      e2eeMetadata = {
+                        media_key: parsed.media_key,
+                        media_nonce: parsed.media_nonce,
+                        e2ee: true,
+                      };
+                    } else {
+                      displayContent = decrypted;
+                    }
+                  } catch {
+                    displayContent = decrypted;
+                  }
+                } else {
+                  displayContent = decrypted;
+                }
               }
               // WHISPR-1074: the backend may ship the enriched shape
               // (delivery_statuses + status). Widen once instead of
@@ -1405,6 +1425,7 @@ export const ChatScreen: React.FC = () => {
               return {
                 ...msg,
                 content: displayContent,
+                metadata: { ...(msg.metadata || {}), ...e2eeMetadata },
                 status,
                 reactions,
                 attachments,


### PR DESCRIPTION
## Summary
- Quand un chat était ouvert, les messages médias E2EE chargés depuis l'API affichaient le JSON brut (`{"caption":"Photo","media_key":"...","media_nonce":"..."}`) au lieu de l'image
- Le path WebSocket parsait déjà ce JSON pour extraire `media_key/media_nonce` dans les métadonnées, mais pas le path `loadMessages` (chargement initial depuis l'API)
- Fix : applique le même parsing dans `loadMessages` — `media_key` et `media_nonce` sont extraits dans `metadata`, le contenu affiché devient la caption

## Test plan
- [ ] Ouvrir un chat direct contenant des images envoyées → les images s'affichent correctement
- [ ] Tests unitaires ChatScreen verts (10/10)
- [ ] Lint clean

Closes WHISPR-961