### PR TITLE
fix(media): afficher placeholder video au lieu de Video direct pour eviter AVPlayerItem -11828

### DIFF
--- a/src/components/Chat/MediaMessage.tsx
+++ b/src/components/Chat/MediaMessage.tsx
@@ -62,6 +62,15 @@ interface MediaMessageProps {
     key: string;
     nonce: string;
   };
+  // WHISPR-fix-video-preview-hevc-ios : pour les vidéos E2EE, le poster
+  // est uploadé séparément et chiffré avec sa propre clé/nonce. Sans ça,
+  // le composant n'a aucun moyen d'afficher une preview sans tomber sur
+  // le blob déchiffré de la vidéo (qui sur iOS+HEVC casse avec
+  // AVPlayerItem -11828 AVErrorFileFormatNotRecognized).
+  thumbnailE2ee?: {
+    key: string;
+    nonce: string;
+  };
 }
 
 export const MediaMessage: React.FC<MediaMessageProps> = ({
@@ -71,6 +80,7 @@ export const MediaMessage: React.FC<MediaMessageProps> = ({
   size,
   thumbnailUri,
   e2ee,
+  thumbnailE2ee,
 }) => {
   ensureExpoAvVideoLoaded();
   const { getThemeColors } = useTheme();
@@ -96,11 +106,28 @@ export const MediaMessage: React.FC<MediaMessageProps> = ({
   );
 
   const { decryptedUri: mainUri } = useE2EEMedia(resolvedMainUri, e2ee);
-  const { decryptedUri: thumbUri } = useE2EEMedia(resolvedThumbUri, e2ee);
+  // WHISPR-fix-video-preview-hevc-ios : le thumbnail E2EE a sa propre clé/nonce
+  // car il est uploadé séparément. Si elle n'est pas fournie, on retombe sur
+  // la clé du média principal (compat pour les images legacy qui reusaient
+  // la clé pour leur thumbnail).
+  const thumbE2eeKeys = thumbnailE2ee || e2ee;
+  const { decryptedUri: thumbUri } = useE2EEMedia(
+    resolvedThumbUri,
+    thumbE2eeKeys,
+  );
 
   // Use decrypted URIs if available, fallback to resolved URIs
   const finalMainUri = mainUri || resolvedMainUri;
-  const finalThumbUri = thumbUri || resolvedThumbUri;
+  // Important : pour une vidéo E2EE sans thumbnail séparé, `resolvedThumbUri`
+  // pointe vers la même ressource que le main (cf. MessageBubble qui passe
+  // thumbnail_url=media_url par défaut). On considère alors qu'on n'a PAS
+  // de vrai thumbnail image et on bascule sur le placeholder, plutôt que
+  // d'essayer d'afficher le blob vidéo déchiffré dans <Image>.
+  const hasDistinctThumbnail =
+    !!resolvedThumbUri && resolvedThumbUri !== resolvedMainUri;
+  const finalThumbUri = hasDistinctThumbnail
+    ? thumbUri || resolvedThumbUri
+    : undefined;
 
   // WHISPR-1039: on lit le ratio via l'évènement onLoad natif plutôt que
   // Image.getSize pour fonctionner uniformément iOS/Android/web et éviter
@@ -385,14 +412,21 @@ export const MediaMessage: React.FC<MediaMessageProps> = ({
         activeOpacity={0.9}
         style={styles.videoContainer}
       >
-        {/* Video preview - use thumbnail image first if available, else Video component or placeholder */}
+        {/* Video preview :
+            - si on a un thumbnail image distinct → <Image> (cas E2EE avec
+              poster côté client, ou plaintext avec thumbnail serveur).
+            - si pas de thumbnail ET pas en E2EE → on peut tenter <Video>
+              comme preview (cas legacy/plaintext, vidéo lisible direct).
+            - en E2EE sans thumbnail → placeholder direct. Tenter <Video>
+              sur un blob déchiffré HEVC casse iOS avec AVErrorFileFormatNotRecognized
+              (-11828) et affiche un cadre noir. */}
         {finalThumbUri ? (
           <Image
             source={{ uri: finalThumbUri }}
             style={styles.videoThumbnail}
             resizeMode="cover"
           />
-        ) : Video && finalMainUri && !thumbnailError ? (
+        ) : Video && finalMainUri && !thumbnailError && !e2ee ? (
           <Video
             ref={thumbnailVideoRef}
             source={{ uri: finalMainUri }}
@@ -441,7 +475,9 @@ export const MediaMessage: React.FC<MediaMessageProps> = ({
             }}
           />
         ) : (
-          // Fallback placeholder if Video component not available or error
+          // Fallback placeholder : Video indisponible, erreur thumbnail,
+          // ou média E2EE sans poster séparé. On garde le bouton play
+          // accessible — le modal full peut quand même tenter la lecture.
           <View
             style={[
               styles.videoThumbnail,

--- a/src/components/Chat/MessageBubble.tsx
+++ b/src/components/Chat/MessageBubble.tsx
@@ -435,6 +435,19 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
           nonce: (message.metadata as any).media_nonce as string,
         }
       : undefined;
+  // WHISPR-fix-video-preview-hevc-ios : le poster vidéo est chiffré avec
+  // sa propre clé/nonce. Sans ces métadonnées, MediaMessage tombera sur
+  // le placeholder pour les vidéos E2EE (au lieu de tenter <Video> sur
+  // le blob déchiffré, qui casse sur iOS avec AVErrorFileFormatNotRecognized).
+  const e2eeThumbnail =
+    (message.metadata as any)?.e2ee &&
+    (message.metadata as any)?.thumbnail_key &&
+    (message.metadata as any)?.thumbnail_nonce
+      ? {
+          key: (message.metadata as any).thumbnail_key as string,
+          nonce: (message.metadata as any).thumbnail_nonce as string,
+        }
+      : undefined;
   const mediaUploadOverlay = isSent
     ? getMediaUploadOverlayState(
         message.status,
@@ -501,10 +514,14 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                   size={firstAttachment.metadata.size}
                   thumbnailUri={resolveMediaUrl(
                     firstAttachment.metadata.thumbnail_url,
-                    firstAttachment.media_id,
-                    "thumbnail",
+                    (firstAttachment.metadata as any).thumbnail_id ||
+                      firstAttachment.media_id,
+                    (firstAttachment.metadata as any).thumbnail_id
+                      ? "blob"
+                      : "thumbnail",
                   )}
                   e2ee={e2eeMedia}
+                  thumbnailE2ee={e2eeThumbnail}
                 />
               )
             ) : null}
@@ -620,10 +637,14 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                       size={firstAttachment.metadata.size}
                       thumbnailUri={resolveMediaUrl(
                         firstAttachment.metadata.thumbnail_url,
-                        firstAttachment.media_id,
-                        "thumbnail",
+                        (firstAttachment.metadata as any).thumbnail_id ||
+                          firstAttachment.media_id,
+                        (firstAttachment.metadata as any).thumbnail_id
+                          ? "blob"
+                          : "thumbnail",
                       )}
                       e2ee={e2eeMedia}
+                      thumbnailE2ee={e2eeThumbnail}
                     />
                   ),
                 )
@@ -723,10 +744,14 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                   size={firstAttachment.metadata.size}
                   thumbnailUri={resolveMediaUrl(
                     firstAttachment.metadata.thumbnail_url,
-                    firstAttachment.media_id,
-                    "thumbnail",
+                    (firstAttachment.metadata as any).thumbnail_id ||
+                      firstAttachment.media_id,
+                    (firstAttachment.metadata as any).thumbnail_id
+                      ? "blob"
+                      : "thumbnail",
                   )}
                   e2ee={e2eeMedia}
+                  thumbnailE2ee={e2eeThumbnail}
                 />
               )}
             </>

--- a/src/components/Chat/__tests__/MediaMessage.test.tsx
+++ b/src/components/Chat/__tests__/MediaMessage.test.tsx
@@ -28,12 +28,33 @@ jest.mock("../../../context/ThemeContext", () => ({
   }),
 }));
 
-// expo-av is imported via try/catch — stub the module so the require resolves
+// expo-av is imported via try/catch — stub the module so the require resolves.
+// We tag the Video component with a sentinel testID so tests can prove it is
+// (or is NOT) rendered for a given scenario.
 jest.mock(
   "expo-av",
-  () => ({ Video: () => null, ResizeMode: { COVER: "cover" } }),
+  () => {
+    const RN = require("react-native");
+    const ReactInstance = require("react");
+    return {
+      Video: (props: any) =>
+        ReactInstance.createElement(RN.View, {
+          ...props,
+          testID: "video-thumbnail-sentinel",
+        }),
+      ResizeMode: { COVER: "cover", CONTAIN: "contain" },
+    };
+  },
   { virtual: true },
 );
+
+// E2EE decryption is heavy and IO-bound — stub it to a deterministic blob URI
+// so we can assert on which uri the component renders.
+jest.mock("../../../services/E2EEService", () => ({
+  E2EEService: {
+    decryptMediaFile: jest.fn(async (uri: string) => `decrypted:${uri}`),
+  },
+}));
 
 import { MediaMessage } from "../MediaMessage";
 
@@ -201,5 +222,77 @@ describe("MediaMessage useResolvedMediaUrl (WHISPR-1216)", () => {
       ([u]: [string]) => u.includes("/blob") && u.includes("stream=1"),
     );
     expect(blobStreamCalls.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("MediaMessage video preview (WHISPR-fix-video-preview-hevc-ios)", () => {
+  beforeEach(() => {
+    // Pour ces tests on stubbe fetch en bytes pour que la résolution du blob
+    // n'est pas bloquée — on s'intéresse au thumbnail rendu, pas à la pipeline
+    // d'URL.
+    (global as any).fetch = jest.fn().mockImplementation(() => {
+      return Promise.resolve({
+        ok: true,
+        url: "",
+        headers: { get: () => "application/octet-stream" },
+        blob: async () =>
+          new Blob([new Uint8Array([0xff, 0xd8])], { type: "image/jpeg" }),
+      });
+    });
+  });
+
+  it("rend une <Image> et JAMAIS <Video> quand un poster E2EE est fourni", async () => {
+    const videoUri = "https://whispr.devzeyu.com/media/v1/video1/blob";
+    const posterUri = "https://whispr.devzeyu.com/media/v1/poster1/blob";
+
+    const { queryByTestId } = render(
+      <MediaMessage
+        uri={videoUri}
+        type="video"
+        thumbnailUri={posterUri}
+        e2ee={{ key: "video-key", nonce: "video-nonce" }}
+        thumbnailE2ee={{ key: "poster-key", nonce: "poster-nonce" }}
+      />,
+    );
+
+    // Le composant <Video> ne doit JAMAIS apparaître en thumbnail pour un
+    // média E2EE avec poster — c'est précisément ce qui cassait avec
+    // AVErrorFileFormatNotRecognized (-11828) sur iOS+HEVC.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(queryByTestId("video-thumbnail-sentinel")).toBeNull();
+  });
+
+  it("rend le placeholder (pas <Video>) pour une vidéo E2EE sans poster", async () => {
+    const videoUri = "https://whispr.devzeyu.com/media/v1/video2/blob";
+
+    const { queryByTestId } = render(
+      <MediaMessage
+        uri={videoUri}
+        type="video"
+        e2ee={{ key: "video-key", nonce: "video-nonce" }}
+      />,
+    );
+
+    // Important : sans thumbnail E2EE explicite, on n'a AUCUN moyen sûr
+    // d'afficher la frame d'une vidéo HEVC sur iOS. On doit rendre le
+    // placeholder, pas tenter <Video> sur le blob déchiffré.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(queryByTestId("video-thumbnail-sentinel")).toBeNull();
+  });
+
+  it("rend bien <Video> comme thumbnail pour une vidéo plaintext sans thumbnail séparé", async () => {
+    // Avec stream OK : la pipeline /blob?stream=1 retourne des bytes, donc
+    // resolvedMainUri se matérialise en blob:fake. Sans thumbnail séparé,
+    // et SANS e2ee, on accepte <Video> en thumbnail (comportement legacy).
+    const { queryByTestId } = render(
+      <MediaMessage
+        uri="https://whispr.devzeyu.com/media/v1/video3/blob"
+        type="video"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(queryByTestId("video-thumbnail-sentinel")).not.toBeNull();
+    });
   });
 });

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -130,6 +130,7 @@ const CHAT_TOUR_STEPS: TourStep[] = [
 import { getConversationDisplayName } from "../../utils";
 import { generateClientRandom } from "../../utils/crypto";
 import { convertHeicToJpeg } from "../../utils/imageCompression";
+import { extractVideoPoster } from "../../utils/videoPoster";
 import { usePresenceStore } from "../../store/presenceStore";
 import { AuthStackParamList } from "../../navigation/AuthNavigator";
 import { colors, withOpacity } from "../../theme/colors";
@@ -668,6 +669,13 @@ export const ChatScreen: React.FC = () => {
                       media_key: parsed.media_key,
                       media_nonce: parsed.media_nonce,
                       e2ee: true,
+                      // WHISPR-fix-video-preview-hevc-ios
+                      ...(parsed.thumbnail_key && parsed.thumbnail_nonce
+                        ? {
+                            thumbnail_key: parsed.thumbnail_key,
+                            thumbnail_nonce: parsed.thumbnail_nonce,
+                          }
+                        : {}),
                     };
                   }
                 } catch {
@@ -1371,6 +1379,13 @@ export const ChatScreen: React.FC = () => {
                         media_key: parsed.media_key,
                         media_nonce: parsed.media_nonce,
                         e2ee: true,
+                        // WHISPR-fix-video-preview-hevc-ios
+                        ...(parsed.thumbnail_key && parsed.thumbnail_nonce
+                          ? {
+                              thumbnail_key: parsed.thumbnail_key,
+                              thumbnail_nonce: parsed.thumbnail_nonce,
+                            }
+                          : {}),
                       };
                     } else {
                       displayContent = decrypted;
@@ -1997,6 +2012,70 @@ export const ChatScreen: React.FC = () => {
           }
         }
 
+        // WHISPR-fix-video-preview-hevc-ios : pour les vidéos, on extrait
+        // un poster JPEG côté client. Sinon le composant MediaMessage tente
+        // <Video> sur le blob déchiffré pour générer la preview de liste,
+        // ce qui casse iOS sur HEVC/.mov avec AVErrorFileFormatNotRecognized
+        // (-11828). Le poster est uploadé séparément ; en E2EE il est chiffré
+        // avec sa propre clé/nonce.
+        let posterUpload:
+          | {
+              id: string;
+              url: string;
+              key?: string;
+              nonce?: string;
+            }
+          | undefined;
+        if (type === "video") {
+          try {
+            const poster = await extractVideoPoster(uploadUri, finalFilename);
+            if (poster) {
+              let posterUploadUri = poster.uri;
+              let posterMime: string = poster.mimeType;
+              let posterE2ee:
+                | { key: string; nonce: string }
+                | undefined;
+              if (shouldEncrypt) {
+                try {
+                  const encPoster = await E2EEService.encryptMediaFile(
+                    poster.uri,
+                  );
+                  posterUploadUri = encPoster.encryptedUri;
+                  posterE2ee = { key: encPoster.key, nonce: encPoster.nonce };
+                  posterMime = "application/octet-stream";
+                } catch (posterEncErr) {
+                  logger.warn(
+                    "ChatScreen.handleSendMedia",
+                    "Poster encryption failed, falling back to plaintext poster",
+                    posterEncErr,
+                  );
+                }
+              }
+              const posterResult = await MediaService.uploadMedia(
+                {
+                  uri: posterUploadUri,
+                  name: poster.filename,
+                  type: posterMime,
+                },
+                undefined,
+                { context: "message", ownerId: userId },
+              );
+              posterUpload = {
+                id: posterResult.id,
+                url: posterResult.url,
+                key: posterE2ee?.key,
+                nonce: posterE2ee?.nonce,
+              };
+            }
+          } catch (posterErr) {
+            logger.warn(
+              "ChatScreen.handleSendMedia",
+              "Video poster extraction/upload failed, falling back to placeholder preview",
+              posterErr,
+            );
+          }
+        }
+
         // 1. Upload file to media-service (encrypted or plain)
         const uploadResult = await MediaService.uploadMedia(
           { uri: finalUploadUri, name: finalFilename, type: uploadMimeType },
@@ -2035,16 +2114,29 @@ export const ChatScreen: React.FC = () => {
           }
         }
 
-        const mediaMetadata = {
+        const mediaMetadata: Record<string, unknown> = {
           media_type: type,
           media_id: uploadResult.id,
           media_url: uploadResult.url,
-          thumbnail_url: uploadResult.thumbnail_url || uploadResult.url,
+          thumbnail_url: posterUpload
+            ? posterUpload.url
+            : uploadResult.thumbnail_url || uploadResult.url,
           filename: uploadResult.filename || finalFilename,
           mime_type: uploadResult.mime_type || finalMimeType,
           size: uploadResult.size,
           duration: resolvedDuration,
         };
+        // WHISPR-fix-video-preview-hevc-ios : si on a réussi à uploader un
+        // poster séparé, on attache son id et (en E2EE) sa clé/nonce. Le
+        // récepteur s'en sert pour rendre une <Image> au lieu de tenter
+        // <Video> sur le blob déchiffré.
+        if (posterUpload) {
+          mediaMetadata.thumbnail_id = posterUpload.id;
+          if (posterUpload.key && posterUpload.nonce) {
+            mediaMetadata.thumbnail_key = posterUpload.key;
+            mediaMetadata.thumbnail_nonce = posterUpload.nonce;
+          }
+        }
 
         // Update optimistic message with remote URLs so preview uses the hosted image
         setMessages((prev) =>
@@ -2174,6 +2266,14 @@ export const ChatScreen: React.FC = () => {
                 caption: messageContent,
                 media_key: e2eeMediaMeta.key,
                 media_nonce: e2eeMediaMeta.nonce,
+                // WHISPR-fix-video-preview-hevc-ios : la clé/nonce du poster
+                // doivent transiter chiffrées (jamais en clair côté serveur).
+                ...(posterUpload?.key && posterUpload?.nonce
+                  ? {
+                      thumbnail_key: posterUpload.key,
+                      thumbnail_nonce: posterUpload.nonce,
+                    }
+                  : {}),
               });
               const enc = await E2EEService.encryptMessageForConversation({
                 conversationId,

--- a/src/utils/videoPoster.ts
+++ b/src/utils/videoPoster.ts
@@ -1,0 +1,94 @@
+/**
+ * Video poster extraction
+ *
+ * WHISPR-fix-video-preview-hevc-ios : iOS enregistre les vidéos en HEVC/H.265
+ * `.mov`. Une fois déchiffrées côté client (blob: URI), AVPlayerItem échoue
+ * avec `-11828` (AVErrorFileFormatNotRecognized) quand on essaye de les
+ * utiliser en thumbnail dans la liste de conv. Pour éviter ça, on extrait
+ * un poster JPEG du premier frame côté émetteur, AVANT chiffrement et
+ * upload, et on le stocke comme thumbnail séparé (chiffré séparément aussi
+ * en E2EE).
+ *
+ * Pendant les tests Jest, `expo-video-thumbnails` est mock-able.
+ * Sur web, l'API native n'existe pas — on retourne null et l'appelant
+ * gère un fallback gracieux (placeholder côté receveur).
+ */
+
+import { NativeModules, Platform } from "react-native";
+import { logger } from "./logger";
+
+type ExpoVideoThumbnailsModule = {
+  getThumbnailAsync: (
+    uri: string,
+    options: { time?: number; quality?: number },
+  ) => Promise<{ uri: string; width?: number; height?: number }>;
+};
+
+function loadVideoThumbnails(): ExpoVideoThumbnailsModule | null {
+  if (Platform.OS === "web") return null;
+  if (process.env.NODE_ENV === "test") {
+    try {
+      return require("expo-video-thumbnails") as ExpoVideoThumbnailsModule;
+    } catch {
+      return null;
+    }
+  }
+  const native = NativeModules as Record<string, unknown>;
+  if (!native?.ExpoVideoThumbnails) return null;
+  try {
+    return require("expo-video-thumbnails") as ExpoVideoThumbnailsModule;
+  } catch {
+    return null;
+  }
+}
+
+export interface VideoPosterResult {
+  uri: string;
+  mimeType: "image/jpeg";
+  filename: string;
+}
+
+/**
+ * Extrait le premier frame d'une vidéo et le retourne sous forme de JPEG.
+ *
+ * - Sur web : retourne null (module natif indisponible).
+ * - Sur natif sans le module : retourne null (dev client incomplet).
+ * - Sur extraction échouée : retourne null. L'appelant doit upload sans
+ *   poster et accepter le fallback placeholder côté receveur.
+ *
+ * @param videoUri  URI locale de la vidéo (file://, content://, etc).
+ * @param baseFilename Nom de fichier d'origine, pour dériver un nom de poster.
+ * @returns Le poster extrait, ou null si non disponible.
+ */
+export async function extractVideoPoster(
+  videoUri: string,
+  baseFilename: string,
+): Promise<VideoPosterResult | null> {
+  const videoThumbnails = loadVideoThumbnails();
+  if (!videoThumbnails) {
+    logger.debug(
+      "videoPoster",
+      "expo-video-thumbnails unavailable, skipping poster extraction",
+    );
+    return null;
+  }
+
+  try {
+    const thumb = await videoThumbnails.getThumbnailAsync(videoUri, {
+      time: 0,
+      quality: 0.8,
+    });
+    if (!thumb?.uri) return null;
+    const posterFilename = baseFilename
+      .replace(/\.(mov|mp4|m4v|avi|mkv|webm)$/i, "")
+      .concat(".poster.jpg");
+    return {
+      uri: thumb.uri,
+      mimeType: "image/jpeg",
+      filename: posterFilename || "poster.jpg",
+    };
+  } catch (err) {
+    logger.warn("videoPoster", "Poster extraction failed", err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Pour les videos E2EE iPhone (HEVC/.mov), le blob dechiffre cote client ne peut pas etre joue par AVPlayerItem (erreur -11828 AVErrorFileFormatNotRecognized) -> cadre noir cote receveur.
- Cote emetteur : extraction d'un poster JPEG via expo-video-thumbnails avant chiffrement + upload separe + cles thumbnail transmises dans le payload E2EE.
- Cote receveur : MediaMessage ne tente plus <Video> en thumbnail quand e2ee est actif. Si poster present -> Image; sinon -> placeholder play (icone videocam).
- Compat plaintext preservee : <Video> en thumbnail reste autorise hors E2EE.

## Test plan
- [x] Unit tests verts (8/8 sur MediaMessage incluant 3 nouveaux cas E2EE)
- [x] Lint clean (0 erreur)
- [x] TypeScript clean (uniquement erreurs prexistantes netinfo)
- [ ] Test live preprod : envoi video iPhone dans une conv E2EE -> preview placeholder, lecture full ouvre le modal
- [ ] Test live preprod : envoi video Android plaintext -> Video reste en thumbnail (compat)