### PR TITLE
[WHISPR-961] fix(groups): resolve user-service group ID via by-conversation endpoint

### DIFF
--- a/src/services/groups/__tests__/api.test.ts
+++ b/src/services/groups/__tests__/api.test.ts
@@ -413,12 +413,16 @@ describe("groupsAPI.getGroupSettings", () => {
     expect(settings.moderation_level).toBe("strict");
   });
 
-  it("falls back to groupId when conversation has no externalGroupId", async () => {
+  it("uses by-conversation lookup when externalGroupId is not set", async () => {
     // 1st call: conversation with no externalGroupId
     mockFetch.mockResolvedValueOnce(
       mockResponse({ body: { data: { id: "grp-1" } } }),
     );
-    // 2nd call: settings
+    // 2nd call: by-conversation endpoint returns the group
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ body: { id: "grp-1", name: "Test Group" } }),
+    );
+    // 3rd call: settings
     mockFetch.mockResolvedValueOnce(
       mockResponse({ body: { message_permission: "all_members" } }),
     );
@@ -426,16 +430,39 @@ describe("groupsAPI.getGroupSettings", () => {
     await groupsAPI.getGroupSettings("grp-1");
 
     expect(mockFetch.mock.calls[1][0]).toBe(
+      `${USER_BASE}/groups/by-conversation/grp-1`,
+    );
+    expect(mockFetch.mock.calls[2][0]).toBe(
       `${USER_BASE}/groups/grp-1/settings`,
     );
   });
 
-  it("returns defaults when the settings endpoint returns a non-OK status", async () => {
-    // conversation fetch
+  it("returns defaults when neither externalGroupId nor by-conversation returns an ID", async () => {
+    // 1st call: conversation with no externalGroupId
     mockFetch.mockResolvedValueOnce(
       mockResponse({ body: { data: { id: "grp-1" } } }),
     );
-    // settings 404
+    // 2nd call: by-conversation 404
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 404 }));
+
+    const settings = await groupsAPI.getGroupSettings("grp-1");
+    expect(settings).toEqual({
+      message_permission: "all_members",
+      media_permission: "all_members",
+      mention_permission: "all_members",
+      add_members_permission: "admins_only",
+      moderation_level: "light",
+      content_filter_enabled: false,
+      join_approval_required: false,
+    });
+  });
+
+  it("returns defaults when the settings endpoint returns a non-OK status", async () => {
+    // 1st call: conversation → externalGroupId provided
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ body: { data: { externalGroupId: "real-uuid" } } }),
+    );
+    // 2nd call: settings 404
     mockFetch.mockResolvedValueOnce(mockResponse({ status: 404 }));
 
     const settings = await groupsAPI.getGroupSettings("grp-1");
@@ -489,18 +516,37 @@ describe("groupsAPI.updateGroupSettings", () => {
     expect(result.message_permission).toBe("admins_only");
   });
 
-  it("falls back to groupId when conversation has no externalGroupId", async () => {
+  it("uses by-conversation lookup when externalGroupId is not set", async () => {
+    // 1st call: conversation → no externalGroupId
     mockFetch.mockResolvedValueOnce(
       mockResponse({ body: { data: { id: "grp-1" } } }),
     );
+    // 2nd call: by-conversation → group found
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ body: { id: "grp-1", name: "Test Group" } }),
+    );
+    // 3rd call: PATCH settings
     mockFetch.mockResolvedValueOnce(
       mockResponse({ body: { message_permission: "all_members" } }),
     );
 
     await groupsAPI.updateGroupSettings("grp-1", {});
 
-    expect(mockFetch.mock.calls[1][0]).toBe(
+    expect(mockFetch.mock.calls[2][0]).toBe(
       `${USER_BASE}/groups/grp-1/settings`,
+    );
+  });
+
+  it("throws when neither externalGroupId nor by-conversation returns a group", async () => {
+    // 1st call: conversation → no externalGroupId
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ body: { data: { id: "grp-1" } } }),
+    );
+    // 2nd call: by-conversation 404
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 404 }));
+
+    await expect(groupsAPI.updateGroupSettings("grp-1", {})).rejects.toThrow(
+      "Groupe non trouvé (identifiant introuvable)",
     );
   });
 

--- a/src/services/groups/api.ts
+++ b/src/services/groups/api.ts
@@ -284,6 +284,21 @@ function membersFromConversationPayload(conv: any): RawConversationMember[] {
   return conv.members as RawConversationMember[];
 }
 
+async function resolveUserServiceGroupId(
+  conversationId: string,
+  headers: Record<string, string>,
+  externalGroupId?: string | null,
+): Promise<string | null> {
+  if (externalGroupId) return externalGroupId;
+  const res = await fetch(
+    `${API_BASE_URL}/groups/by-conversation/${encodeURIComponent(conversationId)}`,
+    { headers },
+  ).catch(() => null);
+  if (!res?.ok) return null;
+  const group = await res.json().catch(() => null);
+  return group?.id ?? null;
+}
+
 const DEFAULT_GROUP_SETTINGS: GroupSettings = {
   message_permission: "all_members",
   media_permission: "all_members",
@@ -800,16 +815,35 @@ export const groupsAPI = {
 
   async getGroupLogs(
     groupId: string,
-    params?: { page?: number; limit?: number; actionType?: string },
+    params?: {
+      page?: number;
+      limit?: number;
+      actionType?: string;
+      conversationId?: string;
+    },
   ): Promise<{ logs: GroupLog[]; total: number }> {
     const headers = await getAuthHeaders();
+    let resolvedGroupId = groupId;
+    if (params?.conversationId) {
+      const conv = await fetchMessagingConversationPayload(
+        params.conversationId,
+        headers,
+      );
+      const externalId = conv?.externalGroupId || conv?.external_group_id;
+      resolvedGroupId =
+        (await resolveUserServiceGroupId(
+          params.conversationId,
+          headers,
+          externalId,
+        )) || groupId;
+    }
     const query = new URLSearchParams();
     if (params?.page) query.set("page", String(params.page));
     if (params?.limit) query.set("limit", String(params.limit));
     if (params?.actionType) query.set("actionType", params.actionType);
     const qs = query.toString();
     const res = await fetch(
-      `${API_BASE_URL}/groups/${encodeURIComponent(groupId)}/logs${qs ? `?${qs}` : ""}`,
+      `${API_BASE_URL}/groups/${encodeURIComponent(resolvedGroupId)}/logs${qs ? `?${qs}` : ""}`,
       { headers },
     );
     if (!res.ok) {
@@ -828,8 +862,15 @@ export const groupsAPI = {
     const headers = await getAuthHeaders();
     const convId = params?.conversationId || groupId;
     const conv = await fetchMessagingConversationPayload(convId, headers);
-    const userServiceGroupId =
-      conv?.externalGroupId || conv?.external_group_id || groupId;
+    const externalId = conv?.externalGroupId || conv?.external_group_id;
+    const userServiceGroupId = await resolveUserServiceGroupId(
+      convId,
+      headers,
+      externalId,
+    );
+    if (!userServiceGroupId) {
+      return { ...DEFAULT_GROUP_SETTINGS };
+    }
     const res = await fetch(
       `${API_BASE_URL}/groups/${encodeURIComponent(userServiceGroupId)}/settings`,
       { headers },
@@ -848,8 +889,15 @@ export const groupsAPI = {
     const headers = await getAuthHeaders();
     const convId = params?.conversationId || groupId;
     const conv = await fetchMessagingConversationPayload(convId, headers);
-    const userServiceGroupId =
-      conv?.externalGroupId || conv?.external_group_id || groupId;
+    const externalId = conv?.externalGroupId || conv?.external_group_id;
+    const userServiceGroupId = await resolveUserServiceGroupId(
+      convId,
+      headers,
+      externalId,
+    );
+    if (!userServiceGroupId) {
+      throw new Error("Groupe non trouvé (identifiant introuvable)");
+    }
     const res = await fetch(
       `${API_BASE_URL}/groups/${encodeURIComponent(userServiceGroupId)}/settings`,
       {


### PR DESCRIPTION
## Summary
- Ajoute la fonction helper `resolveUserServiceGroupId` qui tente d'abord `externalGroupId` de la conversation, puis `GET /groups/by-conversation/:conversationId` comme fallback
- `getGroupSettings` utilise ce helper : retourne les valeurs par défaut si aucun ID ne peut être résolu (plus de crash 404)
- `updateGroupSettings` utilise ce helper : lance une erreur explicite si l'ID est introuvable
- `getGroupLogs` accepte un `conversationId` optionnel et résout l'ID user-service si fourni

## Contexte
Les paramètres de groupe affichaient une erreur 404 car `groupId` dans la route correspond à l'UUID messaging-service, pas à l'UUID user-service. Ce PR corrige la résolution de l'ID côté mobile.

## Test plan
- [x] 49 tests unitaires verts (`npm test -- --watchAll=false --testPathPattern="services/groups"`)
- [x] Lint clean
- [ ] Créer un nouveau groupe → ouvrir ses paramètres → doit s'afficher sans erreur
- [ ] Modifier un paramètre (ex: message_permission) → doit se sauvegarder

Closes WHISPR-961