### PR TITLE
fix: replace deprecated MediaTypeOptions and CameraType enums for SDK 53

### DIFF
--- a/src/components/Chat/CameraCapture.tsx
+++ b/src/components/Chat/CameraCapture.tsx
@@ -190,12 +190,9 @@ export const CameraCapture: React.FC<CameraCaptureProps> = ({
       // l'appareil photo (HEIC sur iOS si "Haute efficacité" est actif).
       // Imposer une qualité re-encoderait systématiquement en JPEG.
       const result = await ImagePicker.launchCameraAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        mediaTypes: ["images"],
         allowsEditing: false,
-        cameraType:
-          cameraType === "front"
-            ? ImagePicker.CameraType.front
-            : ImagePicker.CameraType.back,
+        cameraType: cameraType === "front" ? "front" : "back",
       });
 
       if (!result.canceled && result.assets && result.assets[0]) {
@@ -244,13 +241,10 @@ export const CameraCapture: React.FC<CameraCaptureProps> = ({
       );
 
       const result = await ImagePicker.launchCameraAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Videos,
+        mediaTypes: ["videos"],
         allowsEditing: false,
         quality: 0.9,
-        cameraType:
-          cameraType === "front"
-            ? ImagePicker.CameraType.front
-            : ImagePicker.CameraType.back,
+        cameraType: cameraType === "front" ? "front" : "back",
         videoMaxDuration: 60,
       });
 

--- a/src/screens/Profile/MyProfileScreen.tsx
+++ b/src/screens/Profile/MyProfileScreen.tsx
@@ -285,7 +285,7 @@ export const MyProfileScreen: React.FC = () => {
       }
 
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        mediaTypes: ["images"],
         allowsEditing: true,
         aspect: [1, 1],
         quality: 0.8,

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -563,7 +563,7 @@ export const SettingsScreen: React.FC = () => {
       }
 
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        mediaTypes: ["images"],
         allowsEditing: true,
         quality: 0.9,
       });


### PR DESCRIPTION
## Summary
- Replace `ImagePicker.MediaTypeOptions.Images/Videos` with string arrays `["images"]`/`["videos"]` (SDK 53 API)
- Replace `ImagePicker.CameraType.front/back` with `"front"`/`"back"` strings (SDK 53 API)
- Applies to `CameraCapture.tsx`, `MyProfileScreen.tsx`, and `SettingsScreen.tsx`

## Test plan
- [ ] Send photo from camera in chat — no crash
- [ ] Send video from camera in chat — no crash
- [ ] Pick profile picture — no crash
- [ ] Pick settings image — no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)