### PR TITLE
fix(groups): store settings in conversation metadata when no user-service group exists

### DIFF
--- a/src/services/groups/__tests__/api.test.ts
+++ b/src/services/groups/__tests__/api.test.ts
@@ -537,17 +537,40 @@ describe("groupsAPI.updateGroupSettings", () => {
     );
   });
 
-  it("throws when neither externalGroupId nor by-conversation returns a group", async () => {
-    // 1st call: conversation → no externalGroupId
+  it("falls back to PUT conversation metadata when neither externalGroupId nor by-conversation returns a group", async () => {
+    // 1st call: conversation → no externalGroupId, no existing metadata
     mockFetch.mockResolvedValueOnce(
       mockResponse({ body: { data: { id: "grp-1" } } }),
     );
     // 2nd call: by-conversation 404
     mockFetch.mockResolvedValueOnce(mockResponse({ status: 404 }));
+    // 3rd call: PUT conversation metadata
+    mockFetch.mockResolvedValueOnce(mockResponse({ body: { id: "grp-1" } }));
 
-    await expect(groupsAPI.updateGroupSettings("grp-1", {})).rejects.toThrow(
-      "Groupe non trouvé (identifiant introuvable)",
+    const result = await groupsAPI.updateGroupSettings("grp-1", {
+      message_permission: "admins_only",
+    });
+
+    const putCall = mockFetch.mock.calls[2];
+    expect(putCall[0]).toBe(`${MSG_BASE}/conversations/grp-1`);
+    expect(putCall[1].method).toBe("PUT");
+    const body = JSON.parse(putCall[1].body);
+    expect(body.metadata.group_settings.message_permission).toBe("admins_only");
+    expect(result.message_permission).toBe("admins_only");
+  });
+
+  it("throws when the metadata PUT fails", async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ body: { data: { id: "grp-1" } } }),
     );
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 404 }));
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 500 }));
+
+    await expect(
+      groupsAPI.updateGroupSettings("grp-1", {
+        message_permission: "admins_only",
+      }),
+    ).rejects.toThrow(/Impossible de mettre a jour les parametres \(500\)/);
   });
 
   it("throws when the PATCH fails", async () => {

--- a/src/services/groups/api.ts
+++ b/src/services/groups/api.ts
@@ -869,7 +869,7 @@ export const groupsAPI = {
       externalId,
     );
     if (!userServiceGroupId) {
-      return { ...DEFAULT_GROUP_SETTINGS };
+      return extractGroupSettingsFromConversation(conv);
     }
     const res = await fetch(
       `${API_BASE_URL}/groups/${encodeURIComponent(userServiceGroupId)}/settings`,
@@ -896,7 +896,29 @@ export const groupsAPI = {
       externalId,
     );
     if (!userServiceGroupId) {
-      throw new Error("Groupe non trouvé (identifiant introuvable)");
+      const currentMeta =
+        conv?.metadata && typeof conv.metadata === "object"
+          ? (conv.metadata as Record<string, unknown>)
+          : {};
+      const currentSettings = extractGroupSettingsFromConversation(conv);
+      const nextSettings: GroupSettings = { ...currentSettings, ...updates };
+      const res = await fetch(
+        `${MESSAGING_API_URL}/conversations/${encodeURIComponent(convId)}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json", ...headers },
+          body: JSON.stringify({
+            metadata: { ...currentMeta, group_settings: nextSettings },
+          }),
+        },
+      );
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(
+          `Impossible de mettre a jour les parametres (${res.status})${text ? `: ${text}` : ""}`,
+        );
+      }
+      return nextSettings;
     }
     const res = await fetch(
       `${API_BASE_URL}/groups/${encodeURIComponent(userServiceGroupId)}/settings`,


### PR DESCRIPTION
## Summary
- Groups created via messaging-only flow (no user-service entity) now work with group settings
- When neither `externalGroupId` nor `by-conversation` lookup resolves a user-service group ID, `updateGroupSettings` falls back to storing settings in the messaging conversation metadata
- `getGroupSettings` reads from conversation metadata (via `extractGroupSettingsFromConversation`) instead of returning bare defaults
- Existing groups with a user-service entity are unaffected

## Test plan
- [ ] 50 unit tests green
- [ ] Create new group → open settings → change a setting → no error
- [ ] Settings persist after app reload (stored in conversation metadata)

🤖 Generated with [Claude Code](https://claude.com/claude-code)