### PR TITLE
fix(chat): propagate user_id and read_at in delivery_status for group read receipts

### DIFF
--- a/src/hooks/__tests__/useWebSocket.handlers.test.tsx
+++ b/src/hooks/__tests__/useWebSocket.handlers.test.tsx
@@ -360,7 +360,12 @@ describe("useWebSocket — joinConversationChannel handlers", () => {
       message_id: "m1",
       status: "delivered",
     });
-    expect(onDeliveryStatus).toHaveBeenCalledWith("m1", "delivered");
+    expect(onDeliveryStatus).toHaveBeenCalledWith(
+      "m1",
+      "delivered",
+      undefined,
+      undefined,
+    );
 
     getConvHandler("presence_diff")({
       joins: { "u-3": {} },
@@ -477,7 +482,12 @@ describe("useWebSocket — joinConversationChannel handlers", () => {
     getConvHandler("delivery_status")({ message_id: "m2", status: "sent" });
 
     expect(onDeliveryStatus).toHaveBeenCalledTimes(1);
-    expect(onDeliveryStatus).toHaveBeenCalledWith("m2", "sent");
+    expect(onDeliveryStatus).toHaveBeenCalledWith(
+      "m2",
+      "sent",
+      undefined,
+      undefined,
+    );
   });
 });
 

--- a/src/hooks/__tests__/useWebSocket.test.tsx
+++ b/src/hooks/__tests__/useWebSocket.test.tsx
@@ -149,8 +149,18 @@ describe("useWebSocket - delivery_status filter", () => {
     renderHook(() => useWebSocket({ ...baseOptions, onDeliveryStatus }));
 
     const handler = getRegisteredHandler("delivery_status");
-    handler({ message_id: "msg-1", status: "read" });
-    expect(onDeliveryStatus).toHaveBeenCalledWith("msg-1", "read");
+    handler({
+      message_id: "msg-1",
+      status: "read",
+      user_id: "u-1",
+      read_at: "2024-01-01T00:00:00Z",
+    });
+    expect(onDeliveryStatus).toHaveBeenCalledWith(
+      "msg-1",
+      "read",
+      "u-1",
+      "2024-01-01T00:00:00Z",
+    );
   });
 
   it("ignore delivery_status read quand toggle OFF", () => {
@@ -172,8 +182,20 @@ describe("useWebSocket - delivery_status filter", () => {
     handler({ message_id: "msg-1", status: "delivered" });
     handler({ message_id: "msg-2", status: "sent" });
     expect(onDeliveryStatus).toHaveBeenCalledTimes(2);
-    expect(onDeliveryStatus).toHaveBeenNthCalledWith(1, "msg-1", "delivered");
-    expect(onDeliveryStatus).toHaveBeenNthCalledWith(2, "msg-2", "sent");
+    expect(onDeliveryStatus).toHaveBeenNthCalledWith(
+      1,
+      "msg-1",
+      "delivered",
+      undefined,
+      undefined,
+    );
+    expect(onDeliveryStatus).toHaveBeenNthCalledWith(
+      2,
+      "msg-2",
+      "sent",
+      undefined,
+      undefined,
+    );
   });
 });
 

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -45,7 +45,12 @@ interface UseWebSocketOptions {
   onConversationSummaries?: (conversations: Conversation[]) => void;
   onConversationArchived?: (conversationId: string, archived: boolean) => void;
   onTyping?: (userId: string, typing: boolean) => void;
-  onDeliveryStatus?: (messageId: string, status: string) => void;
+  onDeliveryStatus?: (
+    messageId: string,
+    status: string,
+    userId?: string,
+    readAt?: string,
+  ) => void;
   onContactRequest?: (request: any) => void;
   onPresenceUpdate?: (userId: string, isOnline: boolean) => void;
   onReactionAdded?: (payload: ReactionRealtimePayload) => void;
@@ -107,12 +112,22 @@ export const useWebSocket = (options: UseWebSocketOptions) => {
         const msg = (data?.message ?? data) as Message;
         if (msg?.id) callbacksRef.current.onNewMessage?.(msg);
       },
-      onDelivery: (data: { message_id: string; status: string }) => {
+      onDelivery: (data: {
+        message_id: string;
+        status: string;
+        user_id?: string;
+        read_at?: string;
+      }) => {
         // symetrie punitive : si l user a desactive ses accuses, il ne doit
         // pas voir non plus les accuses des autres. Les statuts sent /
         // delivered passent toujours, seul "read" est filtre.
         if (data.status === "read" && !getReadReceiptsEnabled()) return;
-        callbacksRef.current.onDeliveryStatus?.(data.message_id, data.status);
+        callbacksRef.current.onDeliveryStatus?.(
+          data.message_id,
+          data.status,
+          data.user_id,
+          data.read_at,
+        );
       },
       // message_unread : symetrique de message_read, emis quand un destinataire
       // a appuye sur "Marquer comme non-lu". Le backend revert le delivery_status
@@ -336,10 +351,20 @@ export const useWebSocket = (options: UseWebSocketOptions) => {
         callbacksRef.current.onMessageDeleted?.(messageId, true);
       }
     };
-    const onDelivery = (data: { message_id: string; status: string }) => {
+    const onDelivery = (data: {
+      message_id: string;
+      status: string;
+      user_id?: string;
+      read_at?: string;
+    }) => {
       // cf. user channel : on filtre "read" quand l user a coupe ses accuses
       if (data.status === "read" && !getReadReceiptsEnabled()) return;
-      callbacksRef.current.onDeliveryStatus?.(data.message_id, data.status);
+      callbacksRef.current.onDeliveryStatus?.(
+        data.message_id,
+        data.status,
+        data.user_id,
+        data.read_at,
+      );
     };
     const onPresenceDiff = (data: {
       joins?: Record<string, any>;

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -718,13 +718,35 @@ export const ChatScreen: React.FC = () => {
         }
       }
     },
-    onDeliveryStatus: (messageId: string, status: string) => {
+    onDeliveryStatus: (
+      messageId: string,
+      status: string,
+      userId?: string,
+      readAt?: string,
+    ) => {
       setMessages((prev) =>
-        prev.map((msg) =>
-          msg.id === messageId
-            ? { ...msg, status: status as "sent" | "delivered" | "read" }
-            : msg,
-        ),
+        prev.map((msg) => {
+          if (msg.id !== messageId) return msg;
+          const updated = {
+            ...msg,
+            status: status as MessageWithRelations["status"],
+          };
+          if (status === "read" && userId) {
+            const existing = updated.delivery_statuses ?? [];
+            const idx = existing.findIndex((d) => d.user_id === userId);
+            const entry = {
+              id: idx >= 0 ? existing[idx].id : `${messageId}-${userId}`,
+              message_id: messageId,
+              user_id: userId,
+              read_at: readAt ?? new Date().toISOString(),
+            };
+            updated.delivery_statuses =
+              idx >= 0
+                ? existing.map((d, i) => (i === idx ? entry : d))
+                : [...existing, entry];
+          }
+          return updated;
+        }),
       );
     },
     onMessageUpdated: (message: Message) => {
@@ -2032,9 +2054,7 @@ export const ChatScreen: React.FC = () => {
             if (poster) {
               let posterUploadUri = poster.uri;
               let posterMime: string = poster.mimeType;
-              let posterE2ee:
-                | { key: string; nonce: string }
-                | undefined;
+              let posterE2ee: { key: string; nonce: string } | undefined;
               if (shouldEncrypt) {
                 try {
                   const encPoster = await E2EEService.encryptMediaFile(


### PR DESCRIPTION
## Summary
- The `delivery_status` WebSocket event was typed as `{message_id, status}` only — `user_id` and `read_at` were silently dropped
- `delivery_statuses[]` was never populated via real-time events, so `MessageStatusLabel` always fell back to the bare "Vu" label in group conversations
- Now `user_id` and `read_at` are forwarded through the callback chain and merged into the message's `delivery_statuses` array in ChatScreen
- Result: group messages now show "Vu par Alice, Bob" or "Vu par tous à 15h37" as intended

## Test plan
- [x] Unit tests green (64/64)
- [x] Lint and type-check clean
- [ ] Test in a group conversation: send a message, have another member open it — should show their name in the read receipt
- [ ] "Vu par tous" should appear once all other members have read