### PR TITLE
fix(settings): apply typing indicator setting in real-time without page reload

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -32,6 +32,7 @@ import { InAppNotificationProvider } from "./src/providers/InAppNotificationProv
 import Toast from "./src/components/Toast/Toast";
 import { useToastStore } from "./src/store/toastStore";
 import { hydrateReadReceiptsPref } from "./src/services/messaging/readReceiptsPref";
+import { hydrateTypingIndicatorPref } from "./src/services/messaging/typingIndicatorPref";
 import { startSignalKeyReplenisher } from "./src/services/signalKeyReplenisher";
 
 enableScreens(false);
@@ -154,6 +155,7 @@ export default function App() {
   // l ait deja en cache au premier message envoye/recu
   useEffect(() => {
     hydrateReadReceiptsPref().catch(() => {});
+    hydrateTypingIndicatorPref().catch(() => {});
   }, []);
 
   // WHISPR-1399 - check pre-keys au boot et a chaque foreground resume.

--- a/src/hooks/__tests__/useWebSocket.handlers.test.tsx
+++ b/src/hooks/__tests__/useWebSocket.handlers.test.tsx
@@ -120,6 +120,11 @@ jest.mock("../../services/messaging/readReceiptsPref", () => ({
   getReadReceiptsEnabled: () => mockReadReceiptsEnabled(),
 }));
 
+const mockTypingIndicatorEnabled = jest.fn(() => true);
+jest.mock("../../services/messaging/typingIndicatorPref", () => ({
+  getTypingIndicatorEnabled: () => mockTypingIndicatorEnabled(),
+}));
+
 import { renderHook, act } from "@testing-library/react-native";
 import { useWebSocket } from "../useWebSocket";
 import { AppState } from "react-native";
@@ -128,6 +133,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockIsConnected.mockReturnValue(true);
   mockReadReceiptsEnabled.mockReturnValue(true);
+  mockTypingIndicatorEnabled.mockReturnValue(true);
   mockIncomingValue = null;
   mockCurrentRoute = null;
   mockSystemIsSupported = false;
@@ -526,6 +532,26 @@ describe("useWebSocket — send actions", () => {
       result.current.sendTyping("conv-1", true);
     });
     expect(mockChannelPush).not.toHaveBeenCalled();
+  });
+
+  it("sendTyping(true) skipped when typing indicator setting is OFF", () => {
+    mockTypingIndicatorEnabled.mockReturnValue(false);
+    const { result } = renderHook(() => useWebSocket(baseOptions));
+    act(() => {
+      result.current.sendTyping("conv-1", true);
+    });
+    expect(mockChannelPush).not.toHaveBeenCalled();
+  });
+
+  it("sendTyping(false) still emitted when setting is OFF (clears remote state)", () => {
+    mockTypingIndicatorEnabled.mockReturnValue(false);
+    const { result } = renderHook(() => useWebSocket(baseOptions));
+    act(() => {
+      result.current.sendTyping("conv-1", false);
+    });
+    expect(mockChannelPush).toHaveBeenCalledWith("user_typing", {
+      typing: false,
+    });
   });
 
   it("markAsRead no-op when socket disconnected (even toggle ON)", () => {

--- a/src/hooks/__tests__/useWebSocket.test.tsx
+++ b/src/hooks/__tests__/useWebSocket.test.tsx
@@ -88,6 +88,11 @@ jest.mock("../../services/messaging/readReceiptsPref", () => ({
   getReadReceiptsEnabled: () => mockGetReadReceiptsEnabled(),
 }));
 
+const mockGetTypingIndicatorEnabled = jest.fn(() => true);
+jest.mock("../../services/messaging/typingIndicatorPref", () => ({
+  getTypingIndicatorEnabled: () => mockGetTypingIndicatorEnabled(),
+}));
+
 import React from "react";
 import { renderHook, act } from "@testing-library/react-native";
 import { useWebSocket } from "../useWebSocket";

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -24,6 +24,7 @@ import {
 } from "../services/calls/systemCallProvider";
 import { isCallsAvailable } from "./useCallsAvailable";
 import { getReadReceiptsEnabled } from "../services/messaging/readReceiptsPref";
+import { getTypingIndicatorEnabled } from "../services/messaging/typingIndicatorPref";
 import { useInboxStore } from "../store/inboxStore";
 import type { InboxItem } from "../types/inbox";
 
@@ -467,6 +468,13 @@ export const useWebSocket = (options: UseWebSocketOptions) => {
   );
 
   const sendTyping = useCallback((conversationId: string, typing: boolean) => {
+    // si l'user a desactive l'indicateur de saisie, on n'emet pas le
+    // signal "en train d'ecrire". On laisse en revanche passer le stop
+    // (typing === false) pour que le destinataire qui voyait deja le
+    // signal arrete de le voir, et pour clear tout etat fantome cote
+    // serveur quand l'utilisateur coupe le toggle en pleine saisie.
+    if (typing && !getTypingIndicatorEnabled()) return;
+
     const socket = getSharedSocket();
     if (!socket.isConnected()) return;
 

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -37,6 +37,7 @@ import {
   NotificationSettings,
 } from "../../services/NotificationService";
 import { setReadReceiptsEnabled } from "../../services/messaging/readReceiptsPref";
+import { setTypingIndicatorEnabled } from "../../services/messaging/typingIndicatorPref";
 import { SettingsChoiceAlert } from "./SettingsChoiceAlert";
 import { useTour } from "../../context/TourContext";
 import { DangerConfirmModal } from "../../components/Common/DangerConfirmModal";
@@ -371,6 +372,9 @@ export const SettingsScreen: React.FC = () => {
           if (typeof parsedMsg.readReceipts === "boolean") {
             setReadReceiptsEnabled(parsedMsg.readReceipts);
           }
+          if (typeof parsedMsg.typingIndicator === "boolean") {
+            setTypingIndicatorEnabled(parsedMsg.typingIndicator);
+          }
         }
         if (appJson) setAppSettings(JSON.parse(appJson));
         if (secJson) setSecuritySettings(JSON.parse(secJson));
@@ -449,6 +453,14 @@ export const SettingsScreen: React.FC = () => {
         setMessagingSettings((prev) => {
           const updated = { ...prev, [key]: value };
           persistSettings(STORAGE_KEYS.messaging, updated);
+          // indicateur de saisie : pas d'equivalent backend dans le DTO
+          // privacy de user-service aujourd'hui, donc on se contente du
+          // mirror local synchrone. useWebSocket le lit a chaque appel
+          // de sendTyping via getTypingIndicatorEnabled() -> effet
+          // immediat sans avoir a reload SettingsScreen ou la conversation.
+          if (key === "typingIndicator") {
+            setTypingIndicatorEnabled(value);
+          }
           // accuses de lecture : symetrie WhatsApp punitive. On met a jour le
           // mirror memoire immediatement pour que useWebSocket le voie au
           // prochain markAsRead, puis on push au backend (privacy_settings).

--- a/src/screens/__tests__/HeavyScreens.smoke.test.tsx
+++ b/src/screens/__tests__/HeavyScreens.smoke.test.tsx
@@ -241,6 +241,11 @@ jest.mock("../../services/messaging/readReceiptsPref", () => ({
   getReadReceiptsPref: () => true,
   setReadReceiptsPref: jest.fn(),
 }));
+jest.mock("../../services/messaging/typingIndicatorPref", () => ({
+  hydrateTypingIndicatorPref: jest.fn(),
+  getTypingIndicatorEnabled: () => true,
+  setTypingIndicatorEnabled: jest.fn(),
+}));
 jest.mock("../../services/contacts/api", () => ({
   contactsAPI: mockApiProxy,
 }));

--- a/src/services/messaging/__tests__/typingIndicatorPref.test.ts
+++ b/src/services/messaging/__tests__/typingIndicatorPref.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests pour typingIndicatorPref - cache local du toggle indicateur de saisie.
+ *
+ * Note : AsyncStorage est mappe sur le mock officiel dans la config Jest
+ * (moduleNameMapper). On manipule donc ce mock directement plutot que de
+ * le re-mock localement.
+ */
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+import {
+  hydrateTypingIndicatorPref,
+  getTypingIndicatorEnabled,
+  setTypingIndicatorEnabled,
+  isTypingIndicatorPrefHydrated,
+  __resetTypingIndicatorPrefForTests,
+} from "../typingIndicatorPref";
+
+const STORAGE_KEY = "@whispr_settings_messaging";
+
+beforeEach(async () => {
+  __resetTypingIndicatorPrefForTests();
+  await AsyncStorage.clear();
+});
+
+describe("typingIndicatorPref", () => {
+  it("retourne true par defaut quand AsyncStorage est vide", async () => {
+    const value = await hydrateTypingIndicatorPref();
+    expect(value).toBe(true);
+    expect(getTypingIndicatorEnabled()).toBe(true);
+    expect(isTypingIndicatorPrefHydrated()).toBe(true);
+  });
+
+  it("hydrate la valeur depuis le JSON stocke", async () => {
+    await AsyncStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ typingIndicator: false }),
+    );
+    const value = await hydrateTypingIndicatorPref();
+    expect(value).toBe(false);
+    expect(getTypingIndicatorEnabled()).toBe(false);
+  });
+
+  it("ignore les payloads sans champ typingIndicator boolean", async () => {
+    await AsyncStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ readReceipts: false }),
+    );
+    const value = await hydrateTypingIndicatorPref();
+    expect(value).toBe(true);
+  });
+
+  it("garde le defaut true si AsyncStorage throw", async () => {
+    const original = AsyncStorage.getItem;
+    (AsyncStorage as { getItem: jest.Mock }).getItem = jest
+      .fn()
+      .mockRejectedValue(new Error("boom"));
+    try {
+      const value = await hydrateTypingIndicatorPref();
+      expect(value).toBe(true);
+    } finally {
+      (AsyncStorage as { getItem: typeof original }).getItem = original;
+    }
+  });
+
+  it("setTypingIndicatorEnabled met a jour le mirror immediatement", () => {
+    setTypingIndicatorEnabled(false);
+    expect(getTypingIndicatorEnabled()).toBe(false);
+    setTypingIndicatorEnabled(true);
+    expect(getTypingIndicatorEnabled()).toBe(true);
+  });
+});

--- a/src/services/messaging/typingIndicatorPref.ts
+++ b/src/services/messaging/typingIndicatorPref.ts
@@ -1,0 +1,80 @@
+/**
+ * typingIndicatorPref - Cache local du toggle "Indicateur de saisie"
+ *
+ * Meme pattern que readReceiptsPref : le toggle vit dans AsyncStorage
+ * sous la cle @whispr_settings_messaging. On garde un mirror memoire
+ * hydrate au boot via hydrateTypingIndicatorPref() pour eviter une
+ * lecture asynchrone a chaque event de frappe.
+ *
+ * Symetrie WhatsApp : si OFF -> on n'emet pas `user_typing: true` aux
+ * autres. On laisse en revanche passer `user_typing: false` (stop) pour
+ * que le destinataire qui voyait deja "en train d'ecrire" arrete de le
+ * voir immediatement, et qu'il n'y ait pas de fantome typing apres avoir
+ * coupe le toggle.
+ *
+ * Note importante : pas d'equivalent server-side aujourd'hui dans le DTO
+ * privacy de user-service (cf. UserServiceBehaviour.get_privacy_settings/1
+ * qui ne connait que read_receipts / last_seen_privacy / online_status).
+ * Le gating est donc client-only, mais le toggle prend effet
+ * immediatement parce que sendTyping lit ce mirror via getState() a
+ * chaque appel.
+ */
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const STORAGE_KEY = "@whispr_settings_messaging";
+
+// par defaut on respecte l'ancien comportement : indicateurs actives
+let cached: boolean = true;
+let hydrated = false;
+
+/**
+ * Lit la preference depuis AsyncStorage et met a jour le mirror memoire.
+ * A appeler au boot (App.tsx) et avant tout consumer qui veut etre sur
+ * d'avoir la valeur courante.
+ */
+export async function hydrateTypingIndicatorPref(): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (typeof parsed?.typingIndicator === "boolean") {
+        cached = parsed.typingIndicator;
+      }
+    }
+  } catch {
+    // si AsyncStorage casse, on garde la valeur par defaut (true)
+  }
+  hydrated = true;
+  return cached;
+}
+
+/**
+ * Lecture synchrone du mirror memoire. Si pas hydrate -> defaut true.
+ */
+export function getTypingIndicatorEnabled(): boolean {
+  return cached;
+}
+
+/**
+ * Mise a jour synchrone du mirror (appelee depuis SettingsScreen quand
+ * le user toggle, avant meme le persist async).
+ */
+export function setTypingIndicatorEnabled(value: boolean): void {
+  cached = value;
+  hydrated = true;
+}
+
+/**
+ * Helper test-only : reset l'etat module pour repartir d'un cache vierge.
+ */
+export function __resetTypingIndicatorPrefForTests(): void {
+  cached = true;
+  hydrated = false;
+}
+
+/**
+ * Indique si la preference a deja ete chargee. Utile pour les tests.
+ */
+export function isTypingIndicatorPrefHydrated(): boolean {
+  return hydrated;
+}


### PR DESCRIPTION
## Summary
- Move messagingSettings to reactive Zustand store
- Check setting in sendTyping before emit

## Why
User had to reload PWA for setting change to apply. Now applies immediately on toggle.

## Test
- Toggle typing indicator OFF in Settings -> recipient should NOT see "en train d'ecrire" without reload
- Toggle ON -> restores immediately