### PR TITLE
fix(chat): synchroniser statut presence du modal avec le header

### DIFF
--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -3819,7 +3819,7 @@ export const ChatScreen: React.FC = () => {
                                 : "Contact"
                             }
                             showOnlineBadge={conversation?.type === "direct"}
-                            isOnline={false}
+                            isOnline={isOtherOnline}
                           />
                           <Text style={styles.infoName}>
                             {conversation
@@ -3827,7 +3827,18 @@ export const ChatScreen: React.FC = () => {
                               : "Contact"}
                           </Text>
                           {conversation?.type === "direct" && (
-                            <Text style={styles.infoStatus}>Hors ligne</Text>
+                            <Text
+                              style={[
+                                styles.infoStatus,
+                                isOtherOnline && { color: colors.status.online },
+                              ]}
+                            >
+                              {isOtherOnline
+                                ? "En ligne"
+                                : otherLastSeenAt
+                                  ? `Vu à ${new Date(otherLastSeenAt).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" })}`
+                                  : "Hors ligne"}
+                            </Text>
                           )}
                         </View>
                         <View style={styles.infoSection}>


### PR DESCRIPTION
## Summary
- Modal "Informations de la conversation" utilise maintenant `isOtherOnline` et `otherLastSeenAt` (presenceStore Zustand)
- Avant : `isOnline={false}` et texte "Hors ligne" hardcodes

## Why
User voyait "En ligne" dans le header mais "Hors ligne" dans le modal du meme user au meme instant.

## Test
1. Ouvrir conversation avec un user online
2. Header affiche "En ligne" (vert)
3. Cliquer avatar pour ouvrir modal -> doit aussi afficher "En ligne" + badge vert