### PR TITLE
fix(ui): bugs ConversationsList et CallHistory (popup, preview E2EE, bouton +)

### DIFF
--- a/src/components/Common/InboxPanel.tsx
+++ b/src/components/Common/InboxPanel.tsx
@@ -1,6 +1,6 @@
 /**
- * InboxPanel - Panel bottom-sheet (75% mobile, modal centre web) pour l'inbox
- * de notifications. (WHISPR-1437)
+ * InboxPanel - Panel bottom-sheet (75% mobile, popup top-right web ancre a la
+ * cloche du header) pour l'inbox de notifications. (WHISPR-1437)
  *
  * - Liste les 20 derniers InboxItem avec pagination cursor.
  * - Mark item read au clic + navigation vers le screen pertinent.
@@ -236,7 +236,7 @@ export const InboxPanel: React.FC<InboxPanelProps> = ({ visible, onClose }) => {
     </View>
   );
 
-  // Sur web on centre la modal, sur mobile on fait un bottom-sheet 75%
+  // Sur web on ancre le popup top-right a l'icone cloche, sur mobile on fait un bottom-sheet 75%
   const isWeb = Platform.OS === "web";
 
   return (
@@ -333,20 +333,20 @@ const styles = StyleSheet.create({
     borderTopRightRadius: 22,
     paddingBottom: 20,
   },
-  // web
+  // web : panel ancré top-right pour matcher l'icone cloche en haut a droite
   webRoot: {
     flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
   },
   webBackdrop: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: "rgba(11, 17, 36, 0.6)",
+    backgroundColor: "rgba(11, 17, 36, 0.4)",
   },
   webSheet: {
-    width: "90%",
-    maxWidth: 480,
-    maxHeight: "80%",
+    position: "absolute",
+    top: 70,
+    right: 16,
+    width: 360,
+    maxHeight: 480,
     backgroundColor: SHEET_BG,
     borderRadius: 22,
     paddingBottom: 16,

--- a/src/screens/Calls/CallHistoryScreen.tsx
+++ b/src/screens/Calls/CallHistoryScreen.tsx
@@ -441,20 +441,10 @@ export const CallHistoryScreen: React.FC = () => {
           <TourAutoStart />
 
           {/* Header */}
+          {/* WHISPR-1437 : bouton + masque le temps qu'un selecteur de contact pour nouvel appel soit livre */}
           <AttachStep index={0} fill={Platform.OS !== "web"}>
             <View style={styles.header}>
               <Text style={styles.headerTitle}>Appels</Text>
-              <Pressable
-                style={styles.newCallBtn}
-                onPress={() => {
-                  // TODO : ouvrir sélecteur de contact
-                }}
-                accessibilityLabel="Nouvel appel"
-                accessibilityRole="button"
-                hitSlop={{ top: 4, bottom: 4, left: 4, right: 4 }}
-              >
-                <Ionicons name="add" size={24} color={colors.text.light} />
-              </Pressable>
             </View>
           </AttachStep>
 
@@ -572,14 +562,6 @@ const styles = StyleSheet.create({
     fontSize: 28,
     fontFamily: "Inter_700Bold",
     color: colors.text.light,
-  },
-  newCallBtn: {
-    width: 44,
-    height: 44,
-    alignItems: "center",
-    justifyContent: "center",
-    borderRadius: 22,
-    backgroundColor: withOpacity(colors.primary.main, 0.18),
   },
 
   // Filtres

--- a/src/utils/conversationPreview.ts
+++ b/src/utils/conversationPreview.ts
@@ -78,6 +78,11 @@ function buildMessageBody(message: Message): string {
     return "Message chiffré";
   }
 
+  // les pieces jointes E2EE arrivent avec un envelope JSON dans content, ne pas le leak
+  if (message.message_type === "media" && isE2EEEnvelopeV1(message.content)) {
+    return "Pièce jointe chiffrée";
+  }
+
   const text = compactWhitespace(message.content);
   const linkPreview = normalizeLinkPreview(
     ((message.metadata ?? {}) as { link_preview?: Record<string, unknown> })


### PR DESCRIPTION
## Summary
- InboxPanel : ancrer le popup notifications en top-right sur web au lieu de centrer
- conversationPreview : masquer le JSON E2EE des pieces jointes (afficher "Piece jointe chiffree")
- CallHistory : masquer temporairement le bouton + qui n'a pas de handler

## Bugs corriges
- Notifications popup au milieu de l'ecran au lieu d'etre ancree a l'icone cloche
- Pieces jointes E2EE affichent le JSON brut dans la liste des conversations (leak)
- Bouton + sur ecran Appels ne faisait rien (handler TODO vide)

## Test
1. Ouvrir conversations -> cliquer cloche -> panel doit etre en haut a droite
2. Recevoir piece jointe chiffree -> preview doit afficher "Piece jointe chiffree"
3. Ouvrir ecran Appels -> pas de bouton + visible