### PR TITLE
fix(calls): exposer les vraies erreurs LiveKit en cas d'echec appel web

### DIFF
--- a/src/screens/Calls/IncomingCallScreen.tsx
+++ b/src/screens/Calls/IncomingCallScreen.tsx
@@ -15,8 +15,34 @@ import { systemCallProvider } from "../../services/calls/systemCallProvider";
 
 type Nav = StackNavigationProp<AuthStackParamList>;
 
-const showAcceptError = (message: string) => {
+// Mappe un message tague par callsStore (`accept-api: ...`, `livekit-connect: ...`)
+// vers un texte intelligible pour l'utilisateur. Sans ce mapping, les toasts
+// affichent le tag technique brut et le user ne comprend pas la cause.
+const humanizeAcceptError = (raw: string): string => {
+  if (raw.startsWith("accept-permissions:")) {
+    return raw.replace(/^accept-permissions:\s*/, "");
+  }
+  if (raw.startsWith("accept-api:")) {
+    return `Impossible de joindre le serveur d'appels : ${raw.replace(/^accept-api:\s*/, "")}`;
+  }
+  if (raw.startsWith("livekit-connect:")) {
+    const detail = raw.replace(/^livekit-connect:\s*/, "");
+    if (/timeout/i.test(detail))
+      return "Connexion appel timeout. Reseau trop lent ?";
+    if (/NotAllowedError|permission/i.test(detail))
+      return "Permission micro/camera refusee.";
+    if (/token|auth/i.test(detail))
+      return "Token LiveKit invalide. Reconnectez-vous.";
+    if (/WebRTC|getUserMedia|not supported/i.test(detail))
+      return "WebRTC pas supporte ou bloque sur ce navigateur.";
+    return `Echec connexion appel : ${detail}`;
+  }
+  return raw;
+};
+
+const showAcceptError = (rawMessage: string) => {
   const title = "Impossible de prendre l'appel";
+  const message = humanizeAcceptError(rawMessage);
   if (Platform.OS === "web") {
     // window.alert est synchrone sur web ; Alert.alert RN ne s'affiche pas.
     if (typeof window !== "undefined") window.alert(`${title}\n\n${message}`);

--- a/src/screens/Calls/__tests__/IncomingCallScreen.test.tsx
+++ b/src/screens/Calls/__tests__/IncomingCallScreen.test.tsx
@@ -108,9 +108,12 @@ describe("IncomingCallScreen", () => {
       await Promise.resolve();
       expect(mockAcceptIncoming).toHaveBeenCalledTimes(1);
       expect(mockReset).not.toHaveBeenCalled();
+      // Le tag technique `livekit-connect: ...` est traduit en texte humain
+      // par humanizeAcceptError avant affichage. Le tag reste log via
+      // console.error pour le debug DevTools.
       expect(alertSpy).toHaveBeenCalledWith(
         "Impossible de prendre l'appel",
-        "livekit-connect: WebSocket failed",
+        "Echec connexion appel : WebSocket failed",
       );
       expect(mockSetIncoming).toHaveBeenCalledWith(null);
       expect(mockGoBack).toHaveBeenCalled();

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -2556,9 +2556,35 @@ export const ChatScreen: React.FC = () => {
         }
         navigation.navigate("InCall");
       } catch (err) {
+        // WHISPR-1200 : afficher la vraie cause au lieu d'un message generique.
+        // callsStore.initiate tague chaque etape avec un prefixe stable
+        // (initiate-permissions / initiate-api / livekit-connect).
+        console.error("[Calls] initiate failed:", err);
+        const raw = err instanceof Error ? err.message : String(err);
+        const message = (() => {
+          if (raw.startsWith("initiate-permissions:")) {
+            return raw.replace(/^initiate-permissions:\s*/, "");
+          }
+          if (raw.startsWith("initiate-api:")) {
+            return `Impossible de joindre le serveur d'appels : ${raw.replace(/^initiate-api:\s*/, "")}`;
+          }
+          if (raw.startsWith("livekit-connect:")) {
+            const detail = raw.replace(/^livekit-connect:\s*/, "");
+            if (/timeout/i.test(detail))
+              return "Connexion appel timeout. Reseau trop lent ?";
+            if (/NotAllowedError|permission/i.test(detail))
+              return "Permission micro/camera refusee.";
+            if (/token|auth/i.test(detail))
+              return "Token LiveKit invalide. Reconnectez-vous.";
+            if (/WebRTC|getUserMedia|not supported/i.test(detail))
+              return "WebRTC pas supporte ou bloque sur ce navigateur.";
+            return `Echec connexion appel : ${detail}`;
+          }
+          return `Echec de l'appel : ${raw}`;
+        })();
         setCallsToast({
           visible: true,
-          message: "Impossible de démarrer l'appel. Vérifiez votre connexion.",
+          message,
           type: "error",
         });
       }

--- a/src/services/calls/liveKitProvider.ts
+++ b/src/services/calls/liveKitProvider.ts
@@ -14,6 +14,10 @@ export class CallsLiveKit {
   private room: Room | null = null;
 
   async connect(config: LiveKitConfig): Promise<Room> {
+    // Logs explicites pour debug DevTools sur web PWA : sans visibilite cote
+    // user, room.connect() echoue en silence et l'UI reste coincee.
+    // eslint-disable-next-line no-console
+    console.debug("[LiveKit] connecting to", config.url);
     this.room = new Room({
       adaptiveStream: true,
       dynacast: true,
@@ -21,7 +25,29 @@ export class CallsLiveKit {
         resolution: { width: 640, height: 480, frameRate: 24 },
       },
     });
-    await this.room.connect(config.url, config.token);
+    try {
+      await this.room.connect(config.url, config.token);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("[LiveKit] room.connect failed", {
+        url: config.url,
+        name: (err as { name?: string })?.name,
+        message: (err as Error)?.message,
+        stack: (err as Error)?.stack,
+      });
+      // Re-throw : on enrichit avec le name pour que callsStore tagge le toast
+      // (NotAllowedError / ConnectionError / etc.).
+      const original = err as Error & { name?: string };
+      const enriched = new Error(
+        original.name && original.name !== "Error"
+          ? `${original.name}: ${original.message}`
+          : original.message,
+      );
+      (enriched as Error & { cause?: unknown }).cause = err;
+      throw enriched;
+    }
+    // eslint-disable-next-line no-console
+    console.debug("[LiveKit] connected, room state:", this.room.state);
     return this.room;
   }
 

--- a/src/store/__tests__/callsStore.test.ts
+++ b/src/store/__tests__/callsStore.test.ts
@@ -160,6 +160,38 @@ describe("callsStore — track publish on connect", () => {
     );
   });
 
+  // WHISPR-1200 (web) — initiate() doit aussi tagguer ses echecs pour que
+  // ChatScreen affiche la vraie cause au lieu d'un toast generique.
+  it("tags initiate-api errors so the UI can surface them (WHISPR-1200)", async () => {
+    const callsApi = require("../../services/calls/callsApi").callsApi as {
+      initiate: jest.Mock;
+    };
+    callsApi.initiate.mockRejectedValueOnce(new Error("500 server error"));
+
+    await expect(
+      useCallsStore.getState().initiate("conv-1", "audio", ["u2"]),
+    ).rejects.toThrow(/^initiate-api: /);
+  });
+
+  it("tags livekit-connect errors on initiate so the UI can surface them (WHISPR-1200)", async () => {
+    const callsApi = require("../../services/calls/callsApi").callsApi as {
+      initiate: jest.Mock;
+    };
+    callsApi.initiate.mockResolvedValueOnce({
+      call_id: "c1",
+      status: "ringing",
+      livekit_url: "wss://lk",
+      livekit_token: "tok",
+    });
+    mockProvider.connect.mockRejectedValueOnce(
+      new Error("ConnectionError: ws closed"),
+    );
+
+    await expect(
+      useCallsStore.getState().initiate("conv-1", "audio", ["u2"]),
+    ).rejects.toThrow(/^livekit-connect: /);
+  });
+
   // WHISPR-1198 — reset() est appelé par AuthContext.signOut pour empêcher
   // les fuites d'état d'appel entre deux comptes successifs sur le device.
   describe("reset (WHISPR-1198)", () => {

--- a/src/store/callsStore.ts
+++ b/src/store/callsStore.ts
@@ -77,15 +77,33 @@ export const useCallsStore = create<CallsState>((set, get) => ({
     // pour éviter une NotAllowedError après que la room LiveKit est créée.
     const perm = await requestWebMediaPermissions(type === "video");
     if (!perm.granted) {
-      throw new Error(perm.message ?? "Permission refusée");
+      const message = perm.message ?? "Permission refusée";
+      console.error("[Calls] initiate-permissions failed:", message);
+      throw new Error(`initiate-permissions: ${message}`);
     }
 
-    const resp = await callsApi.initiate(conversationId, type, participants);
+    // WHISPR-1200 : tagging par etape pour que l'UI puisse afficher la vraie
+    // cause (API down, LiveKit injoignable, WebRTC bloque) au lieu d'un
+    // message generique du genre "verifiez votre connexion".
+    let resp;
+    try {
+      resp = await callsApi.initiate(conversationId, type, participants);
+    } catch (err) {
+      console.error("[Calls] initiate-api failed:", err);
+      throw new Error(`initiate-api: ${(err as Error).message}`);
+    }
+
     const provider = getCallsLiveKit();
-    const room = await provider.connect({
-      url: resp.livekit_url,
-      token: resp.livekit_token,
-    });
+    let room;
+    try {
+      room = await provider.connect({
+        url: resp.livekit_url,
+        token: resp.livekit_token,
+      });
+    } catch (err) {
+      console.error("[Calls] livekit-connect failed:", err);
+      throw new Error(`livekit-connect: ${(err as Error).message}`);
+    }
     // Publish local tracks immediately so mute/flip/camera controls have
     // something to act on. Without this, setMicrophoneEnabled(false) is a
     // no-op (no published track) and the user thinks the button is broken.
@@ -97,7 +115,7 @@ export const useCallsStore = create<CallsState>((set, get) => ({
     } catch (err) {
       // Permission denied or device unavailable — keep the call going so the
       // user still sees the UI, the controls will toggle on retry.
-      console.warn("Failed to publish local tracks", err);
+      console.warn("[Calls] failed to publish local tracks", err);
     }
     set({
       active: {
@@ -121,9 +139,9 @@ export const useCallsStore = create<CallsState>((set, get) => ({
     // incohérent (call accepté côté serveur mais WebRTC bloqué navigateur).
     const perm = await requestWebMediaPermissions(inc.type === "video");
     if (!perm.granted) {
-      throw new Error(
-        `accept-permissions: ${perm.message ?? "Permission refusée"}`,
-      );
+      const message = perm.message ?? "Permission refusée";
+      console.error("[Calls] accept-permissions failed:", message);
+      throw new Error(`accept-permissions: ${message}`);
     }
 
     // WHISPR-1200 : on tague chaque étape pour que la couche UI puisse
@@ -133,6 +151,7 @@ export const useCallsStore = create<CallsState>((set, get) => ({
     try {
       resp = await callsApi.accept(inc.callId);
     } catch (err) {
+      console.error("[Calls] accept-api failed:", err);
       throw new Error(`accept-api: ${(err as Error).message}`);
     }
     const provider = getCallsLiveKit();
@@ -143,6 +162,7 @@ export const useCallsStore = create<CallsState>((set, get) => ({
         token: resp.livekit_token,
       });
     } catch (err) {
+      console.error("[Calls] livekit-connect failed:", err);
       throw new Error(`livekit-connect: ${(err as Error).message}`);
     }
     try {
@@ -151,7 +171,7 @@ export const useCallsStore = create<CallsState>((set, get) => ({
         await provider.enableCamera(true);
       }
     } catch (err) {
-      console.warn("Failed to publish local tracks", err);
+      console.warn("[Calls] failed to publish local tracks", err);
     }
     set({
       active: {


### PR DESCRIPTION
## Summary
- Catch LiveKit room.connect() echecs avec messages tagues (initiate-permissions / initiate-api / livekit-connect / accept-*)
- Toast user-facing humanise (timeout / permissions / token / WebRTC / default) au lieu de fail silencieux
- console.error avec stack et console.debug [LiveKit] pour debug DevTools
- Reset UI (close IncomingCall modal) si echec, deja en place mais maintenu

## Why
PR #284 (xAPT) a active les appels LiveKit web mais ils ne fonctionnaient pas. Sans error handling explicit cote callsStore.initiate(), impossible de diagnostiquer la cause (network / permissions / WebRTC / auth). Le toast 'Impossible de demarrer l'appel. Verifiez votre connexion.' masquait la vraie cause.

## Test plan
- [x] Unit tests callsStore : 12/12 (dont 2 nouveaux pour tags initiate-api et livekit-connect sur initiate)
- [x] Unit tests IncomingCallScreen : 6/6 (mise a jour pour humanizeAcceptError)
- [x] Unit tests ChatScreen : passent
- [x] TS check clean sur les fichiers touches
- [ ] Test live : ouvrir https://whispr-preprod.roadmvn.com en PWA, F12 console, tenter appel video, observer logs [LiveKit] et [Calls], verifier toast user-facing

Closes WHISPR-1200 (volet web).