### PR TITLE
fix(chat): coerce empty resolvedUri to undefined to silence source.uri warning

### DIFF
--- a/src/components/Chat/MediaMessage.tsx
+++ b/src/components/Chat/MediaMessage.tsx
@@ -116,8 +116,9 @@ export const MediaMessage: React.FC<MediaMessageProps> = ({
     thumbE2eeKeys,
   );
 
-  // Use decrypted URIs if available, fallback to resolved URIs
-  const finalMainUri = mainUri || resolvedMainUri;
+  // Use decrypted URIs if available, fallback to resolved URIs.
+  // Coerce empty strings to undefined so <Image source={{ uri: "" }}> never fires.
+  const finalMainUri = mainUri || resolvedMainUri || undefined;
   // Important : pour une vidéo E2EE sans thumbnail séparé, `resolvedThumbUri`
   // pointe vers la même ressource que le main (cf. MessageBubble qui passe
   // thumbnail_url=media_url par défaut). On considère alors qu'on n'a PAS


### PR DESCRIPTION
## Summary
- `useResolvedMediaUrl` returns `""` (empty string) while a media URL is being resolved or when no URI is provided
- `MediaMessage` was using `mainUri || resolvedMainUri` which preserves the empty string instead of converting it to `undefined`
- React Native's `<Image source={{ uri: "" }}>` logs a warning (`source.uri should not be an empty string`) × 8 per screen
- Fix: add `|| undefined` at the end so empty strings become `undefined`, which React Native accepts silently

## Test plan
- [x] Unit tests green
- [x] Lint and type-check clean
- [ ] Open a chat with media messages — no more `source.uri should not be an empty string` warnings in Expo Go console