### PR TITLE
sync(main): merge deploy/preprod (preprod-to-main 2026-05-27)

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -32,6 +32,7 @@ import { InAppNotificationProvider } from "./src/providers/InAppNotificationProv
 import Toast from "./src/components/Toast/Toast";
 import { useToastStore } from "./src/store/toastStore";
 import { hydrateReadReceiptsPref } from "./src/services/messaging/readReceiptsPref";
+import { hydrateTypingIndicatorPref } from "./src/services/messaging/typingIndicatorPref";
 import { startSignalKeyReplenisher } from "./src/services/signalKeyReplenisher";
 
 enableScreens(false);
@@ -154,6 +155,7 @@ export default function App() {
   // l ait deja en cache au premier message envoye/recu
   useEffect(() => {
     hydrateReadReceiptsPref().catch(() => {});
+    hydrateTypingIndicatorPref().catch(() => {});
   }, []);
 
   // WHISPR-1399 - check pre-keys au boot et a chaque foreground resume.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,7 +317,7 @@ Use beads for **in-session planning and subtask decomposition**. Jira remains th
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **mobile-app** (5975 symbols, 10436 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **mobile-app** (6632 symbols, 11486 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/src/__test-utils__/mockFactories.ts
+++ b/src/__test-utils__/mockFactories.ts
@@ -59,6 +59,8 @@ export const makeSignalKeyServiceMock = () => ({
 export const makeE2EEServiceMock = () => ({
   E2EEService: {
     resetIdentityCache: jest.fn(),
+    resetPlaintextCache: jest.fn(),
+    resetDecryptedMediaCache: jest.fn().mockResolvedValue(undefined),
     isEncryptedPayload: jest.fn(),
     encryptMessageForConversation: jest.fn(),
     encryptDirectTextMessage: jest.fn(),

--- a/src/__tests__/E2EEService.test.ts
+++ b/src/__tests__/E2EEService.test.ts
@@ -87,5 +87,26 @@ describe("E2EEService", () => {
     });
 
     expect(decrypted).toBe(plaintext);
+
+    // Second call with the same ciphertext must hit the plaintext cache —
+    // no identity lookup, no nacl.box.open. We can detect this by clearing
+    // the identity mock and confirming the second call still returns the
+    // same plaintext without throwing.
+    (TokenService.getIdentityPrivateKey as any).mockReset();
+    (TokenService.getIdentityPrivateKey as any).mockImplementation(() => {
+      throw new Error("should-not-be-called");
+    });
+    const decryptedAgain = await E2EEService.decryptTextMessage({
+      conversationId,
+      content: encrypted.content,
+    });
+    expect(decryptedAgain).toBe(plaintext);
+
+    // Cache reset is callable without side-effects we can observe here
+    // (the identity keypair is itself memoized inside the module, so a
+    // bare resetPlaintextCache + same content won't necessarily re-run
+    // the full decrypt path in this unit setup). We only need the smoke
+    // signal that the helper exists and doesn't throw.
+    expect(() => E2EEService.resetPlaintextCache()).not.toThrow();
   });
 });

--- a/src/components/Chat/CameraCapture.tsx
+++ b/src/components/Chat/CameraCapture.tsx
@@ -192,7 +192,9 @@ export const CameraCapture: React.FC<CameraCaptureProps> = ({
       const result = await ImagePicker.launchCameraAsync({
         mediaTypes: ["images"],
         allowsEditing: false,
-        cameraType: cameraType === "front" ? "front" : "back",
+        cameraType: (cameraType === "front"
+          ? "front"
+          : "back") as ImagePicker.CameraType,
       });
 
       if (!result.canceled && result.assets && result.assets[0]) {
@@ -244,7 +246,9 @@ export const CameraCapture: React.FC<CameraCaptureProps> = ({
         mediaTypes: ["videos"],
         allowsEditing: false,
         quality: 0.9,
-        cameraType: cameraType === "front" ? "front" : "back",
+        cameraType: (cameraType === "front"
+          ? "front"
+          : "back") as ImagePicker.CameraType,
         videoMaxDuration: 60,
       });
 

--- a/src/components/Chat/CameraCapture.tsx
+++ b/src/components/Chat/CameraCapture.tsx
@@ -24,8 +24,19 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import * as ImagePicker from "expo-image-picker";
+import { Audio } from "expo-av";
 import * as Haptics from "expo-haptics";
 import { LinearGradient } from "expo-linear-gradient";
+
+let ExpoVideo: any = null;
+let triedLoadingVideo = false;
+function ensureVideoLoaded(): void {
+  if (ExpoVideo || triedLoadingVideo) return;
+  triedLoadingVideo = true;
+  try {
+    ExpoVideo = require("expo-av").Video;
+  } catch {}
+}
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -138,30 +149,26 @@ export const CameraCapture: React.FC<CameraCaptureProps> = ({
     transform: [{ rotate: `${toggleButtonRotation.value}deg` }],
   }));
 
-  // Request camera permissions
-  const requestCameraPermissions = useCallback(async () => {
+  const requestCameraPermissions = useCallback(async (needsMic = false) => {
     try {
-      const permissionResult =
-        await ImagePicker.requestCameraPermissionsAsync();
-
-      if (!permissionResult) {
-        console.error("[CameraCapture] Permission result is null");
-        Alert.alert("Erreur", "Impossible de vérifier les permissions.");
-        return false;
-      }
-
-      if (permissionResult.status !== "granted") {
-        console.warn(
-          "[CameraCapture] Permission denied:",
-          permissionResult.status,
-        );
+      const camPerm = await ImagePicker.requestCameraPermissionsAsync();
+      if (!camPerm || camPerm.status !== "granted") {
         Alert.alert(
           "Permission requise",
           "Nous avons besoin de votre permission pour accéder à la caméra.",
         );
         return false;
       }
-
+      if (needsMic) {
+        const micPerm = await Audio.requestPermissionsAsync();
+        if (micPerm.status !== "granted") {
+          Alert.alert(
+            "Permission requise",
+            "Nous avons besoin de votre permission pour accéder au microphone pour enregistrer une vidéo.",
+          );
+          return false;
+        }
+      }
       return true;
     } catch (error: any) {
       console.error("[CameraCapture] Error requesting permissions:", error);
@@ -172,7 +179,7 @@ export const CameraCapture: React.FC<CameraCaptureProps> = ({
 
   // Handle photo capture
   const handleTakePhoto = useCallback(async () => {
-    const hasPermission = await requestCameraPermissions();
+    const hasPermission = await requestCameraPermissions(false);
     if (!hasPermission) {
       return;
     }
@@ -228,7 +235,7 @@ export const CameraCapture: React.FC<CameraCaptureProps> = ({
       return;
     }
 
-    const hasPermission = await requestCameraPermissions();
+    const hasPermission = await requestCameraPermissions(true);
     if (!hasPermission) {
       return;
     }
@@ -245,7 +252,6 @@ export const CameraCapture: React.FC<CameraCaptureProps> = ({
       const result = await ImagePicker.launchCameraAsync({
         mediaTypes: ["videos"],
         allowsEditing: false,
-        quality: 0.9,
         cameraType: (cameraType === "front"
           ? "front"
           : "back") as ImagePicker.CameraType,
@@ -254,6 +260,7 @@ export const CameraCapture: React.FC<CameraCaptureProps> = ({
 
       if (!result.canceled && result.assets && result.assets[0]) {
         Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        ensureVideoLoaded();
         setCapturedMedia({
           uri: result.assets[0].uri,
           type: "video",
@@ -451,6 +458,22 @@ export const CameraCapture: React.FC<CameraCaptureProps> = ({
                               console.error(
                                 "[CameraCapture] Preview image error:",
                                 error,
+                              )
+                            }
+                          />
+                        </View>
+                      ) : ExpoVideo ? (
+                        <View style={styles.imageWrapper}>
+                          <ExpoVideo
+                            source={{ uri: capturedMedia.uri }}
+                            style={styles.previewImage}
+                            useNativeControls
+                            resizeMode="cover"
+                            isLooping={false}
+                            onError={(err: any) =>
+                              console.error(
+                                "[CameraCapture] Video preview error:",
+                                err,
                               )
                             }
                           />

--- a/src/components/Chat/CameraCapture.tsx
+++ b/src/components/Chat/CameraCapture.tsx
@@ -190,12 +190,9 @@ export const CameraCapture: React.FC<CameraCaptureProps> = ({
       // l'appareil photo (HEIC sur iOS si "Haute efficacité" est actif).
       // Imposer une qualité re-encoderait systématiquement en JPEG.
       const result = await ImagePicker.launchCameraAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        mediaTypes: ["images"],
         allowsEditing: false,
-        cameraType:
-          cameraType === "front"
-            ? ImagePicker.CameraType.front
-            : ImagePicker.CameraType.back,
+        cameraType: cameraType === "front" ? "front" : "back",
       });
 
       if (!result.canceled && result.assets && result.assets[0]) {
@@ -244,13 +241,10 @@ export const CameraCapture: React.FC<CameraCaptureProps> = ({
       );
 
       const result = await ImagePicker.launchCameraAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Videos,
+        mediaTypes: ["videos"],
         allowsEditing: false,
         quality: 0.9,
-        cameraType:
-          cameraType === "front"
-            ? ImagePicker.CameraType.front
-            : ImagePicker.CameraType.back,
+        cameraType: cameraType === "front" ? "front" : "back",
         videoMaxDuration: 60,
       });
 

--- a/src/components/Chat/CameraCapture.tsx
+++ b/src/components/Chat/CameraCapture.tsx
@@ -24,7 +24,6 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import * as ImagePicker from "expo-image-picker";
-import { Audio } from "expo-av";
 import * as Haptics from "expo-haptics";
 import { LinearGradient } from "expo-linear-gradient";
 
@@ -160,6 +159,7 @@ export const CameraCapture: React.FC<CameraCaptureProps> = ({
         return false;
       }
       if (needsMic) {
+        const { Audio } = require("expo-av");
         const micPerm = await Audio.requestPermissionsAsync();
         if (micPerm.status !== "granted") {
           Alert.alert(

--- a/src/components/Chat/MediaMessage.tsx
+++ b/src/components/Chat/MediaMessage.tsx
@@ -62,6 +62,15 @@ interface MediaMessageProps {
     key: string;
     nonce: string;
   };
+  // WHISPR-fix-video-preview-hevc-ios : pour les vidéos E2EE, le poster
+  // est uploadé séparément et chiffré avec sa propre clé/nonce. Sans ça,
+  // le composant n'a aucun moyen d'afficher une preview sans tomber sur
+  // le blob déchiffré de la vidéo (qui sur iOS+HEVC casse avec
+  // AVPlayerItem -11828 AVErrorFileFormatNotRecognized).
+  thumbnailE2ee?: {
+    key: string;
+    nonce: string;
+  };
 }
 
 export const MediaMessage: React.FC<MediaMessageProps> = ({
@@ -71,6 +80,7 @@ export const MediaMessage: React.FC<MediaMessageProps> = ({
   size,
   thumbnailUri,
   e2ee,
+  thumbnailE2ee,
 }) => {
   ensureExpoAvVideoLoaded();
   const { getThemeColors } = useTheme();
@@ -96,11 +106,28 @@ export const MediaMessage: React.FC<MediaMessageProps> = ({
   );
 
   const { decryptedUri: mainUri } = useE2EEMedia(resolvedMainUri, e2ee);
-  const { decryptedUri: thumbUri } = useE2EEMedia(resolvedThumbUri, e2ee);
+  // WHISPR-fix-video-preview-hevc-ios : le thumbnail E2EE a sa propre clé/nonce
+  // car il est uploadé séparément. Si elle n'est pas fournie, on retombe sur
+  // la clé du média principal (compat pour les images legacy qui reusaient
+  // la clé pour leur thumbnail).
+  const thumbE2eeKeys = thumbnailE2ee || e2ee;
+  const { decryptedUri: thumbUri } = useE2EEMedia(
+    resolvedThumbUri,
+    thumbE2eeKeys,
+  );
 
   // Use decrypted URIs if available, fallback to resolved URIs
   const finalMainUri = mainUri || resolvedMainUri;
-  const finalThumbUri = thumbUri || resolvedThumbUri;
+  // Important : pour une vidéo E2EE sans thumbnail séparé, `resolvedThumbUri`
+  // pointe vers la même ressource que le main (cf. MessageBubble qui passe
+  // thumbnail_url=media_url par défaut). On considère alors qu'on n'a PAS
+  // de vrai thumbnail image et on bascule sur le placeholder, plutôt que
+  // d'essayer d'afficher le blob vidéo déchiffré dans <Image>.
+  const hasDistinctThumbnail =
+    !!resolvedThumbUri && resolvedThumbUri !== resolvedMainUri;
+  const finalThumbUri = hasDistinctThumbnail
+    ? thumbUri || resolvedThumbUri
+    : undefined;
 
   // WHISPR-1039: on lit le ratio via l'évènement onLoad natif plutôt que
   // Image.getSize pour fonctionner uniformément iOS/Android/web et éviter
@@ -385,14 +412,21 @@ export const MediaMessage: React.FC<MediaMessageProps> = ({
         activeOpacity={0.9}
         style={styles.videoContainer}
       >
-        {/* Video preview - use thumbnail image first if available, else Video component or placeholder */}
+        {/* Video preview :
+            - si on a un thumbnail image distinct → <Image> (cas E2EE avec
+              poster côté client, ou plaintext avec thumbnail serveur).
+            - si pas de thumbnail ET pas en E2EE → on peut tenter <Video>
+              comme preview (cas legacy/plaintext, vidéo lisible direct).
+            - en E2EE sans thumbnail → placeholder direct. Tenter <Video>
+              sur un blob déchiffré HEVC casse iOS avec AVErrorFileFormatNotRecognized
+              (-11828) et affiche un cadre noir. */}
         {finalThumbUri ? (
           <Image
             source={{ uri: finalThumbUri }}
             style={styles.videoThumbnail}
             resizeMode="cover"
           />
-        ) : Video && finalMainUri && !thumbnailError ? (
+        ) : Video && finalMainUri && !thumbnailError && !e2ee ? (
           <Video
             ref={thumbnailVideoRef}
             source={{ uri: finalMainUri }}
@@ -441,7 +475,9 @@ export const MediaMessage: React.FC<MediaMessageProps> = ({
             }}
           />
         ) : (
-          // Fallback placeholder if Video component not available or error
+          // Fallback placeholder : Video indisponible, erreur thumbnail,
+          // ou média E2EE sans poster séparé. On garde le bouton play
+          // accessible — le modal full peut quand même tenter la lecture.
           <View
             style={[
               styles.videoThumbnail,

--- a/src/components/Chat/MessageBubble.tsx
+++ b/src/components/Chat/MessageBubble.tsx
@@ -236,7 +236,7 @@ interface MessageBubbleProps {
   resolveMemberName?: (userId: string) => string;
 }
 
-export const MessageBubble: React.FC<MessageBubbleProps> = ({
+const MessageBubbleComponent: React.FC<MessageBubbleProps> = ({
   message,
   isSent,
   currentUserId,
@@ -1051,40 +1051,43 @@ const styles = StyleSheet.create({
   },
 });
 
-export default memo(MessageBubble, (prevProps, nextProps) => {
-  return (
-    prevProps.message.id === nextProps.message.id &&
-    prevProps.message.content === nextProps.message.content &&
-    prevProps.message.status === nextProps.message.status &&
-    prevProps.message.edited_at === nextProps.message.edited_at &&
-    prevProps.message.is_deleted === nextProps.message.is_deleted &&
-    prevProps.senderName === nextProps.senderName &&
-    prevProps.senderAvatarUrl === nextProps.senderAvatarUrl &&
-    prevProps.isConsecutive === nextProps.isConsecutive &&
-    prevProps.isLastInBurst === nextProps.isLastInBurst &&
-    prevProps.showSenderAvatar === nextProps.showSenderAvatar &&
-    prevProps.onReactionDetailsPress === nextProps.onReactionDetailsPress &&
-    prevProps.pendingAppeal?.status === nextProps.pendingAppeal?.status &&
-    (prevProps.message.metadata as any)?.blockedByModeration ===
-      (nextProps.message.metadata as any)?.blockedByModeration &&
-    (prevProps.message.metadata as any)?.appealRejected ===
-      (nextProps.message.metadata as any)?.appealRejected &&
-    (prevProps.message.metadata as any)?.media_url ===
-      (nextProps.message.metadata as any)?.media_url &&
-    prevProps.isLastSentByMe === nextProps.isLastSentByMe &&
-    prevProps.isGroupConversation === nextProps.isGroupConversation &&
-    prevProps.otherMembersCount === nextProps.otherMembersCount &&
-    // delivery_statuses only feeds MessageStatusLabel, which renders solely
-    // for the last-sent bubble — skip the deep compare elsewhere.
-    (!nextProps.isLastSentByMe ||
-      deliveryStatusesEqual(
-        prevProps.message.delivery_statuses,
-        nextProps.message.delivery_statuses,
-      )) &&
-    JSON.stringify(prevProps.message.reactions) ===
-      JSON.stringify(nextProps.message.reactions)
-  );
-});
+export const MessageBubble = memo(
+  MessageBubbleComponent,
+  (prevProps, nextProps) => {
+    return (
+      prevProps.message.id === nextProps.message.id &&
+      prevProps.message.content === nextProps.message.content &&
+      prevProps.message.status === nextProps.message.status &&
+      prevProps.message.edited_at === nextProps.message.edited_at &&
+      prevProps.message.is_deleted === nextProps.message.is_deleted &&
+      prevProps.senderName === nextProps.senderName &&
+      prevProps.senderAvatarUrl === nextProps.senderAvatarUrl &&
+      prevProps.isConsecutive === nextProps.isConsecutive &&
+      prevProps.isLastInBurst === nextProps.isLastInBurst &&
+      prevProps.showSenderAvatar === nextProps.showSenderAvatar &&
+      prevProps.onReactionDetailsPress === nextProps.onReactionDetailsPress &&
+      prevProps.pendingAppeal?.status === nextProps.pendingAppeal?.status &&
+      (prevProps.message.metadata as any)?.blockedByModeration ===
+        (nextProps.message.metadata as any)?.blockedByModeration &&
+      (prevProps.message.metadata as any)?.appealRejected ===
+        (nextProps.message.metadata as any)?.appealRejected &&
+      (prevProps.message.metadata as any)?.media_url ===
+        (nextProps.message.metadata as any)?.media_url &&
+      prevProps.isLastSentByMe === nextProps.isLastSentByMe &&
+      prevProps.isGroupConversation === nextProps.isGroupConversation &&
+      prevProps.otherMembersCount === nextProps.otherMembersCount &&
+      // delivery_statuses only feeds MessageStatusLabel, which renders solely
+      // for the last-sent bubble — skip the deep compare elsewhere.
+      (!nextProps.isLastSentByMe ||
+        deliveryStatusesEqual(
+          prevProps.message.delivery_statuses,
+          nextProps.message.delivery_statuses,
+        )) &&
+      JSON.stringify(prevProps.message.reactions) ===
+        JSON.stringify(nextProps.message.reactions)
+    );
+  },
+);
 
 function deliveryStatusesEqual(
   a: MessageWithRelations["delivery_statuses"],

--- a/src/components/Chat/MessageBubble.tsx
+++ b/src/components/Chat/MessageBubble.tsx
@@ -435,6 +435,19 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
           nonce: (message.metadata as any).media_nonce as string,
         }
       : undefined;
+  // WHISPR-fix-video-preview-hevc-ios : le poster vidéo est chiffré avec
+  // sa propre clé/nonce. Sans ces métadonnées, MediaMessage tombera sur
+  // le placeholder pour les vidéos E2EE (au lieu de tenter <Video> sur
+  // le blob déchiffré, qui casse sur iOS avec AVErrorFileFormatNotRecognized).
+  const e2eeThumbnail =
+    (message.metadata as any)?.e2ee &&
+    (message.metadata as any)?.thumbnail_key &&
+    (message.metadata as any)?.thumbnail_nonce
+      ? {
+          key: (message.metadata as any).thumbnail_key as string,
+          nonce: (message.metadata as any).thumbnail_nonce as string,
+        }
+      : undefined;
   const mediaUploadOverlay = isSent
     ? getMediaUploadOverlayState(
         message.status,
@@ -501,10 +514,14 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                   size={firstAttachment.metadata.size}
                   thumbnailUri={resolveMediaUrl(
                     firstAttachment.metadata.thumbnail_url,
-                    firstAttachment.media_id,
-                    "thumbnail",
+                    (firstAttachment.metadata as any).thumbnail_id ||
+                      firstAttachment.media_id,
+                    (firstAttachment.metadata as any).thumbnail_id
+                      ? "blob"
+                      : "thumbnail",
                   )}
                   e2ee={e2eeMedia}
+                  thumbnailE2ee={e2eeThumbnail}
                 />
               )
             ) : null}
@@ -620,10 +637,14 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                       size={firstAttachment.metadata.size}
                       thumbnailUri={resolveMediaUrl(
                         firstAttachment.metadata.thumbnail_url,
-                        firstAttachment.media_id,
-                        "thumbnail",
+                        (firstAttachment.metadata as any).thumbnail_id ||
+                          firstAttachment.media_id,
+                        (firstAttachment.metadata as any).thumbnail_id
+                          ? "blob"
+                          : "thumbnail",
                       )}
                       e2ee={e2eeMedia}
+                      thumbnailE2ee={e2eeThumbnail}
                     />
                   ),
                 )
@@ -723,10 +744,14 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                   size={firstAttachment.metadata.size}
                   thumbnailUri={resolveMediaUrl(
                     firstAttachment.metadata.thumbnail_url,
-                    firstAttachment.media_id,
-                    "thumbnail",
+                    (firstAttachment.metadata as any).thumbnail_id ||
+                      firstAttachment.media_id,
+                    (firstAttachment.metadata as any).thumbnail_id
+                      ? "blob"
+                      : "thumbnail",
                   )}
                   e2ee={e2eeMedia}
+                  thumbnailE2ee={e2eeThumbnail}
                 />
               )}
             </>

--- a/src/components/Chat/MessageBubble.tsx
+++ b/src/components/Chat/MessageBubble.tsx
@@ -1051,65 +1051,75 @@ const styles = StyleSheet.create({
   },
 });
 
+/**
+ * Memo comparator extracted as a named function so it can be unit-tested
+ * directly without rendering the (heavy) component. Returns true when the
+ * two prop sets are equivalent enough to skip a re-render.
+ */
+export function areMessageBubblePropsEqual(
+  prevProps: MessageBubbleProps,
+  nextProps: MessageBubbleProps,
+): boolean {
+  const prevMeta = prevProps.message.metadata as
+    | Record<string, any>
+    | undefined;
+  const nextMeta = nextProps.message.metadata as
+    | Record<string, any>
+    | undefined;
+  return (
+    prevProps.message.id === nextProps.message.id &&
+    prevProps.message.content === nextProps.message.content &&
+    prevProps.message.status === nextProps.message.status &&
+    prevProps.message.edited_at === nextProps.message.edited_at &&
+    prevProps.message.is_deleted === nextProps.message.is_deleted &&
+    prevProps.message.message_type === nextProps.message.message_type &&
+    prevProps.message.forwarded_from_id ===
+      nextProps.message.forwarded_from_id &&
+    // Reference equality is enough: when the parent rebuilds the message
+    // (new attachments, reply hydrated, etc.) it produces a fresh array/
+    // object via the spread operator. Catches "attachments arrived after
+    // initial load" and "reply_to resolved from a later page".
+    prevProps.message.attachments === nextProps.message.attachments &&
+    prevProps.message.reply_to === nextProps.message.reply_to &&
+    prevProps.senderName === nextProps.senderName &&
+    prevProps.senderAvatarUrl === nextProps.senderAvatarUrl &&
+    prevProps.isConsecutive === nextProps.isConsecutive &&
+    prevProps.isLastInBurst === nextProps.isLastInBurst &&
+    prevProps.showSenderAvatar === nextProps.showSenderAvatar &&
+    prevProps.onReactionDetailsPress === nextProps.onReactionDetailsPress &&
+    prevProps.pendingAppeal?.status === nextProps.pendingAppeal?.status &&
+    prevMeta?.blockedByModeration === nextMeta?.blockedByModeration &&
+    prevMeta?.appealRejected === nextMeta?.appealRejected &&
+    prevMeta?.media_url === nextMeta?.media_url &&
+    prevMeta?.forwarded === nextMeta?.forwarded &&
+    // E2EE media keys feed useE2EEMedia inside MediaMessage; if they show
+    // up after the cache served a plaintext placeholder the bubble must
+    // re-render to kick off decryption.
+    prevMeta?.media_key === nextMeta?.media_key &&
+    prevMeta?.media_nonce === nextMeta?.media_nonce &&
+    prevMeta?.e2ee === nextMeta?.e2ee &&
+    // link_preview is hydrated asynchronously by getLinkPreview() — compare
+    // by URL so that a freshly resolved preview triggers a re-render.
+    (prevMeta?.link_preview as { url?: string } | undefined)?.url ===
+      (nextMeta?.link_preview as { url?: string } | undefined)?.url &&
+    prevProps.isLastSentByMe === nextProps.isLastSentByMe &&
+    prevProps.isGroupConversation === nextProps.isGroupConversation &&
+    prevProps.otherMembersCount === nextProps.otherMembersCount &&
+    // delivery_statuses only feeds MessageStatusLabel, which renders solely
+    // for the last-sent bubble — skip the deep compare elsewhere.
+    (!nextProps.isLastSentByMe ||
+      deliveryStatusesEqual(
+        prevProps.message.delivery_statuses,
+        nextProps.message.delivery_statuses,
+      )) &&
+    JSON.stringify(prevProps.message.reactions) ===
+      JSON.stringify(nextProps.message.reactions)
+  );
+}
+
 export const MessageBubble = memo(
   MessageBubbleComponent,
-  (prevProps, nextProps) => {
-    const prevMeta = prevProps.message.metadata as
-      | Record<string, any>
-      | undefined;
-    const nextMeta = nextProps.message.metadata as
-      | Record<string, any>
-      | undefined;
-    return (
-      prevProps.message.id === nextProps.message.id &&
-      prevProps.message.content === nextProps.message.content &&
-      prevProps.message.status === nextProps.message.status &&
-      prevProps.message.edited_at === nextProps.message.edited_at &&
-      prevProps.message.is_deleted === nextProps.message.is_deleted &&
-      prevProps.message.message_type === nextProps.message.message_type &&
-      prevProps.message.forwarded_from_id ===
-        nextProps.message.forwarded_from_id &&
-      // Reference equality is enough: when the parent rebuilds the message
-      // (new attachments, reply hydrated, etc.) it produces a fresh array/
-      // object via the spread operator. Catches "attachments arrived after
-      // initial load" and "reply_to resolved from a later page".
-      prevProps.message.attachments === nextProps.message.attachments &&
-      prevProps.message.reply_to === nextProps.message.reply_to &&
-      prevProps.senderName === nextProps.senderName &&
-      prevProps.senderAvatarUrl === nextProps.senderAvatarUrl &&
-      prevProps.isConsecutive === nextProps.isConsecutive &&
-      prevProps.isLastInBurst === nextProps.isLastInBurst &&
-      prevProps.showSenderAvatar === nextProps.showSenderAvatar &&
-      prevProps.onReactionDetailsPress === nextProps.onReactionDetailsPress &&
-      prevProps.pendingAppeal?.status === nextProps.pendingAppeal?.status &&
-      prevMeta?.blockedByModeration === nextMeta?.blockedByModeration &&
-      prevMeta?.appealRejected === nextMeta?.appealRejected &&
-      prevMeta?.media_url === nextMeta?.media_url &&
-      prevMeta?.forwarded === nextMeta?.forwarded &&
-      // E2EE media keys feed useE2EEMedia inside MediaMessage; if they show
-      // up after the cache served a plaintext placeholder the bubble must
-      // re-render to kick off decryption.
-      prevMeta?.media_key === nextMeta?.media_key &&
-      prevMeta?.media_nonce === nextMeta?.media_nonce &&
-      prevMeta?.e2ee === nextMeta?.e2ee &&
-      // link_preview is hydrated asynchronously by getLinkPreview() — compare
-      // by URL so that a freshly resolved preview triggers a re-render.
-      (prevMeta?.link_preview as { url?: string } | undefined)?.url ===
-        (nextMeta?.link_preview as { url?: string } | undefined)?.url &&
-      prevProps.isLastSentByMe === nextProps.isLastSentByMe &&
-      prevProps.isGroupConversation === nextProps.isGroupConversation &&
-      prevProps.otherMembersCount === nextProps.otherMembersCount &&
-      // delivery_statuses only feeds MessageStatusLabel, which renders solely
-      // for the last-sent bubble — skip the deep compare elsewhere.
-      (!nextProps.isLastSentByMe ||
-        deliveryStatusesEqual(
-          prevProps.message.delivery_statuses,
-          nextProps.message.delivery_statuses,
-        )) &&
-      JSON.stringify(prevProps.message.reactions) ===
-        JSON.stringify(nextProps.message.reactions)
-    );
-  },
+  areMessageBubblePropsEqual,
 );
 
 function deliveryStatusesEqual(

--- a/src/components/Chat/MessageBubble.tsx
+++ b/src/components/Chat/MessageBubble.tsx
@@ -1054,12 +1054,27 @@ const styles = StyleSheet.create({
 export const MessageBubble = memo(
   MessageBubbleComponent,
   (prevProps, nextProps) => {
+    const prevMeta = prevProps.message.metadata as
+      | Record<string, any>
+      | undefined;
+    const nextMeta = nextProps.message.metadata as
+      | Record<string, any>
+      | undefined;
     return (
       prevProps.message.id === nextProps.message.id &&
       prevProps.message.content === nextProps.message.content &&
       prevProps.message.status === nextProps.message.status &&
       prevProps.message.edited_at === nextProps.message.edited_at &&
       prevProps.message.is_deleted === nextProps.message.is_deleted &&
+      prevProps.message.message_type === nextProps.message.message_type &&
+      prevProps.message.forwarded_from_id ===
+        nextProps.message.forwarded_from_id &&
+      // Reference equality is enough: when the parent rebuilds the message
+      // (new attachments, reply hydrated, etc.) it produces a fresh array/
+      // object via the spread operator. Catches "attachments arrived after
+      // initial load" and "reply_to resolved from a later page".
+      prevProps.message.attachments === nextProps.message.attachments &&
+      prevProps.message.reply_to === nextProps.message.reply_to &&
       prevProps.senderName === nextProps.senderName &&
       prevProps.senderAvatarUrl === nextProps.senderAvatarUrl &&
       prevProps.isConsecutive === nextProps.isConsecutive &&
@@ -1067,12 +1082,20 @@ export const MessageBubble = memo(
       prevProps.showSenderAvatar === nextProps.showSenderAvatar &&
       prevProps.onReactionDetailsPress === nextProps.onReactionDetailsPress &&
       prevProps.pendingAppeal?.status === nextProps.pendingAppeal?.status &&
-      (prevProps.message.metadata as any)?.blockedByModeration ===
-        (nextProps.message.metadata as any)?.blockedByModeration &&
-      (prevProps.message.metadata as any)?.appealRejected ===
-        (nextProps.message.metadata as any)?.appealRejected &&
-      (prevProps.message.metadata as any)?.media_url ===
-        (nextProps.message.metadata as any)?.media_url &&
+      prevMeta?.blockedByModeration === nextMeta?.blockedByModeration &&
+      prevMeta?.appealRejected === nextMeta?.appealRejected &&
+      prevMeta?.media_url === nextMeta?.media_url &&
+      prevMeta?.forwarded === nextMeta?.forwarded &&
+      // E2EE media keys feed useE2EEMedia inside MediaMessage; if they show
+      // up after the cache served a plaintext placeholder the bubble must
+      // re-render to kick off decryption.
+      prevMeta?.media_key === nextMeta?.media_key &&
+      prevMeta?.media_nonce === nextMeta?.media_nonce &&
+      prevMeta?.e2ee === nextMeta?.e2ee &&
+      // link_preview is hydrated asynchronously by getLinkPreview() — compare
+      // by URL so that a freshly resolved preview triggers a re-render.
+      (prevMeta?.link_preview as { url?: string } | undefined)?.url ===
+        (nextMeta?.link_preview as { url?: string } | undefined)?.url &&
       prevProps.isLastSentByMe === nextProps.isLastSentByMe &&
       prevProps.isGroupConversation === nextProps.isGroupConversation &&
       prevProps.otherMembersCount === nextProps.otherMembersCount &&

--- a/src/components/Chat/__tests__/CameraCapture.test.tsx
+++ b/src/components/Chat/__tests__/CameraCapture.test.tsx
@@ -51,6 +51,7 @@ jest.mock("expo-haptics", () => ({
 }));
 
 const mockRequestCameraPerm = jest.fn();
+const mockRequestMicPerm = jest.fn();
 const mockLaunchCamera = jest.fn();
 jest.mock("expo-image-picker", () => ({
   requestCameraPermissionsAsync: (...args: unknown[]) =>
@@ -59,6 +60,24 @@ jest.mock("expo-image-picker", () => ({
   MediaTypeOptions: { Images: "Images", Videos: "Videos" },
   CameraType: { front: "front", back: "back" },
 }));
+
+jest.mock(
+  "expo-av",
+  () => {
+    const RN = require("react-native");
+    const R = require("react");
+    return {
+      Audio: {
+        requestPermissionsAsync: (...args: unknown[]) =>
+          mockRequestMicPerm(...args),
+      },
+      Video: (props: any) =>
+        R.createElement(RN.View, { ...props, testID: "camera-video-preview" }),
+      ResizeMode: { COVER: "cover", CONTAIN: "contain" },
+    };
+  },
+  { virtual: true },
+);
 
 jest.mock("../../../context/ThemeContext", () => ({
   useTheme: () => ({
@@ -81,6 +100,7 @@ let alertSpy: jest.SpyInstance;
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockRequestMicPerm.mockResolvedValue({ status: "granted" });
   alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
   jest.spyOn(console, "error").mockImplementation(() => {});
   jest.spyOn(console, "warn").mockImplementation(() => {});
@@ -137,8 +157,8 @@ describe("CameraCapture — permissions", () => {
     await flushAsync();
 
     expect(alertSpy).toHaveBeenCalledWith(
-      "Erreur",
-      expect.stringMatching(/permission/i),
+      "Permission requise",
+      expect.stringMatching(/caméra/i),
     );
     expect(mockLaunchCamera).not.toHaveBeenCalled();
   });
@@ -250,26 +270,43 @@ describe("CameraCapture — photo capture", () => {
 });
 
 describe("CameraCapture — video capture", () => {
-  it("captures a video and shows the video preview state", async () => {
+  it("captures a video, requests mic permission, and shows the video player", async () => {
     mockRequestCameraPerm.mockResolvedValue({ status: "granted" });
+    mockRequestMicPerm.mockResolvedValue({ status: "granted" });
     mockLaunchCamera.mockResolvedValue({
       canceled: false,
       assets: [{ uri: "file:///mock/clip.mp4" }],
     });
     const onCapture = jest.fn();
-    const { getByText } = render(
+    const { getByText, getByTestId } = render(
       <CameraCapture {...defaultProps} onCapture={onCapture} />,
     );
 
     fireEvent.press(getByText("Vidéo"));
     await flushAsync();
 
-    expect(getByText("Vidéo capturée")).toBeTruthy();
+    expect(mockRequestMicPerm).toHaveBeenCalled();
+    expect(getByTestId("camera-video-preview")).toBeTruthy();
     fireEvent.press(getByText("Envoyer"));
 
     expect(onCapture).toHaveBeenCalledWith(
       expect.objectContaining({ uri: "file:///mock/clip.mp4", type: "video" }),
     );
+  });
+
+  it("alerts and aborts when microphone permission is denied", async () => {
+    mockRequestCameraPerm.mockResolvedValue({ status: "granted" });
+    mockRequestMicPerm.mockResolvedValue({ status: "denied" });
+    const { getByText } = render(<CameraCapture {...defaultProps} />);
+
+    fireEvent.press(getByText("Vidéo"));
+    await flushAsync();
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      "Permission requise",
+      expect.stringMatching(/microphone/i),
+    );
+    expect(mockLaunchCamera).not.toHaveBeenCalled();
   });
 
   it("alerts when video capture throws", async () => {

--- a/src/components/Chat/__tests__/MediaMessage.test.tsx
+++ b/src/components/Chat/__tests__/MediaMessage.test.tsx
@@ -28,12 +28,33 @@ jest.mock("../../../context/ThemeContext", () => ({
   }),
 }));
 
-// expo-av is imported via try/catch — stub the module so the require resolves
+// expo-av is imported via try/catch — stub the module so the require resolves.
+// We tag the Video component with a sentinel testID so tests can prove it is
+// (or is NOT) rendered for a given scenario.
 jest.mock(
   "expo-av",
-  () => ({ Video: () => null, ResizeMode: { COVER: "cover" } }),
+  () => {
+    const RN = require("react-native");
+    const ReactInstance = require("react");
+    return {
+      Video: (props: any) =>
+        ReactInstance.createElement(RN.View, {
+          ...props,
+          testID: "video-thumbnail-sentinel",
+        }),
+      ResizeMode: { COVER: "cover", CONTAIN: "contain" },
+    };
+  },
   { virtual: true },
 );
+
+// E2EE decryption is heavy and IO-bound — stub it to a deterministic blob URI
+// so we can assert on which uri the component renders.
+jest.mock("../../../services/E2EEService", () => ({
+  E2EEService: {
+    decryptMediaFile: jest.fn(async (uri: string) => `decrypted:${uri}`),
+  },
+}));
 
 import { MediaMessage } from "../MediaMessage";
 
@@ -201,5 +222,77 @@ describe("MediaMessage useResolvedMediaUrl (WHISPR-1216)", () => {
       ([u]: [string]) => u.includes("/blob") && u.includes("stream=1"),
     );
     expect(blobStreamCalls.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("MediaMessage video preview (WHISPR-fix-video-preview-hevc-ios)", () => {
+  beforeEach(() => {
+    // Pour ces tests on stubbe fetch en bytes pour que la résolution du blob
+    // n'est pas bloquée — on s'intéresse au thumbnail rendu, pas à la pipeline
+    // d'URL.
+    (global as any).fetch = jest.fn().mockImplementation(() => {
+      return Promise.resolve({
+        ok: true,
+        url: "",
+        headers: { get: () => "application/octet-stream" },
+        blob: async () =>
+          new Blob([new Uint8Array([0xff, 0xd8])], { type: "image/jpeg" }),
+      });
+    });
+  });
+
+  it("rend une <Image> et JAMAIS <Video> quand un poster E2EE est fourni", async () => {
+    const videoUri = "https://whispr.devzeyu.com/media/v1/video1/blob";
+    const posterUri = "https://whispr.devzeyu.com/media/v1/poster1/blob";
+
+    const { queryByTestId } = render(
+      <MediaMessage
+        uri={videoUri}
+        type="video"
+        thumbnailUri={posterUri}
+        e2ee={{ key: "video-key", nonce: "video-nonce" }}
+        thumbnailE2ee={{ key: "poster-key", nonce: "poster-nonce" }}
+      />,
+    );
+
+    // Le composant <Video> ne doit JAMAIS apparaître en thumbnail pour un
+    // média E2EE avec poster — c'est précisément ce qui cassait avec
+    // AVErrorFileFormatNotRecognized (-11828) sur iOS+HEVC.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(queryByTestId("video-thumbnail-sentinel")).toBeNull();
+  });
+
+  it("rend le placeholder (pas <Video>) pour une vidéo E2EE sans poster", async () => {
+    const videoUri = "https://whispr.devzeyu.com/media/v1/video2/blob";
+
+    const { queryByTestId } = render(
+      <MediaMessage
+        uri={videoUri}
+        type="video"
+        e2ee={{ key: "video-key", nonce: "video-nonce" }}
+      />,
+    );
+
+    // Important : sans thumbnail E2EE explicite, on n'a AUCUN moyen sûr
+    // d'afficher la frame d'une vidéo HEVC sur iOS. On doit rendre le
+    // placeholder, pas tenter <Video> sur le blob déchiffré.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(queryByTestId("video-thumbnail-sentinel")).toBeNull();
+  });
+
+  it("rend bien <Video> comme thumbnail pour une vidéo plaintext sans thumbnail séparé", async () => {
+    // Avec stream OK : la pipeline /blob?stream=1 retourne des bytes, donc
+    // resolvedMainUri se matérialise en blob:fake. Sans thumbnail séparé,
+    // et SANS e2ee, on accepte <Video> en thumbnail (comportement legacy).
+    const { queryByTestId } = render(
+      <MediaMessage
+        uri="https://whispr.devzeyu.com/media/v1/video3/blob"
+        type="video"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(queryByTestId("video-thumbnail-sentinel")).not.toBeNull();
+    });
   });
 });

--- a/src/components/Chat/__tests__/MessageBubble.compare.test.ts
+++ b/src/components/Chat/__tests__/MessageBubble.compare.test.ts
@@ -1,0 +1,259 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// Direct unit tests for the memo() comparator extracted from MessageBubble.
+// No rendering, no native mocks — purely the equality predicate. Each test
+// changes exactly one field at a time so we know which check it exercises.
+
+import { areMessageBubblePropsEqual } from "../MessageBubble";
+import type { MessageWithRelations } from "../../../types/messaging";
+
+const baseMessage = (): MessageWithRelations =>
+  ({
+    id: "m-1",
+    conversation_id: "c-1",
+    sender_id: "u-1",
+    content: "hello",
+    status: "sent",
+    edited_at: null,
+    is_deleted: false,
+    message_type: "text",
+    forwarded_from_id: null,
+    attachments: undefined,
+    reply_to: undefined,
+    metadata: undefined,
+    reactions: [],
+    delivery_statuses: [],
+    sent_at: "2026-01-01T00:00:00Z",
+  }) as unknown as MessageWithRelations;
+
+const baseProps = () => ({
+  message: baseMessage(),
+  isSent: false,
+  currentUserId: "u-2",
+  senderName: "Alice",
+  senderAvatarUrl: undefined,
+  isConsecutive: false,
+  isLastInBurst: true,
+  showSenderAvatar: false,
+  onReactionPress: jest.fn(),
+  onReactionDetailsPress: jest.fn(),
+  resolveReactorName: undefined,
+  onReplyPress: undefined,
+  onLongPress: undefined,
+  isHighlighted: false,
+  searchQuery: "",
+  pendingAppeal: undefined,
+  isLastSentByMe: false,
+  isGroupConversation: false,
+  otherMembersCount: 0,
+  resolveMemberName: undefined,
+  onContest: undefined,
+  onRetry: undefined,
+  onCancel: undefined,
+});
+
+describe("areMessageBubblePropsEqual", () => {
+  it("returns true when both prop sets are deeply equivalent", () => {
+    const prev = baseProps();
+    const next = baseProps();
+    // Stabilize the function refs that the comparator checks by identity.
+    next.onReactionDetailsPress = prev.onReactionDetailsPress;
+    expect(areMessageBubblePropsEqual(prev as any, next as any)).toBe(true);
+  });
+
+  // Top-level message fields ─────────────────────────────────────────────
+  it.each([
+    ["id", "m-2"],
+    ["content", "world"],
+    ["status", "delivered"],
+    ["edited_at", "2026-01-02T00:00:00Z"],
+    ["is_deleted", true],
+    ["message_type", "media"],
+    ["forwarded_from_id", "m-99"],
+  ])("returns false when message.%s changes", (field, value) => {
+    const prev = baseProps();
+    const next = baseProps();
+    next.onReactionDetailsPress = prev.onReactionDetailsPress;
+    (next.message as any)[field] = value;
+    expect(areMessageBubblePropsEqual(prev as any, next as any)).toBe(false);
+  });
+
+  it("returns false when message.attachments swaps reference", () => {
+    const prev = baseProps();
+    const next = baseProps();
+    next.onReactionDetailsPress = prev.onReactionDetailsPress;
+    (prev.message as any).attachments = [{ id: "a-1" }];
+    (next.message as any).attachments = [{ id: "a-1" }]; // same content, fresh array
+    expect(areMessageBubblePropsEqual(prev as any, next as any)).toBe(false);
+  });
+
+  it("returns false when message.reply_to swaps reference", () => {
+    const prev = baseProps();
+    const next = baseProps();
+    next.onReactionDetailsPress = prev.onReactionDetailsPress;
+    (prev.message as any).reply_to = { id: "m-orig" };
+    (next.message as any).reply_to = { id: "m-orig" }; // same shape, new object
+    expect(areMessageBubblePropsEqual(prev as any, next as any)).toBe(false);
+  });
+
+  // Top-level non-message props ──────────────────────────────────────────
+  it.each<[string, any]>([
+    ["senderName", "Bob"],
+    ["senderAvatarUrl", "https://x/avatar.png"],
+    ["isConsecutive", true],
+    ["isLastInBurst", false],
+    ["showSenderAvatar", true],
+    ["isLastSentByMe", true],
+    ["isGroupConversation", true],
+    ["otherMembersCount", 4],
+  ])("returns false when %s changes", (field, value) => {
+    const prev = baseProps();
+    const next = baseProps();
+    next.onReactionDetailsPress = prev.onReactionDetailsPress;
+    (next as any)[field] = value;
+    expect(areMessageBubblePropsEqual(prev as any, next as any)).toBe(false);
+  });
+
+  it("returns false when onReactionDetailsPress identity changes", () => {
+    const prev = baseProps();
+    const next = baseProps();
+    // Different fn references — the comparator does ===.
+    expect(areMessageBubblePropsEqual(prev as any, next as any)).toBe(false);
+  });
+
+  it("returns false when pendingAppeal.status changes", () => {
+    const prev = baseProps();
+    const next = baseProps();
+    next.onReactionDetailsPress = prev.onReactionDetailsPress;
+    (prev as any).pendingAppeal = { status: "pending" };
+    (next as any).pendingAppeal = { status: "approved" };
+    expect(areMessageBubblePropsEqual(prev as any, next as any)).toBe(false);
+  });
+
+  // metadata.* paths ─────────────────────────────────────────────────────
+  it.each<[string, any, any]>([
+    ["blockedByModeration", false, true],
+    ["appealRejected", false, true],
+    ["media_url", undefined, "https://x/img.jpg"],
+    ["forwarded", false, true],
+    ["media_key", undefined, "key-1"],
+    ["media_nonce", undefined, "nonce-1"],
+    ["e2ee", undefined, true],
+  ])("returns false when metadata.%s changes", (key, prevVal, nextVal) => {
+    const prev = baseProps();
+    const next = baseProps();
+    next.onReactionDetailsPress = prev.onReactionDetailsPress;
+    (prev.message as any).metadata = { [key]: prevVal };
+    (next.message as any).metadata = { [key]: nextVal };
+    expect(areMessageBubblePropsEqual(prev as any, next as any)).toBe(false);
+  });
+
+  it("returns false when metadata.link_preview.url changes", () => {
+    const prev = baseProps();
+    const next = baseProps();
+    next.onReactionDetailsPress = prev.onReactionDetailsPress;
+    (prev.message as any).metadata = {
+      link_preview: { url: "https://a.example" },
+    };
+    (next.message as any).metadata = {
+      link_preview: { url: "https://b.example" },
+    };
+    expect(areMessageBubblePropsEqual(prev as any, next as any)).toBe(false);
+  });
+
+  it("treats undefined metadata as equivalent across calls", () => {
+    const prev = baseProps();
+    const next = baseProps();
+    next.onReactionDetailsPress = prev.onReactionDetailsPress;
+    expect(areMessageBubblePropsEqual(prev as any, next as any)).toBe(true);
+  });
+
+  // reactions are JSON-compared ──────────────────────────────────────────
+  it("returns false when reactions diverge structurally", () => {
+    const prev = baseProps();
+    const next = baseProps();
+    next.onReactionDetailsPress = prev.onReactionDetailsPress;
+    (prev.message as any).reactions = [];
+    (next.message as any).reactions = [{ user_id: "u-1", reaction: "👍" }];
+    expect(areMessageBubblePropsEqual(prev as any, next as any)).toBe(false);
+  });
+
+  it("treats reactions with same JSON as equivalent", () => {
+    const prev = baseProps();
+    const next = baseProps();
+    next.onReactionDetailsPress = prev.onReactionDetailsPress;
+    (prev.message as any).reactions = [{ user_id: "u-1", reaction: "👍" }];
+    (next.message as any).reactions = [{ user_id: "u-1", reaction: "👍" }];
+    expect(areMessageBubblePropsEqual(prev as any, next as any)).toBe(true);
+  });
+
+  // delivery_statuses ────────────────────────────────────────────────────
+  it("skips delivery_statuses compare when this is not the last-sent bubble", () => {
+    const prev = baseProps();
+    const next = baseProps();
+    next.onReactionDetailsPress = prev.onReactionDetailsPress;
+    (prev as any).isLastSentByMe = false;
+    (next as any).isLastSentByMe = false;
+    (prev.message as any).delivery_statuses = [
+      { user_id: "u-2", delivered_at: "2026-01-01", read_at: null },
+    ];
+    (next.message as any).delivery_statuses = [
+      { user_id: "u-2", delivered_at: "2026-01-02", read_at: "2026-01-02" },
+    ];
+    // Even though delivery_statuses differ, the comparator ignores them.
+    expect(areMessageBubblePropsEqual(prev as any, next as any)).toBe(true);
+  });
+
+  it("compares delivery_statuses when isLastSentByMe is true (equal)", () => {
+    const prev = baseProps();
+    const next = baseProps();
+    next.onReactionDetailsPress = prev.onReactionDetailsPress;
+    (prev as any).isLastSentByMe = true;
+    (next as any).isLastSentByMe = true;
+    const ds = [
+      { user_id: "u-2", delivered_at: "2026-01-01", read_at: "2026-01-01" },
+    ];
+    (prev.message as any).delivery_statuses = ds;
+    (next.message as any).delivery_statuses = [...ds];
+    expect(areMessageBubblePropsEqual(prev as any, next as any)).toBe(true);
+  });
+
+  it("compares delivery_statuses when isLastSentByMe is true (different read_at)", () => {
+    const prev = baseProps();
+    const next = baseProps();
+    next.onReactionDetailsPress = prev.onReactionDetailsPress;
+    (prev as any).isLastSentByMe = true;
+    (next as any).isLastSentByMe = true;
+    (prev.message as any).delivery_statuses = [
+      { user_id: "u-2", delivered_at: "2026-01-01", read_at: null },
+    ];
+    (next.message as any).delivery_statuses = [
+      { user_id: "u-2", delivered_at: "2026-01-01", read_at: "2026-01-02" },
+    ];
+    expect(areMessageBubblePropsEqual(prev as any, next as any)).toBe(false);
+  });
+
+  it("returns false when delivery_statuses lengths differ", () => {
+    const prev = baseProps();
+    const next = baseProps();
+    next.onReactionDetailsPress = prev.onReactionDetailsPress;
+    (prev as any).isLastSentByMe = true;
+    (next as any).isLastSentByMe = true;
+    (prev.message as any).delivery_statuses = [];
+    (next.message as any).delivery_statuses = [
+      { user_id: "u-2", delivered_at: "2026-01-01", read_at: null },
+    ];
+    expect(areMessageBubblePropsEqual(prev as any, next as any)).toBe(false);
+  });
+
+  it("treats undefined delivery_statuses as empty", () => {
+    const prev = baseProps();
+    const next = baseProps();
+    next.onReactionDetailsPress = prev.onReactionDetailsPress;
+    (prev as any).isLastSentByMe = true;
+    (next as any).isLastSentByMe = true;
+    (prev.message as any).delivery_statuses = undefined;
+    (next.message as any).delivery_statuses = undefined;
+    expect(areMessageBubblePropsEqual(prev as any, next as any)).toBe(true);
+  });
+});

--- a/src/components/Common/InboxPanel.tsx
+++ b/src/components/Common/InboxPanel.tsx
@@ -1,6 +1,6 @@
 /**
- * InboxPanel - Panel bottom-sheet (75% mobile, modal centre web) pour l'inbox
- * de notifications. (WHISPR-1437)
+ * InboxPanel - Panel bottom-sheet (75% mobile, popup top-right web ancre a la
+ * cloche du header) pour l'inbox de notifications. (WHISPR-1437)
  *
  * - Liste les 20 derniers InboxItem avec pagination cursor.
  * - Mark item read au clic + navigation vers le screen pertinent.
@@ -236,7 +236,7 @@ export const InboxPanel: React.FC<InboxPanelProps> = ({ visible, onClose }) => {
     </View>
   );
 
-  // Sur web on centre la modal, sur mobile on fait un bottom-sheet 75%
+  // Sur web on ancre le popup top-right a l'icone cloche, sur mobile on fait un bottom-sheet 75%
   const isWeb = Platform.OS === "web";
 
   return (
@@ -333,20 +333,20 @@ const styles = StyleSheet.create({
     borderTopRightRadius: 22,
     paddingBottom: 20,
   },
-  // web
+  // web : panel ancré top-right pour matcher l'icone cloche en haut a droite
   webRoot: {
     flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
   },
   webBackdrop: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: "rgba(11, 17, 36, 0.6)",
+    backgroundColor: "rgba(11, 17, 36, 0.4)",
   },
   webSheet: {
-    width: "90%",
-    maxWidth: 480,
-    maxHeight: "80%",
+    position: "absolute",
+    top: 70,
+    right: 16,
+    width: 360,
+    maxHeight: 480,
     backgroundColor: SHEET_BG,
     borderRadius: 22,
     paddingBottom: 16,

--- a/src/hooks/__tests__/useResolvedMediaUrl.test.tsx
+++ b/src/hooks/__tests__/useResolvedMediaUrl.test.tsx
@@ -275,11 +275,16 @@ describe("useResolvedMediaUrl — auth-resolved native path", () => {
     const { result, unmount } = renderHook(() =>
       useResolvedMediaUrl("https://api/media/v1/long/blob"),
     );
+    // Tick microtasks once so the disk-cache check resolves and we reach
+    // the downloadAsync call we've stubbed with a never-settling promise.
+    await act(async () => {
+      await Promise.resolve();
+    });
     act(() => unmount());
     // Now resolve the download — the hook should ignore the result.
     resolveDownload?.({ headers: { "Content-Type": "image/jpeg" } });
-    // Tick microtasks
     await act(async () => {
+      await Promise.resolve();
       await Promise.resolve();
     });
     expect(result.current.error).toBe(false);

--- a/src/hooks/__tests__/useWebSocket.handlers.test.tsx
+++ b/src/hooks/__tests__/useWebSocket.handlers.test.tsx
@@ -360,7 +360,12 @@ describe("useWebSocket — joinConversationChannel handlers", () => {
       message_id: "m1",
       status: "delivered",
     });
-    expect(onDeliveryStatus).toHaveBeenCalledWith("m1", "delivered");
+    expect(onDeliveryStatus).toHaveBeenCalledWith(
+      "m1",
+      "delivered",
+      undefined,
+      undefined,
+    );
 
     getConvHandler("presence_diff")({
       joins: { "u-3": {} },
@@ -477,7 +482,12 @@ describe("useWebSocket — joinConversationChannel handlers", () => {
     getConvHandler("delivery_status")({ message_id: "m2", status: "sent" });
 
     expect(onDeliveryStatus).toHaveBeenCalledTimes(1);
-    expect(onDeliveryStatus).toHaveBeenCalledWith("m2", "sent");
+    expect(onDeliveryStatus).toHaveBeenCalledWith(
+      "m2",
+      "sent",
+      undefined,
+      undefined,
+    );
   });
 });
 

--- a/src/hooks/__tests__/useWebSocket.handlers.test.tsx
+++ b/src/hooks/__tests__/useWebSocket.handlers.test.tsx
@@ -120,6 +120,11 @@ jest.mock("../../services/messaging/readReceiptsPref", () => ({
   getReadReceiptsEnabled: () => mockReadReceiptsEnabled(),
 }));
 
+const mockTypingIndicatorEnabled = jest.fn(() => true);
+jest.mock("../../services/messaging/typingIndicatorPref", () => ({
+  getTypingIndicatorEnabled: () => mockTypingIndicatorEnabled(),
+}));
+
 import { renderHook, act } from "@testing-library/react-native";
 import { useWebSocket } from "../useWebSocket";
 import { AppState } from "react-native";
@@ -128,6 +133,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockIsConnected.mockReturnValue(true);
   mockReadReceiptsEnabled.mockReturnValue(true);
+  mockTypingIndicatorEnabled.mockReturnValue(true);
   mockIncomingValue = null;
   mockCurrentRoute = null;
   mockSystemIsSupported = false;
@@ -526,6 +532,26 @@ describe("useWebSocket — send actions", () => {
       result.current.sendTyping("conv-1", true);
     });
     expect(mockChannelPush).not.toHaveBeenCalled();
+  });
+
+  it("sendTyping(true) skipped when typing indicator setting is OFF", () => {
+    mockTypingIndicatorEnabled.mockReturnValue(false);
+    const { result } = renderHook(() => useWebSocket(baseOptions));
+    act(() => {
+      result.current.sendTyping("conv-1", true);
+    });
+    expect(mockChannelPush).not.toHaveBeenCalled();
+  });
+
+  it("sendTyping(false) still emitted when setting is OFF (clears remote state)", () => {
+    mockTypingIndicatorEnabled.mockReturnValue(false);
+    const { result } = renderHook(() => useWebSocket(baseOptions));
+    act(() => {
+      result.current.sendTyping("conv-1", false);
+    });
+    expect(mockChannelPush).toHaveBeenCalledWith("user_typing", {
+      typing: false,
+    });
   });
 
   it("markAsRead no-op when socket disconnected (even toggle ON)", () => {

--- a/src/hooks/__tests__/useWebSocket.test.tsx
+++ b/src/hooks/__tests__/useWebSocket.test.tsx
@@ -149,8 +149,18 @@ describe("useWebSocket - delivery_status filter", () => {
     renderHook(() => useWebSocket({ ...baseOptions, onDeliveryStatus }));
 
     const handler = getRegisteredHandler("delivery_status");
-    handler({ message_id: "msg-1", status: "read" });
-    expect(onDeliveryStatus).toHaveBeenCalledWith("msg-1", "read");
+    handler({
+      message_id: "msg-1",
+      status: "read",
+      user_id: "u-1",
+      read_at: "2024-01-01T00:00:00Z",
+    });
+    expect(onDeliveryStatus).toHaveBeenCalledWith(
+      "msg-1",
+      "read",
+      "u-1",
+      "2024-01-01T00:00:00Z",
+    );
   });
 
   it("ignore delivery_status read quand toggle OFF", () => {
@@ -172,8 +182,20 @@ describe("useWebSocket - delivery_status filter", () => {
     handler({ message_id: "msg-1", status: "delivered" });
     handler({ message_id: "msg-2", status: "sent" });
     expect(onDeliveryStatus).toHaveBeenCalledTimes(2);
-    expect(onDeliveryStatus).toHaveBeenNthCalledWith(1, "msg-1", "delivered");
-    expect(onDeliveryStatus).toHaveBeenNthCalledWith(2, "msg-2", "sent");
+    expect(onDeliveryStatus).toHaveBeenNthCalledWith(
+      1,
+      "msg-1",
+      "delivered",
+      undefined,
+      undefined,
+    );
+    expect(onDeliveryStatus).toHaveBeenNthCalledWith(
+      2,
+      "msg-2",
+      "sent",
+      undefined,
+      undefined,
+    );
   });
 });
 

--- a/src/hooks/__tests__/useWebSocket.test.tsx
+++ b/src/hooks/__tests__/useWebSocket.test.tsx
@@ -88,6 +88,11 @@ jest.mock("../../services/messaging/readReceiptsPref", () => ({
   getReadReceiptsEnabled: () => mockGetReadReceiptsEnabled(),
 }));
 
+const mockGetTypingIndicatorEnabled = jest.fn(() => true);
+jest.mock("../../services/messaging/typingIndicatorPref", () => ({
+  getTypingIndicatorEnabled: () => mockGetTypingIndicatorEnabled(),
+}));
+
 import React from "react";
 import { renderHook, act } from "@testing-library/react-native";
 import { useWebSocket } from "../useWebSocket";

--- a/src/hooks/useResolvedMediaUrl.ts
+++ b/src/hooks/useResolvedMediaUrl.ts
@@ -496,14 +496,6 @@ export function useResolvedMediaUrl(uri: string | undefined): ResolvedMediaUrl {
           revokeBlobUrl();
         };
       }
-
-      (async () => {
-        const diskCached = await readDiskCache(uri);
-        if (!diskCached || cancelled) return;
-        setResolvedUri(diskCached);
-        setLoading(false);
-        setError(false);
-      })().catch(() => {});
     }
 
     setLoading(true);
@@ -512,6 +504,21 @@ export function useResolvedMediaUrl(uri: string | undefined): ResolvedMediaUrl {
     (async () => {
       revokeBlobUrl();
       try {
+        // On native, consult the disk cache before hitting the network. A
+        // disk hit promotes itself back into the memory cache and short-
+        // circuits the stream fetch entirely — otherwise every mount
+        // re-downloaded the bytes even though we already had them on disk.
+        if (canUseNativeCache) {
+          const diskCached = await readDiskCache(uri);
+          if (cancelled) return;
+          if (diskCached) {
+            writeNativeCache(uri, diskCached);
+            setResolvedUri(diskCached);
+            setLoading(false);
+            setError(false);
+            return;
+          }
+        }
         let token = await TokenService.getAccessToken();
         const headers: Record<string, string> = {};
         if (token) headers["Authorization"] = `Bearer ${token}`;

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -45,7 +45,12 @@ interface UseWebSocketOptions {
   onConversationSummaries?: (conversations: Conversation[]) => void;
   onConversationArchived?: (conversationId: string, archived: boolean) => void;
   onTyping?: (userId: string, typing: boolean) => void;
-  onDeliveryStatus?: (messageId: string, status: string) => void;
+  onDeliveryStatus?: (
+    messageId: string,
+    status: string,
+    userId?: string,
+    readAt?: string,
+  ) => void;
   onContactRequest?: (request: any) => void;
   onPresenceUpdate?: (userId: string, isOnline: boolean) => void;
   onReactionAdded?: (payload: ReactionRealtimePayload) => void;
@@ -107,12 +112,22 @@ export const useWebSocket = (options: UseWebSocketOptions) => {
         const msg = (data?.message ?? data) as Message;
         if (msg?.id) callbacksRef.current.onNewMessage?.(msg);
       },
-      onDelivery: (data: { message_id: string; status: string }) => {
+      onDelivery: (data: {
+        message_id: string;
+        status: string;
+        user_id?: string;
+        read_at?: string;
+      }) => {
         // symetrie punitive : si l user a desactive ses accuses, il ne doit
         // pas voir non plus les accuses des autres. Les statuts sent /
         // delivered passent toujours, seul "read" est filtre.
         if (data.status === "read" && !getReadReceiptsEnabled()) return;
-        callbacksRef.current.onDeliveryStatus?.(data.message_id, data.status);
+        callbacksRef.current.onDeliveryStatus?.(
+          data.message_id,
+          data.status,
+          data.user_id,
+          data.read_at,
+        );
       },
       // message_unread : symetrique de message_read, emis quand un destinataire
       // a appuye sur "Marquer comme non-lu". Le backend revert le delivery_status
@@ -336,10 +351,20 @@ export const useWebSocket = (options: UseWebSocketOptions) => {
         callbacksRef.current.onMessageDeleted?.(messageId, true);
       }
     };
-    const onDelivery = (data: { message_id: string; status: string }) => {
+    const onDelivery = (data: {
+      message_id: string;
+      status: string;
+      user_id?: string;
+      read_at?: string;
+    }) => {
       // cf. user channel : on filtre "read" quand l user a coupe ses accuses
       if (data.status === "read" && !getReadReceiptsEnabled()) return;
-      callbacksRef.current.onDeliveryStatus?.(data.message_id, data.status);
+      callbacksRef.current.onDeliveryStatus?.(
+        data.message_id,
+        data.status,
+        data.user_id,
+        data.read_at,
+      );
     };
     const onPresenceDiff = (data: {
       joins?: Record<string, any>;

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -24,6 +24,7 @@ import {
 } from "../services/calls/systemCallProvider";
 import { isCallsAvailable } from "./useCallsAvailable";
 import { getReadReceiptsEnabled } from "../services/messaging/readReceiptsPref";
+import { getTypingIndicatorEnabled } from "../services/messaging/typingIndicatorPref";
 import { useInboxStore } from "../store/inboxStore";
 import type { InboxItem } from "../types/inbox";
 
@@ -467,6 +468,13 @@ export const useWebSocket = (options: UseWebSocketOptions) => {
   );
 
   const sendTyping = useCallback((conversationId: string, typing: boolean) => {
+    // si l'user a desactive l'indicateur de saisie, on n'emet pas le
+    // signal "en train d'ecrire". On laisse en revanche passer le stop
+    // (typing === false) pour que le destinataire qui voyait deja le
+    // signal arrete de le voir, et pour clear tout etat fantome cote
+    // serveur quand l'utilisateur coupe le toggle en pleine saisie.
+    if (typing && !getTypingIndicatorEnabled()) return;
+
     const socket = getSharedSocket();
     if (!socket.isConnected()) return;
 

--- a/src/navigation/AuthNavigator.tsx
+++ b/src/navigation/AuthNavigator.tsx
@@ -83,7 +83,7 @@ import type {
 import { prefetchResolvedMediaUris } from "../hooks/useResolvedMediaUrl";
 import { messagingAPI } from "../services/messaging/api";
 import { cacheService } from "../services/messaging/cache";
-import { E2EEService } from "../services/E2EEService";
+import { decryptMessagesForCache } from "./preloadMessagesCache";
 
 /** Durée minimale du splash in-app (ms), en parallèle avec validateSession. */
 const SPLASH_MIN_MS = 2000;
@@ -339,50 +339,7 @@ export const AuthNavigator: React.FC = () => {
             const id = uniqueConversationIds[cursor++];
             try {
               const data = await messagingAPI.getMessages(id, { limit: 30 });
-              const cached = Array.isArray(data)
-                ? await Promise.all(
-                    data.map(async (m: any) => {
-                      let displayContent = m?.content;
-                      let e2eeMetadata: Record<string, unknown> = {};
-                      if (
-                        typeof m?.content === "string" &&
-                        E2EEService.isEncryptedPayload(m.content)
-                      ) {
-                        const decrypted = await E2EEService.decryptTextMessage({
-                          conversationId: id,
-                          content: m.content,
-                        });
-                        if (decrypted === null) {
-                          displayContent = "Message chiffré";
-                        } else if (m?.message_type === "media") {
-                          try {
-                            const parsed = JSON.parse(decrypted);
-                            if (parsed.media_key && parsed.media_nonce) {
-                              displayContent = parsed.caption || "";
-                              e2eeMetadata = {
-                                media_key: parsed.media_key,
-                                media_nonce: parsed.media_nonce,
-                                e2ee: true,
-                              };
-                            } else {
-                              displayContent = decrypted;
-                            }
-                          } catch {
-                            displayContent = decrypted;
-                          }
-                        } else {
-                          displayContent = decrypted;
-                        }
-                      }
-                      return {
-                        ...m,
-                        content: displayContent,
-                        metadata: { ...(m?.metadata || {}), ...e2eeMetadata },
-                        status: m?.status || "sent",
-                      };
-                    }),
-                  )
-                : [];
+              const cached = await decryptMessagesForCache(id, data);
               await cacheService.saveMessages(id, cached as any);
             } catch {}
           }

--- a/src/navigation/AuthNavigator.tsx
+++ b/src/navigation/AuthNavigator.tsx
@@ -83,6 +83,7 @@ import type {
 import { prefetchResolvedMediaUris } from "../hooks/useResolvedMediaUrl";
 import { messagingAPI } from "../services/messaging/api";
 import { cacheService } from "../services/messaging/cache";
+import { E2EEService } from "../services/E2EEService";
 
 /** Durée minimale du splash in-app (ms), en parallèle avec validateSession. */
 const SPLASH_MIN_MS = 2000;
@@ -339,10 +340,48 @@ export const AuthNavigator: React.FC = () => {
             try {
               const data = await messagingAPI.getMessages(id, { limit: 30 });
               const cached = Array.isArray(data)
-                ? data.map((m: any) => ({
-                    ...m,
-                    status: m?.status || "sent",
-                  }))
+                ? await Promise.all(
+                    data.map(async (m: any) => {
+                      let displayContent = m?.content;
+                      let e2eeMetadata: Record<string, unknown> = {};
+                      if (
+                        typeof m?.content === "string" &&
+                        E2EEService.isEncryptedPayload(m.content)
+                      ) {
+                        const decrypted = await E2EEService.decryptTextMessage({
+                          conversationId: id,
+                          content: m.content,
+                        });
+                        if (decrypted === null) {
+                          displayContent = "Message chiffré";
+                        } else if (m?.message_type === "media") {
+                          try {
+                            const parsed = JSON.parse(decrypted);
+                            if (parsed.media_key && parsed.media_nonce) {
+                              displayContent = parsed.caption || "";
+                              e2eeMetadata = {
+                                media_key: parsed.media_key,
+                                media_nonce: parsed.media_nonce,
+                                e2ee: true,
+                              };
+                            } else {
+                              displayContent = decrypted;
+                            }
+                          } catch {
+                            displayContent = decrypted;
+                          }
+                        } else {
+                          displayContent = decrypted;
+                        }
+                      }
+                      return {
+                        ...m,
+                        content: displayContent,
+                        metadata: { ...(m?.metadata || {}), ...e2eeMetadata },
+                        status: m?.status || "sent",
+                      };
+                    }),
+                  )
                 : [];
               await cacheService.saveMessages(id, cached as any);
             } catch {}

--- a/src/navigation/__tests__/preloadMessagesCache.test.ts
+++ b/src/navigation/__tests__/preloadMessagesCache.test.ts
@@ -1,0 +1,192 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+jest.mock("../../services/E2EEService", () => ({
+  E2EEService: {
+    isEncryptedPayload: jest.fn(),
+    decryptTextMessage: jest.fn(),
+  },
+}));
+
+import {
+  decryptMessageForCache,
+  decryptMessagesForCache,
+} from "../preloadMessagesCache";
+import { E2EEService } from "../../services/E2EEService";
+
+const mockIsEncrypted = E2EEService.isEncryptedPayload as jest.Mock;
+const mockDecryptText = E2EEService.decryptTextMessage as jest.Mock;
+
+beforeEach(() => {
+  mockIsEncrypted.mockReset();
+  mockDecryptText.mockReset();
+});
+
+describe("decryptMessageForCache", () => {
+  it("passes plaintext messages through with a default status", async () => {
+    mockIsEncrypted.mockReturnValue(false);
+
+    const raw = {
+      id: "m-1",
+      content: "hello",
+      message_type: "text",
+      metadata: { foo: "bar" },
+    };
+    const result = await decryptMessageForCache("c-1", raw);
+
+    expect(result.content).toBe("hello");
+    expect(result.status).toBe("sent");
+    expect(result.metadata).toEqual({ foo: "bar" });
+    expect(mockDecryptText).not.toHaveBeenCalled();
+  });
+
+  it("preserves explicit status when provided", async () => {
+    mockIsEncrypted.mockReturnValue(false);
+
+    const result = await decryptMessageForCache("c-1", {
+      id: "m-1",
+      content: "x",
+      status: "delivered",
+    });
+    expect(result.status).toBe("delivered");
+  });
+
+  it("decrypts an E2EE text envelope", async () => {
+    mockIsEncrypted.mockReturnValue(true);
+    mockDecryptText.mockResolvedValue("clear text");
+
+    const result = await decryptMessageForCache("c-1", {
+      id: "m-1",
+      content: '{"v":1,"t":"whispr_e2ee_v1"}',
+      message_type: "text",
+    });
+    expect(result.content).toBe("clear text");
+    expect(mockDecryptText).toHaveBeenCalledWith({
+      conversationId: "c-1",
+      content: '{"v":1,"t":"whispr_e2ee_v1"}',
+    });
+  });
+
+  it("falls back to 'Message chiffré' when decryption returns null", async () => {
+    mockIsEncrypted.mockReturnValue(true);
+    mockDecryptText.mockResolvedValue(null);
+
+    const result = await decryptMessageForCache("c-1", {
+      id: "m-1",
+      content: '{"v":1}',
+      message_type: "text",
+    });
+    expect(result.content).toBe("Message chiffré");
+  });
+
+  it("extracts media_key/media_nonce/caption for E2EE media messages", async () => {
+    mockIsEncrypted.mockReturnValue(true);
+    mockDecryptText.mockResolvedValue(
+      JSON.stringify({
+        media_key: "k-1",
+        media_nonce: "n-1",
+        caption: "look at this",
+      }),
+    );
+
+    const result = await decryptMessageForCache("c-1", {
+      id: "m-1",
+      content: '{"v":1}',
+      message_type: "media",
+    });
+    expect(result.content).toBe("look at this");
+    expect(result.metadata).toMatchObject({
+      media_key: "k-1",
+      media_nonce: "n-1",
+      e2ee: true,
+    });
+  });
+
+  it("returns an empty caption when the media envelope omits one", async () => {
+    mockIsEncrypted.mockReturnValue(true);
+    mockDecryptText.mockResolvedValue(
+      JSON.stringify({ media_key: "k", media_nonce: "n" }),
+    );
+
+    const result = await decryptMessageForCache("c-1", {
+      id: "m-1",
+      content: '{"v":1}',
+      message_type: "media",
+    });
+    expect(result.content).toBe("");
+    expect(result.metadata.media_key).toBe("k");
+  });
+
+  it("falls back to raw decrypted text when the media JSON lacks keys", async () => {
+    mockIsEncrypted.mockReturnValue(true);
+    mockDecryptText.mockResolvedValue(JSON.stringify({ other: 1 }));
+
+    const result = await decryptMessageForCache("c-1", {
+      id: "m-1",
+      content: '{"v":1}',
+      message_type: "media",
+    });
+    expect(result.content).toBe(JSON.stringify({ other: 1 }));
+    expect(result.metadata).toEqual({});
+  });
+
+  it("falls back to raw decrypted text when the media payload is not JSON", async () => {
+    mockIsEncrypted.mockReturnValue(true);
+    mockDecryptText.mockResolvedValue("not-json");
+
+    const result = await decryptMessageForCache("c-1", {
+      id: "m-1",
+      content: '{"v":1}',
+      message_type: "media",
+    });
+    expect(result.content).toBe("not-json");
+  });
+
+  it("merges existing metadata with the E2EE additions", async () => {
+    mockIsEncrypted.mockReturnValue(true);
+    mockDecryptText.mockResolvedValue(
+      JSON.stringify({ media_key: "k", media_nonce: "n" }),
+    );
+
+    const result = await decryptMessageForCache("c-1", {
+      id: "m-1",
+      content: '{"v":1}',
+      message_type: "media",
+      metadata: { custom: "field" },
+    });
+    expect(result.metadata).toEqual({
+      custom: "field",
+      media_key: "k",
+      media_nonce: "n",
+      e2ee: true,
+    });
+  });
+
+  it("tolerates a message without content", async () => {
+    mockIsEncrypted.mockReturnValue(false);
+    const result = await decryptMessageForCache("c-1", {
+      id: "m-1",
+      message_type: "system",
+    });
+    expect(result.status).toBe("sent");
+    expect(mockDecryptText).not.toHaveBeenCalled();
+  });
+});
+
+describe("decryptMessagesForCache", () => {
+  it("returns an empty array when input is not an array", async () => {
+    expect(await decryptMessagesForCache("c-1", null)).toEqual([]);
+    expect(await decryptMessagesForCache("c-1", "nope")).toEqual([]);
+    expect(await decryptMessagesForCache("c-1", undefined)).toEqual([]);
+  });
+
+  it("maps every message through decryptMessageForCache", async () => {
+    mockIsEncrypted.mockReturnValue(false);
+    const result = await decryptMessagesForCache("c-1", [
+      { id: "m-1", content: "a" },
+      { id: "m-2", content: "b" },
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result[0].content).toBe("a");
+    expect(result[1].content).toBe("b");
+  });
+});

--- a/src/navigation/preloadMessagesCache.ts
+++ b/src/navigation/preloadMessagesCache.ts
@@ -1,0 +1,72 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// Cache-warm helper used by AuthNavigator at boot to pre-decrypt the latest
+// messages of the top conversations. Extracted from the navigator so the
+// (otherwise hard to reach) E2EE decryption branch is unit-testable.
+
+import { E2EEService } from "../services/E2EEService";
+
+/**
+ * Decrypt one raw API message into the shape the chat screen cache expects.
+ * E2EE envelopes are unwrapped; media messages further parse the inner JSON
+ * to extract the `media_key`/`media_nonce` pair into `metadata` so the chat
+ * bubbles can render them without re-decrypting.
+ */
+export async function decryptMessageForCache(
+  conversationId: string,
+  m: any,
+): Promise<any> {
+  let displayContent = m?.content;
+  let e2eeMetadata: Record<string, unknown> = {};
+  if (
+    typeof m?.content === "string" &&
+    E2EEService.isEncryptedPayload(m.content)
+  ) {
+    const decrypted = await E2EEService.decryptTextMessage({
+      conversationId,
+      content: m.content,
+    });
+    if (decrypted === null) {
+      displayContent = "Message chiffré";
+    } else if (m?.message_type === "media") {
+      try {
+        const parsed = JSON.parse(decrypted);
+        if (parsed.media_key && parsed.media_nonce) {
+          displayContent = parsed.caption || "";
+          e2eeMetadata = {
+            media_key: parsed.media_key,
+            media_nonce: parsed.media_nonce,
+            e2ee: true,
+          };
+        } else {
+          displayContent = decrypted;
+        }
+      } catch {
+        displayContent = decrypted;
+      }
+    } else {
+      displayContent = decrypted;
+    }
+  }
+  return {
+    ...m,
+    content: displayContent,
+    metadata: { ...(m?.metadata || {}), ...e2eeMetadata },
+    status: m?.status || "sent",
+  };
+}
+
+/**
+ * Decrypt the array of raw API messages returned by getMessages so the
+ * navigator can write a plaintext-ready entry into the conversation cache.
+ * Non-arrays return an empty list — defensive, matches the prior inline code.
+ */
+export async function decryptMessagesForCache(
+  conversationId: string,
+  data: unknown,
+): Promise<any[]> {
+  if (!Array.isArray(data)) return [];
+  return Promise.all(
+    data.map((m) => decryptMessageForCache(conversationId, m)),
+  );
+}

--- a/src/screens/Calls/CallHistoryScreen.tsx
+++ b/src/screens/Calls/CallHistoryScreen.tsx
@@ -441,20 +441,10 @@ export const CallHistoryScreen: React.FC = () => {
           <TourAutoStart />
 
           {/* Header */}
+          {/* WHISPR-1437 : bouton + masque le temps qu'un selecteur de contact pour nouvel appel soit livre */}
           <AttachStep index={0} fill={Platform.OS !== "web"}>
             <View style={styles.header}>
               <Text style={styles.headerTitle}>Appels</Text>
-              <Pressable
-                style={styles.newCallBtn}
-                onPress={() => {
-                  // TODO : ouvrir sélecteur de contact
-                }}
-                accessibilityLabel="Nouvel appel"
-                accessibilityRole="button"
-                hitSlop={{ top: 4, bottom: 4, left: 4, right: 4 }}
-              >
-                <Ionicons name="add" size={24} color={colors.text.light} />
-              </Pressable>
             </View>
           </AttachStep>
 
@@ -572,14 +562,6 @@ const styles = StyleSheet.create({
     fontSize: 28,
     fontFamily: "Inter_700Bold",
     color: colors.text.light,
-  },
-  newCallBtn: {
-    width: 44,
-    height: 44,
-    alignItems: "center",
-    justifyContent: "center",
-    borderRadius: 22,
-    backgroundColor: withOpacity(colors.primary.main, 0.18),
   },
 
   // Filtres

--- a/src/screens/Calls/IncomingCallScreen.tsx
+++ b/src/screens/Calls/IncomingCallScreen.tsx
@@ -15,8 +15,34 @@ import { systemCallProvider } from "../../services/calls/systemCallProvider";
 
 type Nav = StackNavigationProp<AuthStackParamList>;
 
-const showAcceptError = (message: string) => {
+// Mappe un message tague par callsStore (`accept-api: ...`, `livekit-connect: ...`)
+// vers un texte intelligible pour l'utilisateur. Sans ce mapping, les toasts
+// affichent le tag technique brut et le user ne comprend pas la cause.
+const humanizeAcceptError = (raw: string): string => {
+  if (raw.startsWith("accept-permissions:")) {
+    return raw.replace(/^accept-permissions:\s*/, "");
+  }
+  if (raw.startsWith("accept-api:")) {
+    return `Impossible de joindre le serveur d'appels : ${raw.replace(/^accept-api:\s*/, "")}`;
+  }
+  if (raw.startsWith("livekit-connect:")) {
+    const detail = raw.replace(/^livekit-connect:\s*/, "");
+    if (/timeout/i.test(detail))
+      return "Connexion appel timeout. Reseau trop lent ?";
+    if (/NotAllowedError|permission/i.test(detail))
+      return "Permission micro/camera refusee.";
+    if (/token|auth/i.test(detail))
+      return "Token LiveKit invalide. Reconnectez-vous.";
+    if (/WebRTC|getUserMedia|not supported/i.test(detail))
+      return "WebRTC pas supporte ou bloque sur ce navigateur.";
+    return `Echec connexion appel : ${detail}`;
+  }
+  return raw;
+};
+
+const showAcceptError = (rawMessage: string) => {
   const title = "Impossible de prendre l'appel";
+  const message = humanizeAcceptError(rawMessage);
   if (Platform.OS === "web") {
     // window.alert est synchrone sur web ; Alert.alert RN ne s'affiche pas.
     if (typeof window !== "undefined") window.alert(`${title}\n\n${message}`);

--- a/src/screens/Calls/__tests__/IncomingCallScreen.test.tsx
+++ b/src/screens/Calls/__tests__/IncomingCallScreen.test.tsx
@@ -108,9 +108,12 @@ describe("IncomingCallScreen", () => {
       await Promise.resolve();
       expect(mockAcceptIncoming).toHaveBeenCalledTimes(1);
       expect(mockReset).not.toHaveBeenCalled();
+      // Le tag technique `livekit-connect: ...` est traduit en texte humain
+      // par humanizeAcceptError avant affichage. Le tag reste log via
+      // console.error pour le debug DevTools.
       expect(alertSpy).toHaveBeenCalledWith(
         "Impossible de prendre l'appel",
-        "livekit-connect: WebSocket failed",
+        "Echec connexion appel : WebSocket failed",
       );
       expect(mockSetIncoming).toHaveBeenCalledWith(null);
       expect(mockGoBack).toHaveBeenCalled();

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -317,8 +317,16 @@ export const ChatScreen: React.FC = () => {
   useEffect(() => {
     e2eeEnabledRef.current = e2eeEnabled;
   }, [e2eeEnabled]);
-  const [messages, setMessages] = useState<MessageWithRelations[]>([]);
-  const [loading, setLoading] = useState(true);
+  // Seed from the in-memory cache so the initial render shows the previous
+  // session's messages immediately — AsyncStorage is too slow to win the
+  // race against loadMessages and would otherwise leave the screen blank for
+  // ~100-200ms while the API/decrypt path runs.
+  const [messages, setMessages] = useState<MessageWithRelations[]>(
+    () => cacheService.getMessagesSync(conversationId) ?? [],
+  );
+  const [loading, setLoading] = useState(
+    () => (cacheService.getMessagesSync(conversationId) ?? []).length === 0,
+  );
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(true);
   const [typingUsers, setTypingUsers] = useState<string[]>([]);
@@ -1483,15 +1491,52 @@ export const ChatScreen: React.FC = () => {
         } else {
           // Initial load — merge with any messages already received via WS.
           // API versions take priority over cache so decrypted content
-          // replaces any encrypted placeholders loaded from cache.
+          // replaces any encrypted placeholders loaded from cache. When the
+          // cache already holds the exact same fields the bubble cares about,
+          // reuse its reference so memo(MessageBubble) can skip the re-render.
           setMessages((prev) => {
-            const apiById = new Map(
-              messagesWithRelations.map((m) => [m.id, m]),
-            );
+            const prevById = new Map(prev.map((m) => [m.id, m]));
+            const reconciled = messagesWithRelations.map((api) => {
+              const cached = prevById.get(api.id);
+              if (!cached) return api;
+              const sameContent = cached.content === api.content;
+              const sameStatus = cached.status === api.status;
+              const sameEdited = cached.edited_at === api.edited_at;
+              const sameDeleted = cached.is_deleted === api.is_deleted;
+              const cachedMeta = cached.metadata as
+                | Record<string, any>
+                | undefined;
+              const apiMeta = api.metadata as Record<string, any> | undefined;
+              const sameMeta =
+                cachedMeta?.media_url === apiMeta?.media_url &&
+                cachedMeta?.blockedByModeration ===
+                  apiMeta?.blockedByModeration &&
+                cachedMeta?.appealRejected === apiMeta?.appealRejected;
+              // `undefined` and `[]` are semantically the same here: the
+              // preload writes messages without reactions/attachments, so the
+              // cache may store `undefined` while the API normalizes to `[]`.
+              const cachedReactions = cached.reactions ?? [];
+              const apiReactions = api.reactions ?? [];
+              const sameReactions =
+                JSON.stringify(cachedReactions) ===
+                JSON.stringify(apiReactions);
+              if (
+                sameContent &&
+                sameStatus &&
+                sameEdited &&
+                sameDeleted &&
+                sameMeta &&
+                sameReactions
+              ) {
+                return cached;
+              }
+              return api;
+            });
+            const apiById = new Map(reconciled.map((m) => [m.id, m]));
             const wsOnly = prev.filter((m) => !apiById.has(m.id));
             const withReplies = resolveReplies(
-              [...messagesWithRelations, ...wsOnly],
-              [...messagesWithRelations, ...wsOnly],
+              [...reconciled, ...wsOnly],
+              [...reconciled, ...wsOnly],
             );
             return withReplies.sort(
               (a, b) =>
@@ -3462,50 +3507,56 @@ export const ChatScreen: React.FC = () => {
                 </KeyboardAvoidingView>
               );
             })()}
-            <MessageActionsMenu
-              visible={showActionsMenu}
-              message={selectedMessage}
-              isSent={selectedMessage?.sender_id === userId}
-              isPinned={pinnedMessages.some(
-                (m) => (m.messageId ?? m.message?.id) === selectedMessage?.id,
-              )}
-              onClose={() => {
-                setShowActionsMenu(false);
-                setSelectedMessage(null);
-              }}
-              onReply={handleStartReply}
-              onEdit={handleEditMessage}
-              onDelete={handleDeleteMessage}
-              onReact={handleStartReaction}
-              onPin={handlePinMessage}
-              onForward={handleForwardMessage}
-              onReport={handleOpenReportSheet}
-            />
-            <ReportMessageSheet
-              visible={showReportSheet}
-              message={reportSheetMessage}
-              conversationId={conversationId}
-              conversationTitle={
-                conversation
-                  ? getConversationDisplayName(conversation)
-                  : "Conversation"
-              }
-              onClose={() => {
-                setShowReportSheet(false);
-                setReportSheetMessage(null);
-              }}
-            />
-            <ForwardMessageModal
-              visible={showForwardModal}
-              conversations={allConversations}
-              currentConversationId={conversationId}
-              sending={forwardSending}
-              onClose={() => {
-                setShowForwardModal(false);
-                setForwardingMessage(null);
-              }}
-              onSelect={handleForwardSelect}
-            />
+            {showActionsMenu && (
+              <MessageActionsMenu
+                visible={showActionsMenu}
+                message={selectedMessage}
+                isSent={selectedMessage?.sender_id === userId}
+                isPinned={pinnedMessages.some(
+                  (m) => (m.messageId ?? m.message?.id) === selectedMessage?.id,
+                )}
+                onClose={() => {
+                  setShowActionsMenu(false);
+                  setSelectedMessage(null);
+                }}
+                onReply={handleStartReply}
+                onEdit={handleEditMessage}
+                onDelete={handleDeleteMessage}
+                onReact={handleStartReaction}
+                onPin={handlePinMessage}
+                onForward={handleForwardMessage}
+                onReport={handleOpenReportSheet}
+              />
+            )}
+            {showReportSheet && (
+              <ReportMessageSheet
+                visible={showReportSheet}
+                message={reportSheetMessage}
+                conversationId={conversationId}
+                conversationTitle={
+                  conversation
+                    ? getConversationDisplayName(conversation)
+                    : "Conversation"
+                }
+                onClose={() => {
+                  setShowReportSheet(false);
+                  setReportSheetMessage(null);
+                }}
+              />
+            )}
+            {showForwardModal && (
+              <ForwardMessageModal
+                visible={showForwardModal}
+                conversations={allConversations}
+                currentConversationId={conversationId}
+                sending={forwardSending}
+                onClose={() => {
+                  setShowForwardModal(false);
+                  setForwardingMessage(null);
+                }}
+                onSelect={handleForwardSelect}
+              />
+            )}
             {showReactionPicker && (
               <ReactionPicker
                 visible={showReactionPicker}
@@ -3516,13 +3567,15 @@ export const ChatScreen: React.FC = () => {
                 onReactionSelect={handleReactionSelectFromPicker}
               />
             )}
-            <ReactionReactorsModal
-              visible={reactionReactorsModal !== null}
-              emoji={reactionReactorsModal?.emoji ?? ""}
-              reactors={reactionModalList}
-              resolveName={resolveReactorDisplayName}
-              onClose={() => setReactionReactorsModal(null)}
-            />
+            {reactionReactorsModal !== null && (
+              <ReactionReactorsModal
+                visible={reactionReactorsModal !== null}
+                emoji={reactionReactorsModal?.emoji ?? ""}
+                reactors={reactionModalList}
+                resolveName={resolveReactorDisplayName}
+                onClose={() => setReactionReactorsModal(null)}
+              />
+            )}
             {appealModal ? (
               <BlockedImageAppealModal
                 visible={appealModal.visible}
@@ -3561,170 +3614,176 @@ export const ChatScreen: React.FC = () => {
               onNext={handleSearchNext}
               onPrevious={handleSearchPrevious}
             />
-            <ScheduleDateTimePicker
-              visible={showSchedulePicker}
-              onClose={() => {
-                setShowSchedulePicker(false);
-                setScheduleMessageText("");
-              }}
-              onConfirm={handleScheduleConfirm}
-            />
-            <Modal
-              visible={showInfoModal && conversation?.type !== "group"}
-              transparent
-              animationType="slide"
-              statusBarTranslucent
-              onRequestClose={() => {
-                setShowInfoModal(false);
-              }}
-            >
-              <View style={styles.modalOverlay}>
-                <View style={styles.modalContent}>
-                  <LinearGradient
-                    colors={colors.background.gradient.app}
-                    start={{ x: 0, y: 0 }}
-                    end={{ x: 1, y: 1 }}
-                    style={styles.modalGradient}
-                  >
-                    <View style={styles.modalHeader}>
-                      <Text style={styles.modalTitle}>
-                        Informations de la conversation
-                      </Text>
-                      <TouchableOpacity
-                        onPress={() => {
-                          Haptics.impactAsync(
-                            Haptics.ImpactFeedbackStyle.Light,
-                          );
-                          setShowInfoModal(false);
-                        }}
-                        style={styles.closeButton}
-                        activeOpacity={0.7}
-                      >
-                        <Ionicons
-                          name="close"
-                          size={24}
-                          color={colors.text.light}
-                        />
-                      </TouchableOpacity>
-                    </View>
-                    <ScrollView
-                      style={styles.modalBody}
-                      showsVerticalScrollIndicator={false}
+            {showSchedulePicker && (
+              <ScheduleDateTimePicker
+                visible={showSchedulePicker}
+                onClose={() => {
+                  setShowSchedulePicker(false);
+                  setScheduleMessageText("");
+                }}
+                onConfirm={handleScheduleConfirm}
+              />
+            )}
+            {showInfoModal && (
+              <Modal
+                visible={showInfoModal && conversation?.type !== "group"}
+                transparent
+                animationType="slide"
+                statusBarTranslucent
+                onRequestClose={() => {
+                  setShowInfoModal(false);
+                }}
+              >
+                <View style={styles.modalOverlay}>
+                  <View style={styles.modalContent}>
+                    <LinearGradient
+                      colors={colors.background.gradient.app}
+                      start={{ x: 0, y: 0 }}
+                      end={{ x: 1, y: 1 }}
+                      style={styles.modalGradient}
                     >
-                      <View style={styles.infoSectionMain}>
-                        <Avatar
-                          size={80}
-                          uri={conversation?.avatar_url}
-                          name={
-                            conversation
+                      <View style={styles.modalHeader}>
+                        <Text style={styles.modalTitle}>
+                          Informations de la conversation
+                        </Text>
+                        <TouchableOpacity
+                          onPress={() => {
+                            Haptics.impactAsync(
+                              Haptics.ImpactFeedbackStyle.Light,
+                            );
+                            setShowInfoModal(false);
+                          }}
+                          style={styles.closeButton}
+                          activeOpacity={0.7}
+                        >
+                          <Ionicons
+                            name="close"
+                            size={24}
+                            color={colors.text.light}
+                          />
+                        </TouchableOpacity>
+                      </View>
+                      <ScrollView
+                        style={styles.modalBody}
+                        showsVerticalScrollIndicator={false}
+                      >
+                        <View style={styles.infoSectionMain}>
+                          <Avatar
+                            size={80}
+                            uri={conversation?.avatar_url}
+                            name={
+                              conversation
+                                ? getConversationDisplayName(conversation)
+                                : "Contact"
+                            }
+                            showOnlineBadge={conversation?.type === "direct"}
+                            isOnline={false}
+                          />
+                          <Text style={styles.infoName}>
+                            {conversation
                               ? getConversationDisplayName(conversation)
-                              : "Contact"
-                          }
-                          showOnlineBadge={conversation?.type === "direct"}
-                          isOnline={false}
-                        />
-                        <Text style={styles.infoName}>
-                          {conversation
-                            ? getConversationDisplayName(conversation)
-                            : "Contact"}
-                        </Text>
-                        {conversation?.type === "direct" && (
-                          <Text style={styles.infoStatus}>Hors ligne</Text>
-                        )}
-                      </View>
-                      <View style={styles.infoSection}>
-                        <Text style={styles.infoLabel}>TYPE</Text>
-                        <Text style={styles.infoValue}>
-                          {conversation?.type === "group"
-                            ? "Groupe"
-                            : "Conversation directe"}
-                        </Text>
-                      </View>
-                      {conversation?.type === "direct" ? (
-                        <View style={styles.infoSection}>
-                          <Text style={styles.infoLabel}>CONFIDENTIALITÉ</Text>
-                          <View style={styles.infoToggleRow}>
-                            <Text style={styles.infoValue}>
-                              Chiffrement E2E
-                            </Text>
-                            <Switch
-                              value={e2eeEnabled}
-                              onValueChange={handleToggleE2EE}
-                              disabled={e2eeToggleBusy}
-                              trackColor={{
-                                false: "rgba(255, 255, 255, 0.15)",
-                                true: colors.primary.main,
-                              }}
-                              thumbColor={colors.text.light}
-                            />
-                          </View>
+                              : "Contact"}
+                          </Text>
+                          {conversation?.type === "direct" && (
+                            <Text style={styles.infoStatus}>Hors ligne</Text>
+                          )}
                         </View>
-                      ) : null}
-                      <View style={styles.infoSection}>
-                        <Text style={styles.infoLabel}>MESSAGES</Text>
-                        <Text style={styles.infoValue}>
-                          {messages.length} message
-                          {messages.length > 1 ? "s" : ""}
-                        </Text>
-                      </View>
-                      <View style={styles.infoSectionActions}>
-                        <Text style={styles.infoLabel}>ACTIONS</Text>
-                        <TouchableOpacity
-                          style={styles.infoActionRow}
-                          onPress={() => {
-                            setShowInfoModal(false);
-                            setShowSearch(true);
-                          }}
-                          activeOpacity={0.7}
-                          accessibilityRole="button"
-                          accessibilityLabel="Rechercher dans la conversation"
-                        >
-                          <Ionicons
-                            name="search"
-                            size={20}
-                            color={colors.text.light}
-                            style={styles.infoActionIcon}
-                          />
-                          <Text style={styles.infoActionLabel}>
-                            Rechercher des messages
+                        <View style={styles.infoSection}>
+                          <Text style={styles.infoLabel}>TYPE</Text>
+                          <Text style={styles.infoValue}>
+                            {conversation?.type === "group"
+                              ? "Groupe"
+                              : "Conversation directe"}
                           </Text>
-                          <Ionicons
-                            name="chevron-forward"
-                            size={20}
-                            color={withOpacity(colors.text.light, 0.4)}
-                          />
-                        </TouchableOpacity>
-                        <TouchableOpacity
-                          style={styles.infoActionRow}
-                          onPress={() => {
-                            setShowInfoModal(false);
-                            handleScheduledPress();
-                          }}
-                          activeOpacity={0.7}
-                          accessibilityRole="button"
-                          accessibilityLabel="Messages programmés"
-                        >
-                          <Ionicons
-                            name="timer-outline"
-                            size={20}
-                            color={colors.text.light}
-                            style={styles.infoActionIcon}
-                          />
-                          <Text style={styles.infoActionLabel}>
-                            Messages programmés
+                        </View>
+                        {conversation?.type === "direct" ? (
+                          <View style={styles.infoSection}>
+                            <Text style={styles.infoLabel}>
+                              CONFIDENTIALITÉ
+                            </Text>
+                            <View style={styles.infoToggleRow}>
+                              <Text style={styles.infoValue}>
+                                Chiffrement E2E
+                              </Text>
+                              <Switch
+                                value={e2eeEnabled}
+                                onValueChange={handleToggleE2EE}
+                                disabled={e2eeToggleBusy}
+                                trackColor={{
+                                  false: "rgba(255, 255, 255, 0.15)",
+                                  true: colors.primary.main,
+                                }}
+                                thumbColor={colors.text.light}
+                              />
+                            </View>
+                          </View>
+                        ) : null}
+                        <View style={styles.infoSection}>
+                          <Text style={styles.infoLabel}>MESSAGES</Text>
+                          <Text style={styles.infoValue}>
+                            {messages.length} message
+                            {messages.length > 1 ? "s" : ""}
                           </Text>
-                          <Ionicons
-                            name="chevron-forward"
-                            size={20}
-                            color={withOpacity(colors.text.light, 0.4)}
-                          />
-                        </TouchableOpacity>
-                      </View>
-                    </ScrollView>
-                  </LinearGradient>
+                        </View>
+                        <View style={styles.infoSectionActions}>
+                          <Text style={styles.infoLabel}>ACTIONS</Text>
+                          <TouchableOpacity
+                            style={styles.infoActionRow}
+                            onPress={() => {
+                              setShowInfoModal(false);
+                              setShowSearch(true);
+                            }}
+                            activeOpacity={0.7}
+                            accessibilityRole="button"
+                            accessibilityLabel="Rechercher dans la conversation"
+                          >
+                            <Ionicons
+                              name="search"
+                              size={20}
+                              color={colors.text.light}
+                              style={styles.infoActionIcon}
+                            />
+                            <Text style={styles.infoActionLabel}>
+                              Rechercher des messages
+                            </Text>
+                            <Ionicons
+                              name="chevron-forward"
+                              size={20}
+                              color={withOpacity(colors.text.light, 0.4)}
+                            />
+                          </TouchableOpacity>
+                          <TouchableOpacity
+                            style={styles.infoActionRow}
+                            onPress={() => {
+                              setShowInfoModal(false);
+                              handleScheduledPress();
+                            }}
+                            activeOpacity={0.7}
+                            accessibilityRole="button"
+                            accessibilityLabel="Messages programmés"
+                          >
+                            <Ionicons
+                              name="timer-outline"
+                              size={20}
+                              color={colors.text.light}
+                              style={styles.infoActionIcon}
+                            />
+                            <Text style={styles.infoActionLabel}>
+                              Messages programmés
+                            </Text>
+                            <Ionicons
+                              name="chevron-forward"
+                              size={20}
+                              color={withOpacity(colors.text.light, 0.4)}
+                            />
+                          </TouchableOpacity>
+                        </View>
+                      </ScrollView>
+                    </LinearGradient>
+                  </View>
                 </View>
-              </View>
-            </Modal>
+              </Modal>
+            )}
             <Toast
               visible={callsToast.visible}
               message={callsToast.message}

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -2556,9 +2556,35 @@ export const ChatScreen: React.FC = () => {
         }
         navigation.navigate("InCall");
       } catch (err) {
+        // WHISPR-1200 : afficher la vraie cause au lieu d'un message generique.
+        // callsStore.initiate tague chaque etape avec un prefixe stable
+        // (initiate-permissions / initiate-api / livekit-connect).
+        console.error("[Calls] initiate failed:", err);
+        const raw = err instanceof Error ? err.message : String(err);
+        const message = (() => {
+          if (raw.startsWith("initiate-permissions:")) {
+            return raw.replace(/^initiate-permissions:\s*/, "");
+          }
+          if (raw.startsWith("initiate-api:")) {
+            return `Impossible de joindre le serveur d'appels : ${raw.replace(/^initiate-api:\s*/, "")}`;
+          }
+          if (raw.startsWith("livekit-connect:")) {
+            const detail = raw.replace(/^livekit-connect:\s*/, "");
+            if (/timeout/i.test(detail))
+              return "Connexion appel timeout. Reseau trop lent ?";
+            if (/NotAllowedError|permission/i.test(detail))
+              return "Permission micro/camera refusee.";
+            if (/token|auth/i.test(detail))
+              return "Token LiveKit invalide. Reconnectez-vous.";
+            if (/WebRTC|getUserMedia|not supported/i.test(detail))
+              return "WebRTC pas supporte ou bloque sur ce navigateur.";
+            return `Echec connexion appel : ${detail}`;
+          }
+          return `Echec de l'appel : ${raw}`;
+        })();
         setCallsToast({
           visible: true,
-          message: "Impossible de démarrer l'appel. Vérifiez votre connexion.",
+          message,
           type: "error",
         });
       }

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -130,6 +130,7 @@ const CHAT_TOUR_STEPS: TourStep[] = [
 import { getConversationDisplayName } from "../../utils";
 import { generateClientRandom } from "../../utils/crypto";
 import { convertHeicToJpeg } from "../../utils/imageCompression";
+import { extractVideoPoster } from "../../utils/videoPoster";
 import { usePresenceStore } from "../../store/presenceStore";
 import { AuthStackParamList } from "../../navigation/AuthNavigator";
 import { colors, withOpacity } from "../../theme/colors";
@@ -668,6 +669,13 @@ export const ChatScreen: React.FC = () => {
                       media_key: parsed.media_key,
                       media_nonce: parsed.media_nonce,
                       e2ee: true,
+                      // WHISPR-fix-video-preview-hevc-ios
+                      ...(parsed.thumbnail_key && parsed.thumbnail_nonce
+                        ? {
+                            thumbnail_key: parsed.thumbnail_key,
+                            thumbnail_nonce: parsed.thumbnail_nonce,
+                          }
+                        : {}),
                     };
                   }
                 } catch {
@@ -1371,6 +1379,13 @@ export const ChatScreen: React.FC = () => {
                         media_key: parsed.media_key,
                         media_nonce: parsed.media_nonce,
                         e2ee: true,
+                        // WHISPR-fix-video-preview-hevc-ios
+                        ...(parsed.thumbnail_key && parsed.thumbnail_nonce
+                          ? {
+                              thumbnail_key: parsed.thumbnail_key,
+                              thumbnail_nonce: parsed.thumbnail_nonce,
+                            }
+                          : {}),
                       };
                     } else {
                       displayContent = decrypted;
@@ -1997,6 +2012,70 @@ export const ChatScreen: React.FC = () => {
           }
         }
 
+        // WHISPR-fix-video-preview-hevc-ios : pour les vidéos, on extrait
+        // un poster JPEG côté client. Sinon le composant MediaMessage tente
+        // <Video> sur le blob déchiffré pour générer la preview de liste,
+        // ce qui casse iOS sur HEVC/.mov avec AVErrorFileFormatNotRecognized
+        // (-11828). Le poster est uploadé séparément ; en E2EE il est chiffré
+        // avec sa propre clé/nonce.
+        let posterUpload:
+          | {
+              id: string;
+              url: string;
+              key?: string;
+              nonce?: string;
+            }
+          | undefined;
+        if (type === "video") {
+          try {
+            const poster = await extractVideoPoster(uploadUri, finalFilename);
+            if (poster) {
+              let posterUploadUri = poster.uri;
+              let posterMime: string = poster.mimeType;
+              let posterE2ee:
+                | { key: string; nonce: string }
+                | undefined;
+              if (shouldEncrypt) {
+                try {
+                  const encPoster = await E2EEService.encryptMediaFile(
+                    poster.uri,
+                  );
+                  posterUploadUri = encPoster.encryptedUri;
+                  posterE2ee = { key: encPoster.key, nonce: encPoster.nonce };
+                  posterMime = "application/octet-stream";
+                } catch (posterEncErr) {
+                  logger.warn(
+                    "ChatScreen.handleSendMedia",
+                    "Poster encryption failed, falling back to plaintext poster",
+                    posterEncErr,
+                  );
+                }
+              }
+              const posterResult = await MediaService.uploadMedia(
+                {
+                  uri: posterUploadUri,
+                  name: poster.filename,
+                  type: posterMime,
+                },
+                undefined,
+                { context: "message", ownerId: userId },
+              );
+              posterUpload = {
+                id: posterResult.id,
+                url: posterResult.url,
+                key: posterE2ee?.key,
+                nonce: posterE2ee?.nonce,
+              };
+            }
+          } catch (posterErr) {
+            logger.warn(
+              "ChatScreen.handleSendMedia",
+              "Video poster extraction/upload failed, falling back to placeholder preview",
+              posterErr,
+            );
+          }
+        }
+
         // 1. Upload file to media-service (encrypted or plain)
         const uploadResult = await MediaService.uploadMedia(
           { uri: finalUploadUri, name: finalFilename, type: uploadMimeType },
@@ -2035,16 +2114,29 @@ export const ChatScreen: React.FC = () => {
           }
         }
 
-        const mediaMetadata = {
+        const mediaMetadata: Record<string, unknown> = {
           media_type: type,
           media_id: uploadResult.id,
           media_url: uploadResult.url,
-          thumbnail_url: uploadResult.thumbnail_url || uploadResult.url,
+          thumbnail_url: posterUpload
+            ? posterUpload.url
+            : uploadResult.thumbnail_url || uploadResult.url,
           filename: uploadResult.filename || finalFilename,
           mime_type: uploadResult.mime_type || finalMimeType,
           size: uploadResult.size,
           duration: resolvedDuration,
         };
+        // WHISPR-fix-video-preview-hevc-ios : si on a réussi à uploader un
+        // poster séparé, on attache son id et (en E2EE) sa clé/nonce. Le
+        // récepteur s'en sert pour rendre une <Image> au lieu de tenter
+        // <Video> sur le blob déchiffré.
+        if (posterUpload) {
+          mediaMetadata.thumbnail_id = posterUpload.id;
+          if (posterUpload.key && posterUpload.nonce) {
+            mediaMetadata.thumbnail_key = posterUpload.key;
+            mediaMetadata.thumbnail_nonce = posterUpload.nonce;
+          }
+        }
 
         // Update optimistic message with remote URLs so preview uses the hosted image
         setMessages((prev) =>
@@ -2174,6 +2266,14 @@ export const ChatScreen: React.FC = () => {
                 caption: messageContent,
                 media_key: e2eeMediaMeta.key,
                 media_nonce: e2eeMediaMeta.nonce,
+                // WHISPR-fix-video-preview-hevc-ios : la clé/nonce du poster
+                // doivent transiter chiffrées (jamais en clair côté serveur).
+                ...(posterUpload?.key && posterUpload?.nonce
+                  ? {
+                      thumbnail_key: posterUpload.key,
+                      thumbnail_nonce: posterUpload.nonce,
+                    }
+                  : {}),
               });
               const enc = await E2EEService.encryptMessageForConversation({
                 conversationId,

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -3819,7 +3819,7 @@ export const ChatScreen: React.FC = () => {
                                 : "Contact"
                             }
                             showOnlineBadge={conversation?.type === "direct"}
-                            isOnline={false}
+                            isOnline={isOtherOnline}
                           />
                           <Text style={styles.infoName}>
                             {conversation
@@ -3827,7 +3827,18 @@ export const ChatScreen: React.FC = () => {
                               : "Contact"}
                           </Text>
                           {conversation?.type === "direct" && (
-                            <Text style={styles.infoStatus}>Hors ligne</Text>
+                            <Text
+                              style={[
+                                styles.infoStatus,
+                                isOtherOnline && { color: colors.status.online },
+                              ]}
+                            >
+                              {isOtherOnline
+                                ? "En ligne"
+                                : otherLastSeenAt
+                                  ? `Vu à ${new Date(otherLastSeenAt).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" })}`
+                                  : "Hors ligne"}
+                            </Text>
                           )}
                         </View>
                         <View style={styles.infoSection}>

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -1503,6 +1503,9 @@ export const ChatScreen: React.FC = () => {
               const sameStatus = cached.status === api.status;
               const sameEdited = cached.edited_at === api.edited_at;
               const sameDeleted = cached.is_deleted === api.is_deleted;
+              const sameMessageType = cached.message_type === api.message_type;
+              const sameForwarded =
+                cached.forwarded_from_id === api.forwarded_from_id;
               const cachedMeta = cached.metadata as
                 | Record<string, any>
                 | undefined;
@@ -1511,7 +1514,14 @@ export const ChatScreen: React.FC = () => {
                 cachedMeta?.media_url === apiMeta?.media_url &&
                 cachedMeta?.blockedByModeration ===
                   apiMeta?.blockedByModeration &&
-                cachedMeta?.appealRejected === apiMeta?.appealRejected;
+                cachedMeta?.appealRejected === apiMeta?.appealRejected &&
+                cachedMeta?.forwarded === apiMeta?.forwarded &&
+                cachedMeta?.media_key === apiMeta?.media_key &&
+                cachedMeta?.media_nonce === apiMeta?.media_nonce &&
+                cachedMeta?.e2ee === apiMeta?.e2ee &&
+                (cachedMeta?.link_preview as { url?: string } | undefined)
+                  ?.url ===
+                  (apiMeta?.link_preview as { url?: string } | undefined)?.url;
               // `undefined` and `[]` are semantically the same here: the
               // preload writes messages without reactions/attachments, so the
               // cache may store `undefined` while the API normalizes to `[]`.
@@ -1520,13 +1530,25 @@ export const ChatScreen: React.FC = () => {
               const sameReactions =
                 JSON.stringify(cachedReactions) ===
                 JSON.stringify(apiReactions);
+              // Same approach for attachments — compare structurally rather
+              // than by reference because the API always builds new objects.
+              // Catches "attachments arrived from the API but were missing
+              // from the preload-served cache entry".
+              const cachedAttachments = cached.attachments ?? [];
+              const apiAttachments = api.attachments ?? [];
+              const sameAttachments =
+                JSON.stringify(cachedAttachments) ===
+                JSON.stringify(apiAttachments);
               if (
                 sameContent &&
                 sameStatus &&
                 sameEdited &&
                 sameDeleted &&
+                sameMessageType &&
+                sameForwarded &&
                 sameMeta &&
-                sameReactions
+                sameReactions &&
+                sameAttachments
               ) {
                 return cached;
               }

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -1350,6 +1350,7 @@ export const ChatScreen: React.FC = () => {
             ) // Include all message types
             .map(async (msg) => {
               let displayContent = msg.content;
+              let e2eeMetadata: Record<string, unknown> = {};
               if (
                 typeof msg.content === "string" &&
                 E2EEService.isEncryptedPayload(msg.content)
@@ -1358,8 +1359,27 @@ export const ChatScreen: React.FC = () => {
                   conversationId,
                   content: msg.content,
                 });
-                displayContent =
-                  decrypted === null ? "Message chiffré" : decrypted;
+                if (decrypted === null) {
+                  displayContent = "Message chiffré";
+                } else if (msg.message_type === "media") {
+                  try {
+                    const parsed = JSON.parse(decrypted);
+                    if (parsed.media_key && parsed.media_nonce) {
+                      displayContent = parsed.caption || "";
+                      e2eeMetadata = {
+                        media_key: parsed.media_key,
+                        media_nonce: parsed.media_nonce,
+                        e2ee: true,
+                      };
+                    } else {
+                      displayContent = decrypted;
+                    }
+                  } catch {
+                    displayContent = decrypted;
+                  }
+                } else {
+                  displayContent = decrypted;
+                }
               }
               // WHISPR-1074: the backend may ship the enriched shape
               // (delivery_statuses + status). Widen once instead of
@@ -1405,6 +1425,7 @@ export const ChatScreen: React.FC = () => {
               return {
                 ...msg,
                 content: displayContent,
+                metadata: { ...(msg.metadata || {}), ...e2eeMetadata },
                 status,
                 reactions,
                 attachments,

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -718,13 +718,35 @@ export const ChatScreen: React.FC = () => {
         }
       }
     },
-    onDeliveryStatus: (messageId: string, status: string) => {
+    onDeliveryStatus: (
+      messageId: string,
+      status: string,
+      userId?: string,
+      readAt?: string,
+    ) => {
       setMessages((prev) =>
-        prev.map((msg) =>
-          msg.id === messageId
-            ? { ...msg, status: status as "sent" | "delivered" | "read" }
-            : msg,
-        ),
+        prev.map((msg) => {
+          if (msg.id !== messageId) return msg;
+          const updated = {
+            ...msg,
+            status: status as MessageWithRelations["status"],
+          };
+          if (status === "read" && userId) {
+            const existing = updated.delivery_statuses ?? [];
+            const idx = existing.findIndex((d) => d.user_id === userId);
+            const entry = {
+              id: idx >= 0 ? existing[idx].id : `${messageId}-${userId}`,
+              message_id: messageId,
+              user_id: userId,
+              read_at: readAt ?? new Date().toISOString(),
+            };
+            updated.delivery_statuses =
+              idx >= 0
+                ? existing.map((d, i) => (i === idx ? entry : d))
+                : [...existing, entry];
+          }
+          return updated;
+        }),
       );
     },
     onMessageUpdated: (message: Message) => {
@@ -2032,9 +2054,7 @@ export const ChatScreen: React.FC = () => {
             if (poster) {
               let posterUploadUri = poster.uri;
               let posterMime: string = poster.mimeType;
-              let posterE2ee:
-                | { key: string; nonce: string }
-                | undefined;
+              let posterE2ee: { key: string; nonce: string } | undefined;
               if (shouldEncrypt) {
                 try {
                   const encPoster = await E2EEService.encryptMediaFile(

--- a/src/screens/Profile/MyProfileScreen.tsx
+++ b/src/screens/Profile/MyProfileScreen.tsx
@@ -285,7 +285,7 @@ export const MyProfileScreen: React.FC = () => {
       }
 
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        mediaTypes: ["images"],
         allowsEditing: true,
         aspect: [1, 1],
         quality: 0.8,

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -37,6 +37,7 @@ import {
   NotificationSettings,
 } from "../../services/NotificationService";
 import { setReadReceiptsEnabled } from "../../services/messaging/readReceiptsPref";
+import { setTypingIndicatorEnabled } from "../../services/messaging/typingIndicatorPref";
 import { SettingsChoiceAlert } from "./SettingsChoiceAlert";
 import { useTour } from "../../context/TourContext";
 import { DangerConfirmModal } from "../../components/Common/DangerConfirmModal";
@@ -371,6 +372,9 @@ export const SettingsScreen: React.FC = () => {
           if (typeof parsedMsg.readReceipts === "boolean") {
             setReadReceiptsEnabled(parsedMsg.readReceipts);
           }
+          if (typeof parsedMsg.typingIndicator === "boolean") {
+            setTypingIndicatorEnabled(parsedMsg.typingIndicator);
+          }
         }
         if (appJson) setAppSettings(JSON.parse(appJson));
         if (secJson) setSecuritySettings(JSON.parse(secJson));
@@ -449,6 +453,14 @@ export const SettingsScreen: React.FC = () => {
         setMessagingSettings((prev) => {
           const updated = { ...prev, [key]: value };
           persistSettings(STORAGE_KEYS.messaging, updated);
+          // indicateur de saisie : pas d'equivalent backend dans le DTO
+          // privacy de user-service aujourd'hui, donc on se contente du
+          // mirror local synchrone. useWebSocket le lit a chaque appel
+          // de sendTyping via getTypingIndicatorEnabled() -> effet
+          // immediat sans avoir a reload SettingsScreen ou la conversation.
+          if (key === "typingIndicator") {
+            setTypingIndicatorEnabled(value);
+          }
           // accuses de lecture : symetrie WhatsApp punitive. On met a jour le
           // mirror memoire immediatement pour que useWebSocket le voie au
           // prochain markAsRead, puis on push au backend (privacy_settings).

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -563,7 +563,7 @@ export const SettingsScreen: React.FC = () => {
       }
 
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        mediaTypes: ["images"],
         allowsEditing: true,
         quality: 0.9,
       });

--- a/src/screens/__tests__/HeavyScreens.smoke.test.tsx
+++ b/src/screens/__tests__/HeavyScreens.smoke.test.tsx
@@ -241,6 +241,11 @@ jest.mock("../../services/messaging/readReceiptsPref", () => ({
   getReadReceiptsPref: () => true,
   setReadReceiptsPref: jest.fn(),
 }));
+jest.mock("../../services/messaging/typingIndicatorPref", () => ({
+  hydrateTypingIndicatorPref: jest.fn(),
+  getTypingIndicatorEnabled: () => true,
+  setTypingIndicatorEnabled: jest.fn(),
+}));
 jest.mock("../../services/contacts/api", () => ({
   contactsAPI: mockApiProxy,
 }));

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -2,6 +2,7 @@ import { TokenService } from "./TokenService";
 import { DeviceService } from "./DeviceService";
 import { SignalKeyService } from "./SignalKeyService";
 import { E2EEService } from "./E2EEService";
+import { cacheService } from "./messaging/cache";
 import { getApiBaseUrl } from "./apiBase";
 import { emitSessionExpired } from "./sessionEvents";
 import { logger } from "../utils/logger";
@@ -313,6 +314,11 @@ export const AuthService = {
     E2EEService.resetIdentityCache();
     E2EEService.resetPlaintextCache();
     await E2EEService.resetDecryptedMediaCache();
+    // Wipe the in-memory message mirror — AsyncStorage gets cleared by
+    // AppResetService but the process-lifetime Map would otherwise let a
+    // subsequent login on the same device read the previous account's
+    // plaintext messages.
+    await cacheService.clearAllMessages();
   },
 
   async validateSession(): Promise<{

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -311,6 +311,8 @@ export const AuthService = {
     // previous identity until killed, and counterparts can't decrypt the
     // user's messages.
     E2EEService.resetIdentityCache();
+    E2EEService.resetPlaintextCache();
+    await E2EEService.resetDecryptedMediaCache();
   },
 
   async validateSession(): Promise<{

--- a/src/services/E2EEService.ts
+++ b/src/services/E2EEService.ts
@@ -14,6 +14,7 @@ import { Platform } from "react-native";
 import * as FileSystem from "expo-file-system/legacy";
 import { TokenService } from "./TokenService";
 import { SignalKeysService } from "./SecurityService";
+import { logger } from "../utils/logger";
 
 nacl.setPRNG((x: Uint8Array, n: number) => {
   const bytes = getRandomBytes(n);
@@ -304,12 +305,43 @@ export const E2EEService = {
    * Wipe the decrypted-media cache (memory + disk). Must be called on logout
    * so plaintext bytes from the previous account do not survive a session
    * change. Idempotent — safe to call even when no media has been decrypted.
+   *
+   * On web, the cache values are `blob:` object URLs that hold a reference
+   * to the decrypted bytes in browser memory until explicitly revoked.
+   * Clearing the Map alone would leak them; we revoke each one first.
+   * On native, the cache values are file paths and the bytes live on disk.
    */
   async resetDecryptedMediaCache(): Promise<void> {
+    if (
+      Platform.OS === "web" &&
+      typeof URL !== "undefined" &&
+      typeof URL.revokeObjectURL === "function"
+    ) {
+      for (const value of DECRYPTED_MEDIA_MEMORY.values()) {
+        if (value.startsWith("blob:")) {
+          try {
+            URL.revokeObjectURL(value);
+          } catch {
+            // ignore — best-effort revoke
+          }
+        }
+      }
+    }
     DECRYPTED_MEDIA_MEMORY.clear();
-    await FileSystem.deleteAsync(DECRYPTED_MEDIA_DIR, {
-      idempotent: true,
-    }).catch(() => {});
+    try {
+      await FileSystem.deleteAsync(DECRYPTED_MEDIA_DIR, {
+        idempotent: true,
+      });
+    } catch (error) {
+      // Surface the failure: leaving plaintext media on disk after logout
+      // is a security concern, even if the next decryptMediaFile call will
+      // overwrite individual files.
+      logger.warn(
+        "E2EEService",
+        "Failed to delete decrypted-media cache directory",
+        error,
+      );
+    }
   },
 
   isEncryptedPayload(content: string): boolean {

--- a/src/services/E2EEService.ts
+++ b/src/services/E2EEService.ts
@@ -246,6 +246,41 @@ function deriveEd25519SigningKeypairFromSeed(
   return nacl.sign.keyPair.fromSeed(seed32);
 }
 
+// In-memory cache of decrypted plaintexts. Keyed on the conversation id
+// concatenated with the full ciphertext envelope — collisions are impossible
+// since nonces are random. Cleared on logout via resetPlaintextCache().
+const MAX_PLAINTEXT_CACHE = 500;
+const PLAINTEXT_CACHE = new Map<string, string>();
+
+function rememberPlaintext(key: string, value: string): void {
+  if (PLAINTEXT_CACHE.has(key)) PLAINTEXT_CACHE.delete(key);
+  PLAINTEXT_CACHE.set(key, value);
+  if (PLAINTEXT_CACHE.size <= MAX_PLAINTEXT_CACHE) return;
+  const oldestKey = PLAINTEXT_CACHE.keys().next().value;
+  if (oldestKey !== undefined) PLAINTEXT_CACHE.delete(oldestKey);
+}
+
+// FNV-1a hash for deterministic decrypted-media cache keys. Same algorithm
+// as in useResolvedMediaUrl.ts so paths stay scrutable across the codebase.
+function fnv1aHex(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+// In-memory cache of decrypted media URIs keyed on (uri + key + nonce). The
+// stored value points to a file on disk written by a previous decryption
+// pass — opening the same conversation a second time hits this map and
+// avoids the multi-hundred-ms decrypt/encode/write cycle per media bubble.
+const DECRYPTED_MEDIA_MEMORY = new Map<string, string>();
+
+const DECRYPTED_MEDIA_DIR =
+  (FileSystem.documentDirectory ?? FileSystem.cacheDirectory ?? "") +
+  "whispr-e2ee-decrypted";
+
 export const E2EEService = {
   /**
    * Drop the cached identity keypair so the next encrypt/decrypt re-reads
@@ -255,6 +290,26 @@ export const E2EEService = {
    */
   resetIdentityCache(): void {
     resetIdentityCacheInternal();
+  },
+
+  /**
+   * Wipe the decrypted-plaintext cache. Must be called on logout so a later
+   * login on the same device does not leak the previous account's messages.
+   */
+  resetPlaintextCache(): void {
+    PLAINTEXT_CACHE.clear();
+  },
+
+  /**
+   * Wipe the decrypted-media cache (memory + disk). Must be called on logout
+   * so plaintext bytes from the previous account do not survive a session
+   * change. Idempotent — safe to call even when no media has been decrypted.
+   */
+  async resetDecryptedMediaCache(): Promise<void> {
+    DECRYPTED_MEDIA_MEMORY.clear();
+    await FileSystem.deleteAsync(DECRYPTED_MEDIA_DIR, {
+      idempotent: true,
+    }).catch(() => {});
   },
 
   isEncryptedPayload(content: string): boolean {
@@ -465,6 +520,13 @@ export const E2EEService = {
     conversationId: string;
     content: string;
   }): Promise<string | null> {
+    // The ciphertext envelope is unique per encryption, so it's a safe cache
+    // key — two messages can never share the same ciphertext bytes. Caps the
+    // map at MAX_PLAINTEXT_CACHE entries to avoid unbounded growth.
+    const cacheKey = `${params.conversationId}:${params.content}`;
+    const cached = PLAINTEXT_CACHE.get(cacheKey);
+    if (cached !== undefined) return cached;
+
     const parsed = safeJsonParse(params.content);
     if (!isEnvelopeV1(parsed)) return null;
     if (parsed.conversation_id !== params.conversationId) return null;
@@ -490,7 +552,9 @@ export const E2EEService = {
     const plain = nacl.secretbox.open(msgBox, msgNonce, messageKey);
     if (!plain) return null;
 
-    return encodeUTF8(plain);
+    const result = encodeUTF8(plain);
+    rememberPlaintext(cacheKey, result);
+    return result;
   },
 
   async encryptMediaFile(uri: string): Promise<{
@@ -549,10 +613,14 @@ export const E2EEService = {
     keyB64: string,
     nonceB64: string,
   ): Promise<string> {
-    const key = fromBase64(keyB64);
-    const nonce = fromBase64(nonceB64);
+    // \x00 keeps the three parts unambiguous when hashed.
+    const cacheKey = `${uri}\x00${keyB64}\x00${nonceB64}`;
+    const cachedMem = DECRYPTED_MEDIA_MEMORY.get(cacheKey);
+    if (cachedMem) return cachedMem;
 
     if (Platform.OS === "web") {
+      const key = fromBase64(keyB64);
+      const nonce = fromBase64(nonceB64);
       const response = await fetch(uri);
       const blob = await response.blob();
       const arrayBuffer = await blob.arrayBuffer();
@@ -562,9 +630,23 @@ export const E2EEService = {
       if (!plain) throw new Error("DECRYPT_MEDIA_FAILED");
 
       const decryptedBlob = new Blob([plain as any]);
-      return URL.createObjectURL(decryptedBlob);
+      const decryptedUri = URL.createObjectURL(decryptedBlob);
+      DECRYPTED_MEDIA_MEMORY.set(cacheKey, decryptedUri);
+      return decryptedUri;
     }
 
+    await FileSystem.makeDirectoryAsync(DECRYPTED_MEDIA_DIR, {
+      intermediates: true,
+    }).catch(() => {});
+    const cachedFileUri = `${DECRYPTED_MEDIA_DIR}/${fnv1aHex(cacheKey)}`;
+    const info = await FileSystem.getInfoAsync(cachedFileUri);
+    if (info.exists) {
+      DECRYPTED_MEDIA_MEMORY.set(cacheKey, cachedFileUri);
+      return cachedFileUri;
+    }
+
+    const key = fromBase64(keyB64);
+    const nonce = fromBase64(nonceB64);
     const base64 = await FileSystem.readAsStringAsync(uri, {
       encoding: FileSystem.EncodingType.Base64,
     });
@@ -574,11 +656,10 @@ export const E2EEService = {
     if (!plain) throw new Error("DECRYPT_MEDIA_FAILED");
 
     const decryptedBase64 = toBase64(plain);
-    const decryptedUri = `${FileSystem.cacheDirectory || ""}dec-${Date.now()}`;
-    await FileSystem.writeAsStringAsync(decryptedUri, decryptedBase64, {
+    await FileSystem.writeAsStringAsync(cachedFileUri, decryptedBase64, {
       encoding: FileSystem.EncodingType.Base64,
     });
-
-    return decryptedUri;
+    DECRYPTED_MEDIA_MEMORY.set(cacheKey, cachedFileUri);
+    return cachedFileUri;
   },
 };

--- a/src/services/__tests__/E2EEService.cache.test.ts
+++ b/src/services/__tests__/E2EEService.cache.test.ts
@@ -1,0 +1,184 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// Targeted tests for the caches added in WHISPR-1555:
+//   - plaintext cache (decryptTextMessage)
+//   - decrypted-media cache (decryptMediaFile, native path)
+//   - reset hooks called from AuthService.logout
+
+// Map name must start with `mock` so jest.mock() factory closures may
+// reference it without tripping the hoist-time guard.
+const mockFsFiles = new Map<string, string>();
+
+jest.mock("expo-file-system/legacy", () => ({
+  documentDirectory: "file:///docs/",
+  cacheDirectory: "file:///cache/",
+  EncodingType: { Base64: "base64", UTF8: "utf8" },
+  makeDirectoryAsync: jest.fn(async () => {}),
+  deleteAsync: jest.fn(async (path: string) => {
+    for (const k of [...mockFsFiles.keys()]) {
+      if (k.startsWith(path)) mockFsFiles.delete(k);
+    }
+  }),
+  getInfoAsync: jest.fn(async (path: string) => ({
+    exists: mockFsFiles.has(path),
+    uri: path,
+  })),
+  readAsStringAsync: jest.fn(async (path: string) => {
+    const v = mockFsFiles.get(path);
+    if (!v) throw new Error("ENOENT");
+    return v;
+  }),
+  writeAsStringAsync: jest.fn(async (path: string, value: string) => {
+    mockFsFiles.set(path, value);
+  }),
+}));
+
+jest.mock("react-native", () => ({
+  Platform: { OS: "ios" },
+}));
+
+jest.mock("../TokenService", () => ({
+  TokenService: {
+    getIdentityPrivateKey: jest.fn(),
+    getAccessToken: jest.fn(),
+    decodeAccessToken: jest.fn(),
+  },
+}));
+
+jest.mock("../SecurityService", () => ({
+  SignalKeysService: {
+    listDevices: jest.fn(),
+    getKeyBundle: jest.fn(),
+  },
+}));
+
+import nacl from "tweetnacl";
+import { encodeBase64, decodeUTF8 } from "tweetnacl-util";
+
+import { E2EEService } from "../E2EEService";
+
+beforeEach(() => {
+  mockFsFiles.clear();
+  // Wipe both caches between tests so memoization doesn't leak.
+  E2EEService.resetPlaintextCache();
+  return E2EEService.resetDecryptedMediaCache();
+});
+
+describe("E2EEService — decrypted media cache", () => {
+  it("decryptMediaFile writes a deterministic file path and reuses it", async () => {
+    const key = nacl.randomBytes(32);
+    const nonce = nacl.randomBytes(24);
+    const plain = decodeUTF8("hello-image-bytes");
+    const cipher = nacl.secretbox(plain, nonce, key);
+
+    // Encrypted source file: the implementation reads it as base64.
+    const sourceUri = "file:///source/image.enc";
+    mockFsFiles.set(sourceUri, encodeBase64(cipher));
+
+    const first = await E2EEService.decryptMediaFile(
+      sourceUri,
+      encodeBase64(key),
+      encodeBase64(nonce),
+    );
+    expect(first).toContain("whispr-e2ee-decrypted/");
+    expect(mockFsFiles.has(first)).toBe(true);
+
+    const second = await E2EEService.decryptMediaFile(
+      sourceUri,
+      encodeBase64(key),
+      encodeBase64(nonce),
+    );
+    expect(second).toBe(first);
+  });
+
+  it("decryptMediaFile short-circuits to disk when memory is cold", async () => {
+    const key = nacl.randomBytes(32);
+    const nonce = nacl.randomBytes(24);
+    const plain = decodeUTF8("payload");
+    const cipher = nacl.secretbox(plain, nonce, key);
+
+    const sourceUri = "file:///source/x";
+    mockFsFiles.set(sourceUri, encodeBase64(cipher));
+
+    const first = await E2EEService.decryptMediaFile(
+      sourceUri,
+      encodeBase64(key),
+      encodeBase64(nonce),
+    );
+
+    // Drop the in-memory cache but keep the disk so the next call must hit
+    // getInfoAsync and short-circuit through the disk-hit path.
+    E2EEService.resetPlaintextCache();
+    // Note: resetDecryptedMediaCache wipes disk too — use a manual clear
+    // of the memory cache via a fresh call after clearing the mock state.
+    const fs = require("expo-file-system/legacy");
+    fs.readAsStringAsync.mockClear();
+    fs.writeAsStringAsync.mockClear();
+
+    const second = await E2EEService.decryptMediaFile(
+      sourceUri,
+      encodeBase64(key),
+      encodeBase64(nonce),
+    );
+    expect(second).toBe(first);
+    // No re-decrypt happened: no extra read of the encrypted source, no
+    // extra write of the plaintext.
+    expect(fs.readAsStringAsync).not.toHaveBeenCalled();
+    expect(fs.writeAsStringAsync).not.toHaveBeenCalled();
+  });
+
+  it("decryptMediaFile throws when secretbox.open fails (wrong key)", async () => {
+    const realKey = nacl.randomBytes(32);
+    const nonce = nacl.randomBytes(24);
+    const plain = decodeUTF8("payload");
+    const cipher = nacl.secretbox(plain, nonce, realKey);
+
+    const sourceUri = "file:///source/wrong-key";
+    mockFsFiles.set(sourceUri, encodeBase64(cipher));
+
+    const otherKey = nacl.randomBytes(32);
+    await expect(
+      E2EEService.decryptMediaFile(
+        sourceUri,
+        encodeBase64(otherKey),
+        encodeBase64(nonce),
+      ),
+    ).rejects.toThrow("DECRYPT_MEDIA_FAILED");
+  });
+
+  it("resetDecryptedMediaCache clears both memory and disk", async () => {
+    const key = nacl.randomBytes(32);
+    const nonce = nacl.randomBytes(24);
+    const plain = decodeUTF8("bytes");
+    const cipher = nacl.secretbox(plain, nonce, key);
+
+    const sourceUri = "file:///source/clearme";
+    mockFsFiles.set(sourceUri, encodeBase64(cipher));
+
+    const decrypted = await E2EEService.decryptMediaFile(
+      sourceUri,
+      encodeBase64(key),
+      encodeBase64(nonce),
+    );
+    expect(mockFsFiles.has(decrypted)).toBe(true);
+
+    await E2EEService.resetDecryptedMediaCache();
+    expect(mockFsFiles.has(decrypted)).toBe(false);
+  });
+
+  it("resetDecryptedMediaCache surfaces a warning when deleteAsync rejects", async () => {
+    const fs = require("expo-file-system/legacy");
+    fs.deleteAsync.mockRejectedValueOnce(new Error("EACCES"));
+    // The method itself must not throw — it logs and resolves.
+    await expect(
+      E2EEService.resetDecryptedMediaCache(),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("E2EEService — plaintext cache helpers", () => {
+  it("resetPlaintextCache is idempotent and synchronous", () => {
+    expect(() => E2EEService.resetPlaintextCache()).not.toThrow();
+    expect(() => E2EEService.resetPlaintextCache()).not.toThrow();
+  });
+});

--- a/src/services/calls/liveKitProvider.ts
+++ b/src/services/calls/liveKitProvider.ts
@@ -14,6 +14,10 @@ export class CallsLiveKit {
   private room: Room | null = null;
 
   async connect(config: LiveKitConfig): Promise<Room> {
+    // Logs explicites pour debug DevTools sur web PWA : sans visibilite cote
+    // user, room.connect() echoue en silence et l'UI reste coincee.
+    // eslint-disable-next-line no-console
+    console.debug("[LiveKit] connecting to", config.url);
     this.room = new Room({
       adaptiveStream: true,
       dynacast: true,
@@ -21,7 +25,29 @@ export class CallsLiveKit {
         resolution: { width: 640, height: 480, frameRate: 24 },
       },
     });
-    await this.room.connect(config.url, config.token);
+    try {
+      await this.room.connect(config.url, config.token);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("[LiveKit] room.connect failed", {
+        url: config.url,
+        name: (err as { name?: string })?.name,
+        message: (err as Error)?.message,
+        stack: (err as Error)?.stack,
+      });
+      // Re-throw : on enrichit avec le name pour que callsStore tagge le toast
+      // (NotAllowedError / ConnectionError / etc.).
+      const original = err as Error & { name?: string };
+      const enriched = new Error(
+        original.name && original.name !== "Error"
+          ? `${original.name}: ${original.message}`
+          : original.message,
+      );
+      (enriched as Error & { cause?: unknown }).cause = err;
+      throw enriched;
+    }
+    // eslint-disable-next-line no-console
+    console.debug("[LiveKit] connected, room state:", this.room.state);
     return this.room;
   }
 

--- a/src/services/groups/__tests__/api.test.ts
+++ b/src/services/groups/__tests__/api.test.ts
@@ -537,17 +537,40 @@ describe("groupsAPI.updateGroupSettings", () => {
     );
   });
 
-  it("throws when neither externalGroupId nor by-conversation returns a group", async () => {
-    // 1st call: conversation → no externalGroupId
+  it("falls back to PUT conversation metadata when neither externalGroupId nor by-conversation returns a group", async () => {
+    // 1st call: conversation → no externalGroupId, no existing metadata
     mockFetch.mockResolvedValueOnce(
       mockResponse({ body: { data: { id: "grp-1" } } }),
     );
     // 2nd call: by-conversation 404
     mockFetch.mockResolvedValueOnce(mockResponse({ status: 404 }));
+    // 3rd call: PUT conversation metadata
+    mockFetch.mockResolvedValueOnce(mockResponse({ body: { id: "grp-1" } }));
 
-    await expect(groupsAPI.updateGroupSettings("grp-1", {})).rejects.toThrow(
-      "Groupe non trouvé (identifiant introuvable)",
+    const result = await groupsAPI.updateGroupSettings("grp-1", {
+      message_permission: "admins_only",
+    });
+
+    const putCall = mockFetch.mock.calls[2];
+    expect(putCall[0]).toBe(`${MSG_BASE}/conversations/grp-1`);
+    expect(putCall[1].method).toBe("PUT");
+    const body = JSON.parse(putCall[1].body);
+    expect(body.metadata.group_settings.message_permission).toBe("admins_only");
+    expect(result.message_permission).toBe("admins_only");
+  });
+
+  it("throws when the metadata PUT fails", async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ body: { data: { id: "grp-1" } } }),
     );
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 404 }));
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 500 }));
+
+    await expect(
+      groupsAPI.updateGroupSettings("grp-1", {
+        message_permission: "admins_only",
+      }),
+    ).rejects.toThrow(/Impossible de mettre a jour les parametres \(500\)/);
   });
 
   it("throws when the PATCH fails", async () => {

--- a/src/services/groups/__tests__/api.test.ts
+++ b/src/services/groups/__tests__/api.test.ts
@@ -413,12 +413,16 @@ describe("groupsAPI.getGroupSettings", () => {
     expect(settings.moderation_level).toBe("strict");
   });
 
-  it("falls back to groupId when conversation has no externalGroupId", async () => {
+  it("uses by-conversation lookup when externalGroupId is not set", async () => {
     // 1st call: conversation with no externalGroupId
     mockFetch.mockResolvedValueOnce(
       mockResponse({ body: { data: { id: "grp-1" } } }),
     );
-    // 2nd call: settings
+    // 2nd call: by-conversation endpoint returns the group
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ body: { id: "grp-1", name: "Test Group" } }),
+    );
+    // 3rd call: settings
     mockFetch.mockResolvedValueOnce(
       mockResponse({ body: { message_permission: "all_members" } }),
     );
@@ -426,16 +430,39 @@ describe("groupsAPI.getGroupSettings", () => {
     await groupsAPI.getGroupSettings("grp-1");
 
     expect(mockFetch.mock.calls[1][0]).toBe(
+      `${USER_BASE}/groups/by-conversation/grp-1`,
+    );
+    expect(mockFetch.mock.calls[2][0]).toBe(
       `${USER_BASE}/groups/grp-1/settings`,
     );
   });
 
-  it("returns defaults when the settings endpoint returns a non-OK status", async () => {
-    // conversation fetch
+  it("returns defaults when neither externalGroupId nor by-conversation returns an ID", async () => {
+    // 1st call: conversation with no externalGroupId
     mockFetch.mockResolvedValueOnce(
       mockResponse({ body: { data: { id: "grp-1" } } }),
     );
-    // settings 404
+    // 2nd call: by-conversation 404
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 404 }));
+
+    const settings = await groupsAPI.getGroupSettings("grp-1");
+    expect(settings).toEqual({
+      message_permission: "all_members",
+      media_permission: "all_members",
+      mention_permission: "all_members",
+      add_members_permission: "admins_only",
+      moderation_level: "light",
+      content_filter_enabled: false,
+      join_approval_required: false,
+    });
+  });
+
+  it("returns defaults when the settings endpoint returns a non-OK status", async () => {
+    // 1st call: conversation → externalGroupId provided
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ body: { data: { externalGroupId: "real-uuid" } } }),
+    );
+    // 2nd call: settings 404
     mockFetch.mockResolvedValueOnce(mockResponse({ status: 404 }));
 
     const settings = await groupsAPI.getGroupSettings("grp-1");
@@ -489,18 +516,37 @@ describe("groupsAPI.updateGroupSettings", () => {
     expect(result.message_permission).toBe("admins_only");
   });
 
-  it("falls back to groupId when conversation has no externalGroupId", async () => {
+  it("uses by-conversation lookup when externalGroupId is not set", async () => {
+    // 1st call: conversation → no externalGroupId
     mockFetch.mockResolvedValueOnce(
       mockResponse({ body: { data: { id: "grp-1" } } }),
     );
+    // 2nd call: by-conversation → group found
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ body: { id: "grp-1", name: "Test Group" } }),
+    );
+    // 3rd call: PATCH settings
     mockFetch.mockResolvedValueOnce(
       mockResponse({ body: { message_permission: "all_members" } }),
     );
 
     await groupsAPI.updateGroupSettings("grp-1", {});
 
-    expect(mockFetch.mock.calls[1][0]).toBe(
+    expect(mockFetch.mock.calls[2][0]).toBe(
       `${USER_BASE}/groups/grp-1/settings`,
+    );
+  });
+
+  it("throws when neither externalGroupId nor by-conversation returns a group", async () => {
+    // 1st call: conversation → no externalGroupId
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ body: { data: { id: "grp-1" } } }),
+    );
+    // 2nd call: by-conversation 404
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 404 }));
+
+    await expect(groupsAPI.updateGroupSettings("grp-1", {})).rejects.toThrow(
+      "Groupe non trouvé (identifiant introuvable)",
     );
   });
 

--- a/src/services/groups/api.ts
+++ b/src/services/groups/api.ts
@@ -284,6 +284,21 @@ function membersFromConversationPayload(conv: any): RawConversationMember[] {
   return conv.members as RawConversationMember[];
 }
 
+async function resolveUserServiceGroupId(
+  conversationId: string,
+  headers: Record<string, string>,
+  externalGroupId?: string | null,
+): Promise<string | null> {
+  if (externalGroupId) return externalGroupId;
+  const res = await fetch(
+    `${API_BASE_URL}/groups/by-conversation/${encodeURIComponent(conversationId)}`,
+    { headers },
+  ).catch(() => null);
+  if (!res?.ok) return null;
+  const group = await res.json().catch(() => null);
+  return group?.id ?? null;
+}
+
 const DEFAULT_GROUP_SETTINGS: GroupSettings = {
   message_permission: "all_members",
   media_permission: "all_members",
@@ -800,16 +815,35 @@ export const groupsAPI = {
 
   async getGroupLogs(
     groupId: string,
-    params?: { page?: number; limit?: number; actionType?: string },
+    params?: {
+      page?: number;
+      limit?: number;
+      actionType?: string;
+      conversationId?: string;
+    },
   ): Promise<{ logs: GroupLog[]; total: number }> {
     const headers = await getAuthHeaders();
+    let resolvedGroupId = groupId;
+    if (params?.conversationId) {
+      const conv = await fetchMessagingConversationPayload(
+        params.conversationId,
+        headers,
+      );
+      const externalId = conv?.externalGroupId || conv?.external_group_id;
+      resolvedGroupId =
+        (await resolveUserServiceGroupId(
+          params.conversationId,
+          headers,
+          externalId,
+        )) || groupId;
+    }
     const query = new URLSearchParams();
     if (params?.page) query.set("page", String(params.page));
     if (params?.limit) query.set("limit", String(params.limit));
     if (params?.actionType) query.set("actionType", params.actionType);
     const qs = query.toString();
     const res = await fetch(
-      `${API_BASE_URL}/groups/${encodeURIComponent(groupId)}/logs${qs ? `?${qs}` : ""}`,
+      `${API_BASE_URL}/groups/${encodeURIComponent(resolvedGroupId)}/logs${qs ? `?${qs}` : ""}`,
       { headers },
     );
     if (!res.ok) {
@@ -828,8 +862,15 @@ export const groupsAPI = {
     const headers = await getAuthHeaders();
     const convId = params?.conversationId || groupId;
     const conv = await fetchMessagingConversationPayload(convId, headers);
-    const userServiceGroupId =
-      conv?.externalGroupId || conv?.external_group_id || groupId;
+    const externalId = conv?.externalGroupId || conv?.external_group_id;
+    const userServiceGroupId = await resolveUserServiceGroupId(
+      convId,
+      headers,
+      externalId,
+    );
+    if (!userServiceGroupId) {
+      return { ...DEFAULT_GROUP_SETTINGS };
+    }
     const res = await fetch(
       `${API_BASE_URL}/groups/${encodeURIComponent(userServiceGroupId)}/settings`,
       { headers },
@@ -848,8 +889,15 @@ export const groupsAPI = {
     const headers = await getAuthHeaders();
     const convId = params?.conversationId || groupId;
     const conv = await fetchMessagingConversationPayload(convId, headers);
-    const userServiceGroupId =
-      conv?.externalGroupId || conv?.external_group_id || groupId;
+    const externalId = conv?.externalGroupId || conv?.external_group_id;
+    const userServiceGroupId = await resolveUserServiceGroupId(
+      convId,
+      headers,
+      externalId,
+    );
+    if (!userServiceGroupId) {
+      throw new Error("Groupe non trouvé (identifiant introuvable)");
+    }
     const res = await fetch(
       `${API_BASE_URL}/groups/${encodeURIComponent(userServiceGroupId)}/settings`,
       {

--- a/src/services/groups/api.ts
+++ b/src/services/groups/api.ts
@@ -869,7 +869,7 @@ export const groupsAPI = {
       externalId,
     );
     if (!userServiceGroupId) {
-      return { ...DEFAULT_GROUP_SETTINGS };
+      return extractGroupSettingsFromConversation(conv);
     }
     const res = await fetch(
       `${API_BASE_URL}/groups/${encodeURIComponent(userServiceGroupId)}/settings`,
@@ -896,7 +896,29 @@ export const groupsAPI = {
       externalId,
     );
     if (!userServiceGroupId) {
-      throw new Error("Groupe non trouvé (identifiant introuvable)");
+      const currentMeta =
+        conv?.metadata && typeof conv.metadata === "object"
+          ? (conv.metadata as Record<string, unknown>)
+          : {};
+      const currentSettings = extractGroupSettingsFromConversation(conv);
+      const nextSettings: GroupSettings = { ...currentSettings, ...updates };
+      const res = await fetch(
+        `${MESSAGING_API_URL}/conversations/${encodeURIComponent(convId)}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json", ...headers },
+          body: JSON.stringify({
+            metadata: { ...currentMeta, group_settings: nextSettings },
+          }),
+        },
+      );
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(
+          `Impossible de mettre a jour les parametres (${res.status})${text ? `: ${text}` : ""}`,
+        );
+      }
+      return nextSettings;
     }
     const res = await fetch(
       `${API_BASE_URL}/groups/${encodeURIComponent(userServiceGroupId)}/settings`,

--- a/src/services/linkPreview.ts
+++ b/src/services/linkPreview.ts
@@ -53,8 +53,9 @@ export function extractFirstUrl(text?: string | null): string | null {
 }
 
 function decodeHtmlEntities(value: string): string {
+  // decoder &amp; en dernier evite le double-unescape:
+  // sinon "&amp;lt;" deviendrait "<" au lieu de "&lt;"
   return value
-    .replace(/&amp;/gi, "&")
     .replace(/&quot;/gi, '"')
     .replace(/&#39;/gi, "'")
     .replace(/&apos;/gi, "'")
@@ -65,7 +66,8 @@ function decodeHtmlEntities(value: string): string {
     )
     .replace(/&#x([0-9a-f]+);/gi, (_, code: string) =>
       String.fromCharCode(parseInt(code, 16)),
-    );
+    )
+    .replace(/&amp;/gi, "&");
 }
 
 function compactWhitespace(

--- a/src/services/messaging/__tests__/messagingCache.test.ts
+++ b/src/services/messaging/__tests__/messagingCache.test.ts
@@ -10,10 +10,28 @@ jest.mock("@react-native-async-storage/async-storage", () => ({
   removeItem: jest.fn(async (key: string) => {
     delete storage[key];
   }),
+  multiRemove: jest.fn(async (keys: string[]) => {
+    for (const k of keys) delete storage[k];
+  }),
+  getAllKeys: jest.fn(async () => Object.keys(storage)),
 }));
 
 import { cacheService } from "../cache";
-import type { Conversation } from "../../../types/messaging";
+import type {
+  Conversation,
+  MessageWithRelations,
+} from "../../../types/messaging";
+
+const makeMessage = (id: string): MessageWithRelations =>
+  ({
+    id,
+    conversation_id: "conv-1",
+    sender_id: "u-1",
+    content: `Hello ${id}`,
+    message_type: "text",
+    sent_at: "2026-01-01T00:00:00Z",
+    status: "sent",
+  }) as unknown as MessageWithRelations;
 
 const makeConversation = (id: string): Conversation =>
   ({
@@ -85,5 +103,119 @@ describe("cacheService.clearCache", () => {
 
     expect(storage["whispr.conversations.cache"]).toBeUndefined();
     expect(storage["whispr.conversations.cache.timestamp"]).toBeUndefined();
+  });
+});
+
+describe("cacheService — messages", () => {
+  beforeEach(async () => {
+    // Drop the in-memory mirror so tests don't bleed into each other.
+    await cacheService.clearAllMessages();
+    for (const k of Object.keys(storage)) delete storage[k];
+  });
+
+  it("getMessagesSync returns null before anything is saved", () => {
+    expect(cacheService.getMessagesSync("conv-1")).toBeNull();
+  });
+
+  it("getMessagesSync returns the in-memory mirror after saveMessages", async () => {
+    const messages = [makeMessage("m-1"), makeMessage("m-2")];
+    await cacheService.saveMessages("conv-1", messages);
+
+    const sync = cacheService.getMessagesSync("conv-1");
+    expect(sync).toHaveLength(2);
+    expect(sync?.[0].id).toBe("m-1");
+  });
+
+  it("saveMessages writes to AsyncStorage with a timestamp", async () => {
+    await cacheService.saveMessages("conv-1", [makeMessage("m-1")]);
+
+    const data = storage["whispr.messages.cache.conv-1"];
+    expect(JSON.parse(data)).toHaveLength(1);
+    expect(
+      Number(storage["whispr.messages.cache.timestamp.conv-1"]),
+    ).toBeLessThanOrEqual(Date.now());
+  });
+
+  it("saveMessages refuses non-array input", async () => {
+    await cacheService.saveMessages(
+      "conv-1",
+      null as unknown as MessageWithRelations[],
+    );
+    expect(storage["whispr.messages.cache.conv-1"]).toBe("[]");
+  });
+
+  it("saveMessages is a noop when conversationId is empty", async () => {
+    await cacheService.saveMessages("", [makeMessage("m-1")]);
+    expect(Object.keys(storage)).toHaveLength(0);
+  });
+
+  it("getMessagesSync is a noop when conversationId is empty", () => {
+    expect(cacheService.getMessagesSync("")).toBeNull();
+  });
+
+  it("getMessages returns null when nothing has been cached", async () => {
+    await expect(cacheService.getMessages("conv-1")).resolves.toBeNull();
+  });
+
+  it("getMessages parses the cached payload and refills the memory mirror", async () => {
+    await cacheService.saveMessages("conv-1", [makeMessage("m-1")]);
+    // Drop the in-memory mirror but keep AsyncStorage to simulate a cold
+    // session: getMessages should rehydrate the mirror from disk.
+    (cacheService as any).clearAllMessages.length; // sanity reference
+    // Use a fresh import surface — simulate restart by deleting the mirror
+    // through clearMessages then re-reading from disk.
+    const fromDisk = await cacheService.getMessages("conv-1");
+    expect(fromDisk).toHaveLength(1);
+    expect(fromDisk?.[0].id).toBe("m-1");
+    // After getMessages, getMessagesSync must hit the mirror.
+    expect(cacheService.getMessagesSync("conv-1")).toHaveLength(1);
+  });
+
+  it("getMessages returns null when the cache is older than the TTL", async () => {
+    await cacheService.saveMessages("conv-1", [makeMessage("m-1")]);
+    // MESSAGES_CACHE_TTL is 1h
+    storage["whispr.messages.cache.timestamp.conv-1"] = String(
+      Date.now() - 2 * 60 * 60 * 1000,
+    );
+
+    await expect(cacheService.getMessages("conv-1")).resolves.toBeNull();
+  });
+
+  it("getMessages returns null when the JSON is malformed", async () => {
+    storage["whispr.messages.cache.conv-1"] = "not-valid";
+    storage["whispr.messages.cache.timestamp.conv-1"] = String(Date.now());
+    await expect(cacheService.getMessages("conv-1")).resolves.toBeNull();
+  });
+
+  it("getMessages returns null when conversationId is empty", async () => {
+    await expect(cacheService.getMessages("")).resolves.toBeNull();
+  });
+
+  it("clearMessages wipes both storage keys and the memory mirror", async () => {
+    await cacheService.saveMessages("conv-1", [makeMessage("m-1")]);
+    await cacheService.clearMessages("conv-1");
+
+    expect(storage["whispr.messages.cache.conv-1"]).toBeUndefined();
+    expect(storage["whispr.messages.cache.timestamp.conv-1"]).toBeUndefined();
+    expect(cacheService.getMessagesSync("conv-1")).toBeNull();
+  });
+
+  it("clearMessages is a noop when conversationId is empty", async () => {
+    await cacheService.saveMessages("conv-1", [makeMessage("m-1")]);
+    await cacheService.clearMessages("");
+    // The entry must still be there.
+    expect(cacheService.getMessagesSync("conv-1")).toHaveLength(1);
+  });
+
+  it("clearAllMessages wipes every conversation entry from memory and disk", async () => {
+    await cacheService.saveMessages("conv-1", [makeMessage("m-1")]);
+    await cacheService.saveMessages("conv-2", [makeMessage("m-2")]);
+
+    await cacheService.clearAllMessages();
+
+    expect(cacheService.getMessagesSync("conv-1")).toBeNull();
+    expect(cacheService.getMessagesSync("conv-2")).toBeNull();
+    expect(storage["whispr.messages.cache.conv-1"]).toBeUndefined();
+    expect(storage["whispr.messages.cache.conv-2"]).toBeUndefined();
   });
 });

--- a/src/services/messaging/__tests__/typingIndicatorPref.test.ts
+++ b/src/services/messaging/__tests__/typingIndicatorPref.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests pour typingIndicatorPref - cache local du toggle indicateur de saisie.
+ *
+ * Note : AsyncStorage est mappe sur le mock officiel dans la config Jest
+ * (moduleNameMapper). On manipule donc ce mock directement plutot que de
+ * le re-mock localement.
+ */
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+import {
+  hydrateTypingIndicatorPref,
+  getTypingIndicatorEnabled,
+  setTypingIndicatorEnabled,
+  isTypingIndicatorPrefHydrated,
+  __resetTypingIndicatorPrefForTests,
+} from "../typingIndicatorPref";
+
+const STORAGE_KEY = "@whispr_settings_messaging";
+
+beforeEach(async () => {
+  __resetTypingIndicatorPrefForTests();
+  await AsyncStorage.clear();
+});
+
+describe("typingIndicatorPref", () => {
+  it("retourne true par defaut quand AsyncStorage est vide", async () => {
+    const value = await hydrateTypingIndicatorPref();
+    expect(value).toBe(true);
+    expect(getTypingIndicatorEnabled()).toBe(true);
+    expect(isTypingIndicatorPrefHydrated()).toBe(true);
+  });
+
+  it("hydrate la valeur depuis le JSON stocke", async () => {
+    await AsyncStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ typingIndicator: false }),
+    );
+    const value = await hydrateTypingIndicatorPref();
+    expect(value).toBe(false);
+    expect(getTypingIndicatorEnabled()).toBe(false);
+  });
+
+  it("ignore les payloads sans champ typingIndicator boolean", async () => {
+    await AsyncStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ readReceipts: false }),
+    );
+    const value = await hydrateTypingIndicatorPref();
+    expect(value).toBe(true);
+  });
+
+  it("garde le defaut true si AsyncStorage throw", async () => {
+    const original = AsyncStorage.getItem;
+    (AsyncStorage as { getItem: jest.Mock }).getItem = jest
+      .fn()
+      .mockRejectedValue(new Error("boom"));
+    try {
+      const value = await hydrateTypingIndicatorPref();
+      expect(value).toBe(true);
+    } finally {
+      (AsyncStorage as { getItem: typeof original }).getItem = original;
+    }
+  });
+
+  it("setTypingIndicatorEnabled met a jour le mirror immediatement", () => {
+    setTypingIndicatorEnabled(false);
+    expect(getTypingIndicatorEnabled()).toBe(false);
+    setTypingIndicatorEnabled(true);
+    expect(getTypingIndicatorEnabled()).toBe(true);
+  });
+});

--- a/src/services/messaging/cache.ts
+++ b/src/services/messaging/cache.ts
@@ -29,6 +29,12 @@ function messagesTimestampKey(conversationId: string): string {
   return `${MESSAGES_CACHE_TIMESTAMP_PREFIX}${normalizeKeyPart(conversationId)}`;
 }
 
+// Synchronous in-memory mirror of the messages cache. Lets the chat screen
+// hydrate its initial state without waiting on AsyncStorage, which on iOS
+// can take >100ms for non-trivial payloads and lose the race against the
+// API/decrypt path.
+const MESSAGES_MEMORY_CACHE = new Map<string, MessageWithRelations[]>();
+
 export const cacheService = {
   /**
    * Save conversations to cache with timestamp
@@ -94,6 +100,7 @@ export const cacheService = {
             .filter((m) => m && typeof m.id === "string")
             .slice(0, MESSAGES_CACHE_MAX)
         : [];
+      MESSAGES_MEMORY_CACHE.set(conversationId, trimmed);
       await AsyncStorage.setItem(
         messagesKey(conversationId),
         JSON.stringify(trimmed),
@@ -105,6 +112,16 @@ export const cacheService = {
     } catch (error) {
       console.error("Error saving messages cache:", error);
     }
+  },
+
+  /**
+   * Synchronous read from the in-memory mirror. Returns the most recent
+   * messages saved during this session, or null if nothing was cached yet.
+   * Use this to seed the initial state of a screen without awaiting disk.
+   */
+  getMessagesSync(conversationId: string): MessageWithRelations[] | null {
+    if (!conversationId) return null;
+    return MESSAGES_MEMORY_CACHE.get(conversationId) ?? null;
   },
 
   async getMessages(
@@ -127,7 +144,9 @@ export const cacheService = {
       }
 
       const parsed = JSON.parse(data) as MessageWithRelations[];
-      return Array.isArray(parsed) ? parsed : null;
+      if (!Array.isArray(parsed)) return null;
+      MESSAGES_MEMORY_CACHE.set(conversationId, parsed);
+      return parsed;
     } catch (error) {
       console.error("Error reading messages cache:", error);
       return null;
@@ -137,6 +156,7 @@ export const cacheService = {
   async clearMessages(conversationId: string): Promise<void> {
     try {
       if (!conversationId) return;
+      MESSAGES_MEMORY_CACHE.delete(conversationId);
       await Promise.all([
         AsyncStorage.removeItem(messagesKey(conversationId)),
         AsyncStorage.removeItem(messagesTimestampKey(conversationId)),
@@ -148,6 +168,7 @@ export const cacheService = {
 
   async clearAllMessages(): Promise<void> {
     try {
+      MESSAGES_MEMORY_CACHE.clear();
       const keys = await AsyncStorage.getAllKeys();
       const targets = keys.filter(
         (k) =>

--- a/src/services/messaging/typingIndicatorPref.ts
+++ b/src/services/messaging/typingIndicatorPref.ts
@@ -1,0 +1,80 @@
+/**
+ * typingIndicatorPref - Cache local du toggle "Indicateur de saisie"
+ *
+ * Meme pattern que readReceiptsPref : le toggle vit dans AsyncStorage
+ * sous la cle @whispr_settings_messaging. On garde un mirror memoire
+ * hydrate au boot via hydrateTypingIndicatorPref() pour eviter une
+ * lecture asynchrone a chaque event de frappe.
+ *
+ * Symetrie WhatsApp : si OFF -> on n'emet pas `user_typing: true` aux
+ * autres. On laisse en revanche passer `user_typing: false` (stop) pour
+ * que le destinataire qui voyait deja "en train d'ecrire" arrete de le
+ * voir immediatement, et qu'il n'y ait pas de fantome typing apres avoir
+ * coupe le toggle.
+ *
+ * Note importante : pas d'equivalent server-side aujourd'hui dans le DTO
+ * privacy de user-service (cf. UserServiceBehaviour.get_privacy_settings/1
+ * qui ne connait que read_receipts / last_seen_privacy / online_status).
+ * Le gating est donc client-only, mais le toggle prend effet
+ * immediatement parce que sendTyping lit ce mirror via getState() a
+ * chaque appel.
+ */
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const STORAGE_KEY = "@whispr_settings_messaging";
+
+// par defaut on respecte l'ancien comportement : indicateurs actives
+let cached: boolean = true;
+let hydrated = false;
+
+/**
+ * Lit la preference depuis AsyncStorage et met a jour le mirror memoire.
+ * A appeler au boot (App.tsx) et avant tout consumer qui veut etre sur
+ * d'avoir la valeur courante.
+ */
+export async function hydrateTypingIndicatorPref(): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (typeof parsed?.typingIndicator === "boolean") {
+        cached = parsed.typingIndicator;
+      }
+    }
+  } catch {
+    // si AsyncStorage casse, on garde la valeur par defaut (true)
+  }
+  hydrated = true;
+  return cached;
+}
+
+/**
+ * Lecture synchrone du mirror memoire. Si pas hydrate -> defaut true.
+ */
+export function getTypingIndicatorEnabled(): boolean {
+  return cached;
+}
+
+/**
+ * Mise a jour synchrone du mirror (appelee depuis SettingsScreen quand
+ * le user toggle, avant meme le persist async).
+ */
+export function setTypingIndicatorEnabled(value: boolean): void {
+  cached = value;
+  hydrated = true;
+}
+
+/**
+ * Helper test-only : reset l'etat module pour repartir d'un cache vierge.
+ */
+export function __resetTypingIndicatorPrefForTests(): void {
+  cached = true;
+  hydrated = false;
+}
+
+/**
+ * Indique si la preference a deja ete chargee. Utile pour les tests.
+ */
+export function isTypingIndicatorPrefHydrated(): boolean {
+  return hydrated;
+}

--- a/src/store/__tests__/callsStore.test.ts
+++ b/src/store/__tests__/callsStore.test.ts
@@ -160,6 +160,38 @@ describe("callsStore — track publish on connect", () => {
     );
   });
 
+  // WHISPR-1200 (web) — initiate() doit aussi tagguer ses echecs pour que
+  // ChatScreen affiche la vraie cause au lieu d'un toast generique.
+  it("tags initiate-api errors so the UI can surface them (WHISPR-1200)", async () => {
+    const callsApi = require("../../services/calls/callsApi").callsApi as {
+      initiate: jest.Mock;
+    };
+    callsApi.initiate.mockRejectedValueOnce(new Error("500 server error"));
+
+    await expect(
+      useCallsStore.getState().initiate("conv-1", "audio", ["u2"]),
+    ).rejects.toThrow(/^initiate-api: /);
+  });
+
+  it("tags livekit-connect errors on initiate so the UI can surface them (WHISPR-1200)", async () => {
+    const callsApi = require("../../services/calls/callsApi").callsApi as {
+      initiate: jest.Mock;
+    };
+    callsApi.initiate.mockResolvedValueOnce({
+      call_id: "c1",
+      status: "ringing",
+      livekit_url: "wss://lk",
+      livekit_token: "tok",
+    });
+    mockProvider.connect.mockRejectedValueOnce(
+      new Error("ConnectionError: ws closed"),
+    );
+
+    await expect(
+      useCallsStore.getState().initiate("conv-1", "audio", ["u2"]),
+    ).rejects.toThrow(/^livekit-connect: /);
+  });
+
   // WHISPR-1198 — reset() est appelé par AuthContext.signOut pour empêcher
   // les fuites d'état d'appel entre deux comptes successifs sur le device.
   describe("reset (WHISPR-1198)", () => {

--- a/src/store/callsStore.ts
+++ b/src/store/callsStore.ts
@@ -77,15 +77,33 @@ export const useCallsStore = create<CallsState>((set, get) => ({
     // pour éviter une NotAllowedError après que la room LiveKit est créée.
     const perm = await requestWebMediaPermissions(type === "video");
     if (!perm.granted) {
-      throw new Error(perm.message ?? "Permission refusée");
+      const message = perm.message ?? "Permission refusée";
+      console.error("[Calls] initiate-permissions failed:", message);
+      throw new Error(`initiate-permissions: ${message}`);
     }
 
-    const resp = await callsApi.initiate(conversationId, type, participants);
+    // WHISPR-1200 : tagging par etape pour que l'UI puisse afficher la vraie
+    // cause (API down, LiveKit injoignable, WebRTC bloque) au lieu d'un
+    // message generique du genre "verifiez votre connexion".
+    let resp;
+    try {
+      resp = await callsApi.initiate(conversationId, type, participants);
+    } catch (err) {
+      console.error("[Calls] initiate-api failed:", err);
+      throw new Error(`initiate-api: ${(err as Error).message}`);
+    }
+
     const provider = getCallsLiveKit();
-    const room = await provider.connect({
-      url: resp.livekit_url,
-      token: resp.livekit_token,
-    });
+    let room;
+    try {
+      room = await provider.connect({
+        url: resp.livekit_url,
+        token: resp.livekit_token,
+      });
+    } catch (err) {
+      console.error("[Calls] livekit-connect failed:", err);
+      throw new Error(`livekit-connect: ${(err as Error).message}`);
+    }
     // Publish local tracks immediately so mute/flip/camera controls have
     // something to act on. Without this, setMicrophoneEnabled(false) is a
     // no-op (no published track) and the user thinks the button is broken.
@@ -97,7 +115,7 @@ export const useCallsStore = create<CallsState>((set, get) => ({
     } catch (err) {
       // Permission denied or device unavailable — keep the call going so the
       // user still sees the UI, the controls will toggle on retry.
-      console.warn("Failed to publish local tracks", err);
+      console.warn("[Calls] failed to publish local tracks", err);
     }
     set({
       active: {
@@ -121,9 +139,9 @@ export const useCallsStore = create<CallsState>((set, get) => ({
     // incohérent (call accepté côté serveur mais WebRTC bloqué navigateur).
     const perm = await requestWebMediaPermissions(inc.type === "video");
     if (!perm.granted) {
-      throw new Error(
-        `accept-permissions: ${perm.message ?? "Permission refusée"}`,
-      );
+      const message = perm.message ?? "Permission refusée";
+      console.error("[Calls] accept-permissions failed:", message);
+      throw new Error(`accept-permissions: ${message}`);
     }
 
     // WHISPR-1200 : on tague chaque étape pour que la couche UI puisse
@@ -133,6 +151,7 @@ export const useCallsStore = create<CallsState>((set, get) => ({
     try {
       resp = await callsApi.accept(inc.callId);
     } catch (err) {
+      console.error("[Calls] accept-api failed:", err);
       throw new Error(`accept-api: ${(err as Error).message}`);
     }
     const provider = getCallsLiveKit();
@@ -143,6 +162,7 @@ export const useCallsStore = create<CallsState>((set, get) => ({
         token: resp.livekit_token,
       });
     } catch (err) {
+      console.error("[Calls] livekit-connect failed:", err);
       throw new Error(`livekit-connect: ${(err as Error).message}`);
     }
     try {
@@ -151,7 +171,7 @@ export const useCallsStore = create<CallsState>((set, get) => ({
         await provider.enableCamera(true);
       }
     } catch (err) {
-      console.warn("Failed to publish local tracks", err);
+      console.warn("[Calls] failed to publish local tracks", err);
     }
     set({
       active: {

--- a/src/utils/conversationPreview.ts
+++ b/src/utils/conversationPreview.ts
@@ -78,6 +78,11 @@ function buildMessageBody(message: Message): string {
     return "Message chiffré";
   }
 
+  // les pieces jointes E2EE arrivent avec un envelope JSON dans content, ne pas le leak
+  if (message.message_type === "media" && isE2EEEnvelopeV1(message.content)) {
+    return "Pièce jointe chiffrée";
+  }
+
   const text = compactWhitespace(message.content);
   const linkPreview = normalizeLinkPreview(
     ((message.metadata ?? {}) as { link_preview?: Record<string, unknown> })

--- a/src/utils/imageCompression.ts
+++ b/src/utils/imageCompression.ts
@@ -102,10 +102,14 @@ export interface CompressionOptions {
   compress?: number;
 }
 
-const DEFAULT_MAX_WIDTH = 1920;
-const DEFAULT_MAX_HEIGHT = 1920;
-const DEFAULT_QUALITY = 0.8;
-const DEFAULT_COMPRESS = 0.7;
+// Bornes relevees temporairement pour la periode de demo : on accepte
+// des images plus grandes et moins compressees pour les captures de
+// presentation. Valeurs d'origine : max 1920px, compress 0.7, quality 0.8.
+// A remettre apres la demo si la conso MinIO devient un sujet.
+const DEFAULT_MAX_WIDTH = 3840;
+const DEFAULT_MAX_HEIGHT = 3840;
+const DEFAULT_QUALITY = 0.95;
+const DEFAULT_COMPRESS = 0.92;
 
 function getImageSize(uri: string): Promise<{ width: number; height: number }> {
   return new Promise((resolve, reject) => {

--- a/src/utils/videoPoster.ts
+++ b/src/utils/videoPoster.ts
@@ -1,0 +1,94 @@
+/**
+ * Video poster extraction
+ *
+ * WHISPR-fix-video-preview-hevc-ios : iOS enregistre les vidéos en HEVC/H.265
+ * `.mov`. Une fois déchiffrées côté client (blob: URI), AVPlayerItem échoue
+ * avec `-11828` (AVErrorFileFormatNotRecognized) quand on essaye de les
+ * utiliser en thumbnail dans la liste de conv. Pour éviter ça, on extrait
+ * un poster JPEG du premier frame côté émetteur, AVANT chiffrement et
+ * upload, et on le stocke comme thumbnail séparé (chiffré séparément aussi
+ * en E2EE).
+ *
+ * Pendant les tests Jest, `expo-video-thumbnails` est mock-able.
+ * Sur web, l'API native n'existe pas — on retourne null et l'appelant
+ * gère un fallback gracieux (placeholder côté receveur).
+ */
+
+import { NativeModules, Platform } from "react-native";
+import { logger } from "./logger";
+
+type ExpoVideoThumbnailsModule = {
+  getThumbnailAsync: (
+    uri: string,
+    options: { time?: number; quality?: number },
+  ) => Promise<{ uri: string; width?: number; height?: number }>;
+};
+
+function loadVideoThumbnails(): ExpoVideoThumbnailsModule | null {
+  if (Platform.OS === "web") return null;
+  if (process.env.NODE_ENV === "test") {
+    try {
+      return require("expo-video-thumbnails") as ExpoVideoThumbnailsModule;
+    } catch {
+      return null;
+    }
+  }
+  const native = NativeModules as Record<string, unknown>;
+  if (!native?.ExpoVideoThumbnails) return null;
+  try {
+    return require("expo-video-thumbnails") as ExpoVideoThumbnailsModule;
+  } catch {
+    return null;
+  }
+}
+
+export interface VideoPosterResult {
+  uri: string;
+  mimeType: "image/jpeg";
+  filename: string;
+}
+
+/**
+ * Extrait le premier frame d'une vidéo et le retourne sous forme de JPEG.
+ *
+ * - Sur web : retourne null (module natif indisponible).
+ * - Sur natif sans le module : retourne null (dev client incomplet).
+ * - Sur extraction échouée : retourne null. L'appelant doit upload sans
+ *   poster et accepter le fallback placeholder côté receveur.
+ *
+ * @param videoUri  URI locale de la vidéo (file://, content://, etc).
+ * @param baseFilename Nom de fichier d'origine, pour dériver un nom de poster.
+ * @returns Le poster extrait, ou null si non disponible.
+ */
+export async function extractVideoPoster(
+  videoUri: string,
+  baseFilename: string,
+): Promise<VideoPosterResult | null> {
+  const videoThumbnails = loadVideoThumbnails();
+  if (!videoThumbnails) {
+    logger.debug(
+      "videoPoster",
+      "expo-video-thumbnails unavailable, skipping poster extraction",
+    );
+    return null;
+  }
+
+  try {
+    const thumb = await videoThumbnails.getThumbnailAsync(videoUri, {
+      time: 0,
+      quality: 0.8,
+    });
+    if (!thumb?.uri) return null;
+    const posterFilename = baseFilename
+      .replace(/\.(mov|mp4|m4v|avi|mkv|webm)$/i, "")
+      .concat(".poster.jpg");
+    return {
+      uri: thumb.uri,
+      mimeType: "image/jpeg",
+      filename: posterFilename || "poster.jpg",
+    };
+  } catch (err) {
+    logger.warn("videoPoster", "Poster extraction failed", err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Sync deploy/preprod -> main (2026-05-27)

Rapatrie les 35 commits de `deploy/preprod` vers `main`.

### Highlights (depuis dernier sync)

- fix(calls): exposer vraies erreurs LiveKit en cas d'echec web
- fix(calls): masquer le bouton + en attendant l'ecran de selection de contact
- fix(preview): masquer JSON brut des pieces jointes E2EE dans la liste de conversations
- fix(notifications): ancrer le panel en haut a droite sur web
- fix(chat): synchroniser statut presence du modal avec le header
- perf(chat): speed up 1v1 encrypted chat open (WHISPR-1555)
- fix(chat): propagate user_id + read_at in delivery_status pour group read receipts
- fix(settings): apply typing indicator setting in real-time
- fix(camera): replace deprecated MediaTypeOptions + request microphone for video
- fix(camera): lazy-require expo-av Audio
- fix(groups): store settings in conversation metadata when no user-service group
- fix(groups): resolve user-service group ID via by-conversation endpoint
- fix(media): placeholder video sur iOS pour eviter AVPlayerItem -11828
- test(chat): raise new-code coverage above the 80% Sonar gate

### Merge stats

- 35 commits de preprod
- 17 commits de main (deja synces / CI fixes)
- merge propre, pas de conflit
- `tsc --noEmit` clean (sauf erreurs pre-existantes `useNetworkMonitor.ts`)

### Verification

- [ ] CI verte
- [ ] Bots reviews OK (Sonar, Codecov, GitGuardian, CodeQL)
- [ ] Pas de merge avant validation Tudy

DO NOT MERGE - sync PR.